### PR TITLE
fix: ルート依存に @pinecone-database/pinecone を追加（package.json + lock のみ）

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,9 @@
       "workspaces": [
         "packages/*"
       ],
+      "dependencies": {
+        "@pinecone-database/pinecone": "^7.0.0"
+      },
       "devDependencies": {
         "@biomejs/biome": "^2.4.7",
         "tsx": "^4.21.0"
@@ -1929,6 +1932,7 @@
       "name": "@openclaw/workflow-controller",
       "version": "2026.3.9",
       "dependencies": {
+        "@easy-flow/pinecone-client": "*",
         "@easy-flow/pinecone-context-engine": "*"
       },
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -16,5 +16,8 @@
   "devDependencies": {
     "@biomejs/biome": "^2.4.7",
     "tsx": "^4.21.0"
+  },
+  "dependencies": {
+    "@pinecone-database/pinecone": "^7.0.0"
   }
 }


### PR DESCRIPTION
## 変更内容

`package.json` と `package-lock.json` の2ファイルのみの変更。

### 背景
Fly.io インスタンスの entrypoint.sh が毎回 `git reset --hard origin/main` → `npm install` を実行する際、workspace 子パッケージ（`packages/pinecone-client`）の依存である `@pinecone-database/pinecone` が正しくインストールされない場合がある。

### 対策
ルートの `dependencies` に `@pinecone-database/pinecone` を明示追加することで、npm の依存解決を確実にする。

### 既存インスタンスへの影響
なし。元々 `package-lock.json` 経由でインストールされていたため、動作に変更はありません。

### package-lock.json の差分について
`workflow-controller` に `@easy-flow/pinecone-client` が追加されていますが、これは main ブランチの `workflow-controller/package.json` に既に含まれている依存のロック反映であり、コードへの影響はありません。