### PR TITLE
fix(openclaw-pinecone-plugin): exports を dist/ に変更し build 時に openclaw.plugin.json をコピー

### DIFF
--- a/packages/openclaw-pinecone-plugin/package.json
+++ b/packages/openclaw-pinecone-plugin/package.json
@@ -32,6 +32,7 @@
     }
   },
   "devDependencies": {
+    "@types/node": "^22.0.0",
     "typescript": "^5.0.0",
     "vitest": "^3.0.0"
   }


### PR DESCRIPTION
## 概要

OpenClaw が `plugins.load.paths` からプラグインを解決する際、`package.json` の `exports` フィールドを参照して `src/` や `dist/` 配下の `openclaw.plugin.json` を探索する。

従来の `./src/index.ts` 指定では `dist/` に `openclaw.plugin.json` が存在しないため、Fly.io インスタンスでプラグイン起動エラーが発生していた。

## 変更内容

- `exports` を `./src/index.ts` → `./dist/index.js` に変更（`import` / `types` / `default` を明示）
- `build` スクリプトに `cp openclaw.plugin.json dist/` を追加
- `main` / `types` フィールドを追加
- `files` フィールドで `dist/` と `openclaw.plugin.json` を明示

## 背景

easy-flow-infra への Pinecone 適用時に発覚。`src/` と `dist/` に手動コピーすることで動作確認済み（agentId: net で `pinecone-memory: registered` 確認）。

この PR により `npm run build` 後は手動コピー不要になり、残インスタンス（web-director-openclaw / central-hd-osada-agent）への適用も簡素化される。

## テスト

- easy-flow-infra で `pinecone-memory: registered (agentId: net, index: easy-flow-memory)` 動作確認済み