### PR TITLE
perf(pinecone): topK 20→10 / minScore 0.7→0.75 でTTFT改善 (Issue #10)

### DIFF
--- a/packages/pinecone-context-engine/src/pinecone-context-engine.test.ts
+++ b/packages/pinecone-context-engine/src/pinecone-context-engine.test.ts
@@ -313,8 +313,8 @@ describe("PineconeContextEngine", () => {
 
       expect(client.query).toHaveBeenCalledOnce();
       const queryParams = client.query.mock.calls[0][0] as QueryParams;
-      expect(queryParams.topK).toBe(20);
-      expect(queryParams.minScore).toBe(0.7);
+      expect(queryParams.topK).toBe(10);
+      expect(queryParams.minScore).toBe(0.75);
       expect(queryParams.agentId).toBe("test-agent");
       expect(result.systemPromptAddition).toContain("Relevant Memory");
       expect(result.systemPromptAddition).toContain("Previous conversation about testing");

--- a/packages/pinecone-context-engine/src/shared.ts
+++ b/packages/pinecone-context-engine/src/shared.ts
@@ -14,8 +14,8 @@ export const DEFAULT_SKIP_PATTERNS = [
 ];
 
 export const RECENT_TURNS_FOR_QUERY = 3;
-export const DEFAULT_TOP_K = 20;
-export const DEFAULT_MIN_SCORE = 0.7;
+export const DEFAULT_TOP_K = 10;
+export const DEFAULT_MIN_SCORE = 0.75;
 /**
  * Default token budget for Pinecone memory injection.
  * Set to 16000 to accommodate Japanese/CJK conversations, which use


### PR DESCRIPTION
## 概要

Issue #10 TTFT（Time To First Token）改善の実装。

---

## 背景・経緯

### 問題

Pinecone Context Engine の assemble() はユーザーからメッセージが届いた後、LLM にプロンプトを送る**前**に実行される。
このタイミングで Pinecone への Embedding API 呼び出し + ベクトル検索が同期的に行われるため、ユーザーが返答を待つ時間（TTFT）に直接影響する。

### 計測（2026-03-19 mell-dev / us-east-1）

```
Run 1: 958ms
Run 2: 723ms
Run 3: 225ms
Run 4: 193ms
Run 5: 231ms
avg: 466ms / min: 193ms / max: 958ms
```

cold start 時は約1秒近い遅延が発生している。
Pinecone の Starter プランは us-east-1 固定のため、リージョン変更による改善は現時点では不可（有料プランへの移行が前提）。

### PineconeContextEngineParallel は現時点では使えない

PR #62 で実装された PineconeContextEngineParallel は contextPromise を返すことで LLM リクエストと Pinecone クエリを並列化する設計だが、現行の OpenClaw SDK（v2026.3.13）の AssembleResult 型は contextPromise フィールドを持たない。
そのため切り替えると Pinecone の記憶が一切 LLM に注入されなくなる。SDK 対応待ちの状態。

### 今できる最善

OpenClaw SDK のバージョンに依存せず、**パラメータ調整で即効性のある改善**を行う方針を選択。

---

## 変更内容と意図

### DEFAULT_TOP_K: 20 → 10

Pinecone は上位 K 件のベクトルを返す。K=20 は設計当初の保守的な値だったが：

- 実際に LLM コンテキストに使われる件数はトークン予算（16,000）で上限が決まるため、20件全部が使われるわけではない
- クエリ結果件数が多いほど Pinecone の応答・転送コストが増える
- 10件に絞ることで、クエリ処理量を削減しつつ LLM への入力トークン数も減らす

### DEFAULT_MIN_SCORE: 0.70 → 0.75

スコアは Pinecone のコサイン類似度（0〜1）。0.70 は「まあ関連している」レベルだが：

- 低スコアの記憶は文脈に合わない情報をノイズとして注入するリスクがある
- 0.75 に引き上げることで「明確に関連している」記憶だけを選別する
- 注入される記憶の総トークン数が減り、TTFT のさらなる短縮につながる

---

## テスト

```
61 tests passed (61)
```

既存テスト 1件（topK/minScore のハードコード値）を新しい定数値に合わせて更新。

---

## 検証計画

- [ ] mirai インスタンスで実測・記憶品質確認
- [ ] aqua インスタンスで実測・記憶品質確認
- [ ] mell インスタンスで実測・記憶品質確認
- [ ] 問題なければ全インスタンス + openclaw-templates テンプレートへ展開

Closes #10