### PR TITLE
fix: increase DEFAULT_TOKEN_BUDGET to 16000 for Japanese conversations

### DIFF
--- a/packages/pinecone-context-engine/src/pinecone-context-engine.ts
+++ b/packages/pinecone-context-engine/src/pinecone-context-engine.ts
@@ -31,7 +31,13 @@ const DEFAULT_SKIP_PATTERNS = [
 const RECENT_TURNS_FOR_QUERY = 3;
 const DEFAULT_TOP_K = 20;
 const DEFAULT_MIN_SCORE = 0.7;
-const DEFAULT_TOKEN_BUDGET = 8000;
+/**
+ * Default token budget for Pinecone memory injection.
+ * Set to 16000 to accommodate Japanese/CJK conversations, which use
+ * ~1.5 tokens/char (after PR #16 fix). This allows ~10,000 Japanese
+ * characters per context injection (comparable to pre-fix behavior).
+ */
+const DEFAULT_TOKEN_BUDGET = 16000;
 const DEFAULT_INGEST_ROLES: ("user" | "assistant")[] = ["user", "assistant"];
 const DEFAULT_COMPACT_AFTER_DAYS = 7;
 


### PR DESCRIPTION
## 概要
PR #16 の日本語トークン推定修正（0.5→1.5）に伴い、DEFAULT_TOKEN_BUDGET を調整します。

## 問題
PR #16 で日本語 1文字 = 1.5 トークンに修正したことで、
8000 budget の実効的な日本語注入量が約 16,000 文字 → 5,300 文字（1/3）に減少した。

## 変更
`DEFAULT_TOKEN_BUDGET: 8000 → 16000`

日本語会話でも旧来相当の注入量（約 10,000 文字）を確保できる。

## テスト
- 全テスト PASS

Closes #18