### PR TITLE
fix(bulk-migrator): sh -c ラップ漏れ修正 + python3 → node 置き換え（バグ4・5）

### DIFF
--- a/packages/migrate-memory/src/bulk-migrator.test.ts
+++ b/packages/migrate-memory/src/bulk-migrator.test.ts
@@ -291,25 +291,29 @@ describe("bulkMigrate", () => {
 
       const errorSpy = vi.spyOn(console, "error");
 
-      const result = await bulkMigrate(
-        { configPath: "mock", dryRun: false, targetInstance: "no-token" },
-        mockRunner,
-      );
+      try {
+        const result = await bulkMigrate(
+          { configPath: "mock", dryRun: false, targetInstance: "no-token" },
+          mockRunner,
+        );
 
-      // ensureEasyFlowAgent がエラーをスローし、bulkMigrate が catch して failed にカウント
-      expect(result.failed).toBe(1);
-      expect(result.processed).toBe(0);
+        // ensureEasyFlowAgent がエラーをスローし、bulkMigrate が catch して failed にカウント
+        expect(result.failed).toBe(1);
+        expect(result.processed).toBe(0);
 
-      const errorLogs = errorSpy.mock.calls
-        .filter((call) => typeof call[0] === "string" && call[0].includes("migration failed"))
-        .map((call) => call[0]);
-      expect(errorLogs).toHaveLength(1);
+        const errorLogs = errorSpy.mock.calls
+          .filter((call) => typeof call[0] === "string" && call[0].includes("migration failed"))
+          .map((call) => call[0]);
+        expect(errorLogs).toHaveLength(1);
+      } finally {
+        // 環境変数を復元（アサーション失敗時も確実に実行）
+        if (origGhToken !== undefined) process.env.GH_TOKEN = origGhToken;
+        else delete process.env.GH_TOKEN;
+        if (origGithubToken !== undefined) process.env.GITHUB_TOKEN = origGithubToken;
+        else delete process.env.GITHUB_TOKEN;
 
-      // 環境変数を復元
-      if (origGhToken !== undefined) process.env.GH_TOKEN = origGhToken;
-      if (origGithubToken !== undefined) process.env.GITHUB_TOKEN = origGithubToken;
-
-      errorSpy.mockRestore();
+        errorSpy.mockRestore();
+      }
     });
   });
 

--- a/packages/migrate-memory/src/bulk-migrator.ts
+++ b/packages/migrate-memory/src/bulk-migrator.ts
@@ -240,7 +240,7 @@ async function runSmokeTest(
   const smokeScript = `
 const {Pinecone}=require('/data/easy-flow-agent/node_modules/@pinecone-database/pinecone');
 new Pinecone({apiKey:process.env.PINECONE_API_KEY})
-  .index('${instance.index}')
+  .index(${JSON.stringify(instance.index)})
   .describeIndexStats()
   .then(s=>console.log(JSON.stringify(s.namespaces)))
   .catch(e=>console.error(e.message));


### PR DESCRIPTION
## 概要

buzz-openclaw の本番移行（2026-03-15）で発見したバグ 2 件を修正。

## バグ詳細

### バグ 4: `runSmokeTest` — `sh -c` ラップ漏れ

`fly ssh console -C "cd ... && node ..."` はシェルを介さないため、`cd` が実行できずエラーになる。  
`sh -c 'echo <b64> | base64 -d | node'` 方式に変更し、`require()` のパスを絶対パスにした。

### バグ 5: `configurePineconePlugin` — python3 依存 + `sh -c` ラップ漏れ

python3 がインストールされていないインスタンス（buzz-openclaw 等）でエラー。  
また `echo '...' | base64 -d | python3` のパイプも `sh -c` ラップなしでは動かない。  
Node.js に書き直し（全インスタンスで利用可能）、`sh -c` でラップして修正。

## 影響範囲

bulk-migrate コマンドのみ。migrate-memory / assemble 等には影響なし。

Related: #27 #29