### PR TITLE
fix: deleteMany を Pinecone SDK v7 形式に更新

### DIFF
--- a/packages/pinecone-client/src/client.test.ts
+++ b/packages/pinecone-client/src/client.test.ts
@@ -269,10 +269,12 @@ describe("PineconeClient", () => {
       expect(mockIndex.namespace).toHaveBeenCalledWith("agent:mell");
 
       const mockNs = mockIndex.namespace();
-      expect(mockNs.deleteMany).toHaveBeenCalledWith([
-        "mell:MEMORY.md:0",
-        "mell:MEMORY.md:1",
-      ]);
+      expect(mockNs.deleteMany).toHaveBeenCalledWith({
+        ids: [
+          "mell:MEMORY.md:0",
+          "mell:MEMORY.md:1",
+        ],
+      });
     });
   });
 
@@ -288,10 +290,12 @@ describe("PineconeClient", () => {
       expect(mockNs.listPaginated).toHaveBeenCalledWith({
         prefix: "mell:MEMORY.md:",
       });
-      expect(mockNs.deleteMany).toHaveBeenCalledWith([
-        "mell:MEMORY.md:0",
-        "mell:MEMORY.md:1",
-      ]);
+      expect(mockNs.deleteMany).toHaveBeenCalledWith({
+        ids: [
+          "mell:MEMORY.md:0",
+          "mell:MEMORY.md:1",
+        ],
+      });
     });
 
     it("handles pagination", async () => {
@@ -308,10 +312,12 @@ describe("PineconeClient", () => {
       await client.deleteBySource("mell", "file.md");
 
       expect(mockNs.listPaginated).toHaveBeenCalledTimes(2);
-      expect(mockNs.deleteMany).toHaveBeenCalledWith([
-        "mell:file.md:0",
-        "mell:file.md:1",
-      ]);
+      expect(mockNs.deleteMany).toHaveBeenCalledWith({
+        ids: [
+          "mell:file.md:0",
+          "mell:file.md:1",
+        ],
+      });
     });
 
     it("does not call deleteMany when no vectors found", async () => {

--- a/packages/pinecone-client/src/client.ts
+++ b/packages/pinecone-client/src/client.ts
@@ -98,7 +98,7 @@ export class PineconeClient implements IPineconeClient {
 
     const index = this.indexManager.getIndex();
     const ns = index.namespace(`agent:${agentId}`);
-    await ns.deleteMany(ids);
+    await ns.deleteMany({ ids });
   }
 
   async deleteBySource(agentId: string, sourceFile: string): Promise<void> {

--- a/packages/pinecone-client/src/index-manager.ts
+++ b/packages/pinecone-client/src/index-manager.ts
@@ -73,7 +73,7 @@ export class IndexManager {
     }
 
     if (ids.length > 0) {
-      await ns.deleteMany(ids);
+      await ns.deleteMany({ ids });
     }
   }
 


### PR DESCRIPTION
## 概要
PR #12 に続く Pinecone SDK v7.1.0 API 差分の追加修正。

## 変更点

### `packages/pinecone-client/src/client.ts`
- `ns.deleteMany(ids)` → `ns.deleteMany({ ids })`

### `packages/pinecone-client/src/index-manager.ts`
- `ns.deleteMany(ids)` → `ns.deleteMany({ ids })`

### `packages/pinecone-client/src/client.test.ts`
- モックアサーションを v7 形式に更新

## テスト
pinecone-client テスト 35 件全通過

## 動作確認
mell-dev でのスモークテストで Test 1〜4（embed/upsert/query）全通過を確認済み