### PR TITLE
fix: Pinecone SDK v7.1.0 API 差分の修正

### DIFF
--- a/packages/pinecone-client/src/client.test.ts
+++ b/packages/pinecone-client/src/client.test.ts
@@ -20,8 +20,8 @@ vi.mock("@pinecone-database/pinecone", () => {
     listIndexes: vi.fn().mockResolvedValue({ indexes: [{ name: "easy-flow-memory" }] }),
     createIndex: vi.fn().mockResolvedValue(undefined),
     inference: {
-      embed: vi.fn().mockImplementation((_model: string, texts: string[]) =>
-        Promise.resolve(texts.map(() => ({ values: Array(1024).fill(0.1) }))),
+      embed: vi.fn().mockImplementation((params: { inputs: string[] }) =>
+        Promise.resolve({ data: params.inputs.map(() => ({ values: Array(1024).fill(0.1) })) }),
       ),
     },
   }));
@@ -96,18 +96,18 @@ describe("PineconeClient", () => {
       const chunks = [createChunk()];
       await client.upsert(chunks);
 
-      expect(mockPineconeInstance.inference.embed).toHaveBeenCalledWith(
-        "multilingual-e5-large",
-        ["Test memory content"],
-        { inputType: "passage" },
-      );
+      expect(mockPineconeInstance.inference.embed).toHaveBeenCalledWith({
+        model: "multilingual-e5-large",
+        inputs: ["Test memory content"],
+        parameters: { input_type: "passage", truncate: "END" },
+      });
 
       const mockIndex = mockPineconeInstance.index();
       expect(mockIndex.namespace).toHaveBeenCalledWith("agent:mell");
 
       const mockNs = mockIndex.namespace();
-      expect(mockNs.upsert).toHaveBeenCalledWith(
-        expect.arrayContaining([
+      expect(mockNs.upsert).toHaveBeenCalledWith({
+        records: expect.arrayContaining([
           expect.objectContaining({
             id: "mell:MEMORY.md:0",
             values: expect.any(Array),
@@ -118,7 +118,7 @@ describe("PineconeClient", () => {
             }),
           }),
         ]),
-      );
+      });
     });
 
     it("throws if chunks have mixed agentIds", async () => {
@@ -139,7 +139,7 @@ describe("PineconeClient", () => {
 
       const mockNs = mockPineconeInstance.index().namespace();
       const upsertCall = mockNs.upsert.mock.calls[0][0];
-      expect(upsertCall).toHaveLength(2);
+      expect(upsertCall.records).toHaveLength(2);
     });
 
     it("splits into multiple batches when chunks exceed 100", async () => {
@@ -155,8 +155,8 @@ describe("PineconeClient", () => {
 
       const mockNs = mockPineconeInstance.index().namespace();
       expect(mockNs.upsert).toHaveBeenCalledTimes(2);
-      expect(mockNs.upsert.mock.calls[0][0]).toHaveLength(100);
-      expect(mockNs.upsert.mock.calls[1][0]).toHaveLength(50);
+      expect(mockNs.upsert.mock.calls[0][0].records).toHaveLength(100);
+      expect(mockNs.upsert.mock.calls[1][0].records).toHaveLength(50);
     });
   });
 
@@ -197,11 +197,11 @@ describe("PineconeClient", () => {
         agentId: "mell",
       });
 
-      expect(mockPineconeInstance.inference.embed).toHaveBeenCalledWith(
-        "multilingual-e5-large",
-        ["search query"],
-        { inputType: "query" },
-      );
+      expect(mockPineconeInstance.inference.embed).toHaveBeenCalledWith({
+        model: "multilingual-e5-large",
+        inputs: ["search query"],
+        parameters: { input_type: "query", truncate: "END" },
+      });
 
       expect(results).toHaveLength(1);
       expect(results[0].score).toBe(0.95);

--- a/packages/pinecone-client/src/client.ts
+++ b/packages/pinecone-client/src/client.ts
@@ -48,7 +48,7 @@ export class PineconeClient implements IPineconeClient {
     }));
 
     for (let i = 0; i < records.length; i += UPSERT_BATCH_SIZE) {
-      await ns.upsert(records.slice(i, i + UPSERT_BATCH_SIZE));
+      await ns.upsert({ records: records.slice(i, i + UPSERT_BATCH_SIZE) });
     }
   }
 

--- a/packages/pinecone-client/src/embedding.test.ts
+++ b/packages/pinecone-client/src/embedding.test.ts
@@ -24,28 +24,28 @@ describe("EmbeddingService", () => {
 
   it("calls pinecone.inference.embed with correct parameters", async () => {
     const fakeEmbedding = createFakeEmbedding();
-    const embedFn = vi.fn().mockResolvedValue([{ values: fakeEmbedding }]);
+    const embedFn = vi.fn().mockResolvedValue({ data: [{ values: fakeEmbedding }] });
     const mockPinecone = createMockPinecone(embedFn);
     const service = new EmbeddingService(mockPinecone);
 
     const result = await service.embed(["Hello world"], "query");
 
-    expect(embedFn).toHaveBeenCalledWith(
-      "multilingual-e5-large",
-      ["Hello world"],
-      { inputType: "query" },
-    );
+    expect(embedFn).toHaveBeenCalledWith({
+      model: "multilingual-e5-large",
+      inputs: ["Hello world"],
+      parameters: { input_type: "query", truncate: "END" },
+    });
     expect(result).toHaveLength(1);
     expect(result[0]).toEqual(fakeEmbedding);
   });
 
   it("handles multiple texts in a single batch", async () => {
     const fakeEmbedding = createFakeEmbedding();
-    const embedFn = vi.fn().mockResolvedValue([
+    const embedFn = vi.fn().mockResolvedValue({ data: [
       { values: fakeEmbedding },
       { values: fakeEmbedding },
       { values: fakeEmbedding },
-    ]);
+    ] });
     const mockPinecone = createMockPinecone(embedFn);
     const service = new EmbeddingService(mockPinecone);
 
@@ -60,8 +60,8 @@ describe("EmbeddingService", () => {
 
   it("auto-splits into batches when exceeding BATCH_SIZE", async () => {
     const fakeEmbedding = createFakeEmbedding();
-    const embedFn = vi.fn().mockImplementation((_model: string, texts: string[]) =>
-      Promise.resolve(texts.map(() => ({ values: fakeEmbedding }))),
+    const embedFn = vi.fn().mockImplementation((params: { inputs: string[] }) =>
+      Promise.resolve({ data: params.inputs.map(() => ({ values: fakeEmbedding })) }),
     );
     const mockPinecone = createMockPinecone(embedFn);
     const service = new EmbeddingService(mockPinecone);
@@ -74,30 +74,30 @@ describe("EmbeddingService", () => {
     expect(result).toHaveLength(200);
 
     // Verify batch sizes
-    expect(embedFn.mock.calls[0][1]).toHaveLength(96);
-    expect(embedFn.mock.calls[1][1]).toHaveLength(96);
-    expect(embedFn.mock.calls[2][1]).toHaveLength(8);
+    expect(embedFn.mock.calls[0][0].inputs).toHaveLength(96);
+    expect(embedFn.mock.calls[1][0].inputs).toHaveLength(96);
+    expect(embedFn.mock.calls[2][0].inputs).toHaveLength(8);
   });
 
   it("passes inputType correctly for passage and query", async () => {
     const fakeEmbedding = createFakeEmbedding();
-    const embedFn = vi.fn().mockResolvedValue([{ values: fakeEmbedding }]);
+    const embedFn = vi.fn().mockResolvedValue({ data: [{ values: fakeEmbedding }] });
     const mockPinecone = createMockPinecone(embedFn);
     const service = new EmbeddingService(mockPinecone);
 
     await service.embed(["passage text"], "passage");
-    expect(embedFn).toHaveBeenCalledWith(
-      "multilingual-e5-large",
-      ["passage text"],
-      { inputType: "passage" },
-    );
+    expect(embedFn).toHaveBeenCalledWith({
+      model: "multilingual-e5-large",
+      inputs: ["passage text"],
+      parameters: { input_type: "passage", truncate: "END" },
+    });
 
     await service.embed(["query text"], "query");
-    expect(embedFn).toHaveBeenCalledWith(
-      "multilingual-e5-large",
-      ["query text"],
-      { inputType: "query" },
-    );
+    expect(embedFn).toHaveBeenCalledWith({
+      model: "multilingual-e5-large",
+      inputs: ["query text"],
+      parameters: { input_type: "query", truncate: "END" },
+    });
   });
 
   it("has BATCH_SIZE of 96", () => {

--- a/packages/pinecone-client/src/embedding.ts
+++ b/packages/pinecone-client/src/embedding.ts
@@ -23,11 +23,13 @@ export class EmbeddingService {
 
     for (let i = 0; i < texts.length; i += EmbeddingService.BATCH_SIZE) {
       const batch = texts.slice(i, i + EmbeddingService.BATCH_SIZE);
-      const response = await this.pinecone.inference.embed(MODEL, batch, {
-        inputType,
+      const response = await this.pinecone.inference.embed({
+        model: MODEL,
+        inputs: batch,
+        parameters: { input_type: inputType, truncate: "END" },
       });
 
-      for (const item of response) {
+      for (const item of response.data) {
         results.push(item.values as number[]);
       }
     }


### PR DESCRIPTION
## 概要
Pinecone SDK v7.1.0 で API 形式が変更されたため、以下の 3 箇所を修正します。

## 変更点

### `packages/pinecone-client/src/embedding.ts`
- `inference.embed(model, inputs, options)`（旧 3 引数形式）→ `inference.embed({ model, inputs, parameters })`（v7 オブジェクト形式）
- レスポンス: `for (const item of response)` → `for (const item of response.data)`

### `packages/pinecone-client/src/client.ts`
- `ns.upsert(records)`（配列直渡し）→ `ns.upsert({ records })`（v7 オブジェクト形式）

### `packages/pinecone-client/src/embedding.test.ts` / `client.test.ts`
- SDK v7 の新 API に合わせてモック・アサーションを更新

## テスト結果
pinecone-client パッケージのテスト 35 件全通過

## 動作確認（mell-dev）
mell-dev での smoke test で Pinecone SDK v7 の embed/upsert/query が正常動作することを確認済み