### PR TITLE
fix(ci): bulk-update workflow の ESM モジュール解決エラーを修正

### DIFF
--- a/.github/workflows/bulk-update.yml
+++ b/.github/workflows/bulk-update.yml
@@ -41,7 +41,7 @@ jobs:
           for instance in mell-dev central-hd-osada-agent; do
             if [ -z "$TARGET" ] || [ "$TARGET" = "$instance" ]; then
               echo "=== Updating $instance ==="
-              node packages/migrate-memory/dist/cli.js bulk-update --target="$instance" $DRY_RUN_FLAG
+              npx tsx packages/migrate-memory/dist/cli.js bulk-update --target="$instance" $DRY_RUN_FLAG
             fi
           done
 
@@ -71,6 +71,6 @@ jobs:
           for instance in mino-openclaw buzz-openclaw umito-openclaw estack-soumu-openclaw; do
             if [ -z "$TARGET" ] || [ "$TARGET" = "$instance" ]; then
               echo "=== Updating $instance ==="
-              node packages/migrate-memory/dist/cli.js bulk-update --target="$instance" $DRY_RUN_FLAG
+              npx tsx packages/migrate-memory/dist/cli.js bulk-update --target="$instance" $DRY_RUN_FLAG
             fi
           done

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
         "packages/*"
       ],
       "devDependencies": {
-        "@biomejs/biome": "^2.4.7"
+        "@biomejs/biome": "^2.4.7",
+        "tsx": "^4.21.0"
       }
     },
     "node_modules/@biomejs/biome": {
@@ -1339,6 +1340,19 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/get-tsconfig": {
+      "version": "4.13.6",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
+      "integrity": "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
@@ -1452,6 +1466,16 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
     "node_modules/rollup": {
@@ -1602,6 +1626,26 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
       }
     },
     "node_modules/typescript": {
@@ -1838,6 +1882,7 @@
         "@easy-flow/pinecone-context-engine": "*"
       },
       "devDependencies": {
+        "@types/node": "^22.0.0",
         "typescript": "^5.0.0",
         "vitest": "^3.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "format": "biome format --write packages/"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.4.7"
+    "@biomejs/biome": "^2.4.7",
+    "tsx": "^4.21.0"
   }
 }


### PR DESCRIPTION
## Summary
- bulk-update workflow で `node` が `pinecone-client/src/index.ts` 内の `./chunker.js` を解決できず `ERR_MODULE_NOT_FOUND` で失敗していた
- CLI 実行を `node` → `npx tsx` に変更し、ソース直接参照パターンとの互換性を確保
- `tsx` をルート devDependency に追加

## Test plan
- [ ] `npm test` が全パッケージで通ること（ローカル確認済み）
- [ ] bulk-update workflow を dry-run で実行して成功すること