### PR TITLE
fix: PR #12 レビュー指摘対応 — client.test.ts 未使用変数を削除

### DIFF
--- a/packages/pinecone-client/src/client.test.ts
+++ b/packages/pinecone-client/src/client.test.ts
@@ -343,12 +343,12 @@ describe("PineconeClient", () => {
 
   describe("constructor", () => {
     it("uses default index name", () => {
-      const c = new PineconeClient({ apiKey: "key" });
+      new PineconeClient({ apiKey: "key" });
       expect(Pinecone).toHaveBeenCalledWith({ apiKey: "key" });
     });
 
     it("accepts custom index name", () => {
-      const c = new PineconeClient({ apiKey: "key", indexName: "custom-index" });
+      new PineconeClient({ apiKey: "key", indexName: "custom-index" });
       expect(Pinecone).toHaveBeenCalled();
     });
   });


### PR DESCRIPTION
## 概要
PR #12 の AI レビュー指摘事項（🔵 情報提供）の対応。

## 変更点

### `packages/pinecone-client/src/client.test.ts`
- L341: `const c = new PineconeClient(...)` → `new PineconeClient(...)`（未使用変数 `c` を削除）
- L345: `const c = new PineconeClient(...)` → `new PineconeClient(...)`（未使用変数 `c` を削除）

`noUnusedLocals` が有効な場合のコンパイルエラー防止。

## テスト
pinecone-client テスト 35 件全通過

Closes: PR #12 指摘事項