### PR TITLE
feat(ci): GitHub Actions bulk-update workflow (Issue #40)

### DIFF
--- a/.github/workflows/bulk-update.yml
+++ b/.github/workflows/bulk-update.yml
@@ -28,17 +28,21 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run build -w packages/migrate-memory
-      - name: Run bulk-update
+      - name: Run bulk-update (estack-ai-agent org)
+        env:
+          TARGET: ${{ inputs.target }}
+          DRY_RUN: ${{ inputs.dry_run }}
         run: |
-          TARGET_FLAG=""
-          if [ -n "${{ inputs.target }}" ]; then
-            TARGET_FLAG="--target=${{ inputs.target }}"
-          fi
           DRY_RUN_FLAG=""
-          if [ "${{ inputs.dry_run }}" = "true" ]; then
+          if [ "$DRY_RUN" = "true" ]; then
             DRY_RUN_FLAG="--dry-run"
           fi
-          node packages/migrate-memory/dist/cli.js bulk-update $TARGET_FLAG $DRY_RUN_FLAG
+          for instance in mell-dev central-hd-osada-agent; do
+            if [ -z "$TARGET" ] || [ "$TARGET" = "$instance" ]; then
+              echo "=== Updating $instance ==="
+              node packages/migrate-memory/dist/cli.js bulk-update --target="$instance" $DRY_RUN_FLAG
+            fi
+          done
 
   bulk-update-estack-inc:
     runs-on: ubuntu-latest
@@ -53,14 +57,18 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run build -w packages/migrate-memory
-      - name: Run bulk-update
+      - name: Run bulk-update (estack-inc org)
+        env:
+          TARGET: ${{ inputs.target }}
+          DRY_RUN: ${{ inputs.dry_run }}
         run: |
-          TARGET_FLAG=""
-          if [ -n "${{ inputs.target }}" ]; then
-            TARGET_FLAG="--target=${{ inputs.target }}"
-          fi
           DRY_RUN_FLAG=""
-          if [ "${{ inputs.dry_run }}" = "true" ]; then
+          if [ "$DRY_RUN" = "true" ]; then
             DRY_RUN_FLAG="--dry-run"
           fi
-          node packages/migrate-memory/dist/cli.js bulk-update $TARGET_FLAG $DRY_RUN_FLAG
+          for instance in mino-openclaw buzz-openclaw umito-openclaw estack-soumu-openclaw; do
+            if [ -z "$TARGET" ] || [ "$TARGET" = "$instance" ]; then
+              echo "=== Updating $instance ==="
+              node packages/migrate-memory/dist/cli.js bulk-update --target="$instance" $DRY_RUN_FLAG
+            fi
+          done


### PR DESCRIPTION
## Summary

- Actions タブの「Run workflow」ボタンから全インスタンスへの easy-flow-agent 一括更新を実行可能にする GitHub Actions ワークフローを追加
- `target` 入力で特定インスタンスのみ指定可能、`dry_run` で実行前確認が可能
- 2つの並列ジョブで org ごとに分離: `bulk-update-estack-ai`（FLY_API_TOKEN_ESTACK_AI）と `bulk-update-estack-inc`（FLY_API_TOKEN_ESTACK_INC）

### 対象インスタンス

| Job | Org | Instances | Secret |
|-----|-----|-----------|--------|
| bulk-update-estack-ai | estack-ai-agent | mell-dev, central-hd-osada-agent | FLY_API_TOKEN_ESTACK_AI |
| bulk-update-estack-inc | estack-inc | mino-openclaw, buzz-openclaw, umito-openclaw, estack-soumu-openclaw | FLY_API_TOKEN_ESTACK_INC |

## Test plan

- [ ] GitHub リポジトリの Settings > Secrets に `FLY_API_TOKEN_ESTACK_AI` と `FLY_API_TOKEN_ESTACK_INC` が設定されていることを確認
- [ ] Actions タブから `dry_run: true` で実行し、エラーなく完了することを確認
- [ ] `target` に特定インスタンス名を指定して、該当ジョブのみ実行されることを確認

Closes estack-inc/easy-flow-agent#40

🤖 Generated with [Claude Code](https://claude.com/claude-code)