### PR TITLE
fix: workflow-controller をビルド済み dist/ 付きに変更

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ node_modules/
 
 # Build outputs
 dist/
+!packages/workflow-controller/dist/
+!packages/openclaw-pinecone-plugin/dist/
 build/
 *.js.map
 *.d.ts.map

--- a/packages/workflow-controller/build.cjs
+++ b/packages/workflow-controller/build.cjs
@@ -1,0 +1,64 @@
+/**
+ * workflow-controller ビルドスクリプト
+ * esbuild でトランスパイル（型チェックなし）+ openclaw.plugin.json コピー
+ * 
+ * 依存関係: esbuild がルート node_modules に必要
+ * 使用法: node build.js
+ */
+import { execSync } from "child_process";
+import { cpSync, existsSync, mkdirSync, readdirSync } from "fs";
+import { dirname, join, resolve } from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SRC = join(__dirname, "src");
+const DIST = join(__dirname, "dist");
+
+// dist/ をクリーン作成
+if (existsSync(DIST)) {
+  execSync(`rm -rf ${DIST}`);
+}
+mkdirSync(DIST, { recursive: true });
+
+// esbuild を探す
+const esbuildPaths = [
+  join(__dirname, "node_modules", ".bin", "esbuild"),
+  join(__dirname, "..", "..", "node_modules", ".bin", "esbuild"),
+];
+const esbuild = esbuildPaths.find(p => existsSync(p));
+if (!esbuild) {
+  console.error("esbuild not found");
+  process.exit(1);
+}
+
+// src/ 配下の全 .ts ファイルを再帰的に収集（テスト除外）
+function collectFiles(dir, base = "") {
+  const results = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const rel = base ? join(base, entry.name) : entry.name;
+    if (entry.isDirectory()) {
+      results.push(...collectFiles(join(dir, entry.name), rel));
+    } else if (entry.name.endsWith(".ts") && !entry.name.includes(".test.") && !entry.name.includes("test-fixtures")) {
+      results.push(rel);
+    }
+  }
+  return results;
+}
+
+const files = collectFiles(SRC);
+console.log(`Transpiling ${files.length} files...`);
+
+for (const rel of files) {
+  const src = join(SRC, rel);
+  const out = join(DIST, rel.replace(/\.ts$/, ".js"));
+  const outDir = dirname(out);
+  if (!existsSync(outDir)) mkdirSync(outDir, { recursive: true });
+  execSync(`${esbuild} "${src}" --format=esm --platform=node --target=es2022 --outfile="${out}"`, {
+    stdio: "pipe",
+  });
+}
+
+// openclaw.plugin.json をコピー
+cpSync(join(__dirname, "openclaw.plugin.json"), join(DIST, "openclaw.plugin.json"));
+
+console.log("Build complete:", readdirSync(DIST).join(", "));

--- a/packages/workflow-controller/build.js
+++ b/packages/workflow-controller/build.js
@@ -1,0 +1,64 @@
+/**
+ * workflow-controller ビルドスクリプト
+ * esbuild でトランスパイル（型チェックなし）+ openclaw.plugin.json コピー
+ * 
+ * 依存関係: esbuild がルート node_modules に必要
+ * 使用法: node build.js
+ */
+import { execSync } from "child_process";
+import { cpSync, existsSync, mkdirSync, readdirSync } from "fs";
+import { dirname, join, resolve } from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SRC = join(__dirname, "src");
+const DIST = join(__dirname, "dist");
+
+// dist/ をクリーン作成
+if (existsSync(DIST)) {
+  execSync(`rm -rf ${DIST}`);
+}
+mkdirSync(DIST, { recursive: true });
+
+// esbuild を探す
+const esbuildPaths = [
+  join(__dirname, "node_modules", ".bin", "esbuild"),
+  join(__dirname, "..", "..", "node_modules", ".bin", "esbuild"),
+];
+const esbuild = esbuildPaths.find(p => existsSync(p));
+if (!esbuild) {
+  console.error("esbuild not found");
+  process.exit(1);
+}
+
+// src/ 配下の全 .ts ファイルを再帰的に収集（テスト除外）
+function collectFiles(dir, base = "") {
+  const results = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const rel = base ? join(base, entry.name) : entry.name;
+    if (entry.isDirectory()) {
+      results.push(...collectFiles(join(dir, entry.name), rel));
+    } else if (entry.name.endsWith(".ts") && !entry.name.includes(".test.") && !entry.name.includes("test-fixtures")) {
+      results.push(rel);
+    }
+  }
+  return results;
+}
+
+const files = collectFiles(SRC);
+console.log(`Transpiling ${files.length} files...`);
+
+for (const rel of files) {
+  const src = join(SRC, rel);
+  const out = join(DIST, rel.replace(/\.ts$/, ".js"));
+  const outDir = dirname(out);
+  if (!existsSync(outDir)) mkdirSync(outDir, { recursive: true });
+  execSync(`${esbuild} "${src}" --format=esm --platform=node --target=es2022 --outfile="${out}"`, {
+    stdio: "pipe",
+  });
+}
+
+// openclaw.plugin.json をコピー
+cpSync(join(__dirname, "openclaw.plugin.json"), join(DIST, "openclaw.plugin.json"));
+
+console.log("Build complete:", readdirSync(DIST).join(", "));

--- a/packages/workflow-controller/dist/agent-state-converter.js
+++ b/packages/workflow-controller/dist/agent-state-converter.js
@@ -1,0 +1,75 @@
+function agentStateToUnified(agentState, workflowContext) {
+  return {
+    workflowId: workflowContext.workflowId,
+    currentStepId: workflowContext.currentStepId,
+    completedStepIds: [...agentState.completedSteps],
+    blockedReasons: [],
+    // Agent レイヤーではブロック理由を持たない
+    facts: [...agentState.facts],
+    openQuestions: [...agentState.openQuestions],
+    currentPlan: agentState.currentPlan
+  };
+}
+function unifiedToAgentState(unified) {
+  return {
+    completedSteps: [...unified.completedStepIds],
+    facts: [...unified.facts],
+    currentPlan: unified.currentPlan,
+    openQuestions: [...unified.openQuestions],
+    metadata: {
+      updatedAt: Date.now()
+    }
+  };
+}
+function updateAgentContext(state, updates) {
+  let facts = [...state.facts];
+  let questions = [...state.openQuestions];
+  if (updates.newFacts) {
+    facts = [...facts, ...updates.newFacts];
+  }
+  if (updates.resolvedQuestions) {
+    const resolved = new Set(updates.resolvedQuestions);
+    questions = questions.filter((q) => !resolved.has(q));
+  }
+  if (updates.newQuestions) {
+    questions = [...questions, ...updates.newQuestions];
+  }
+  return {
+    completedSteps: [...state.completedSteps],
+    facts,
+    currentPlan: updates.planUpdate ?? state.currentPlan,
+    openQuestions: questions,
+    metadata: {
+      ...state.metadata,
+      updatedAt: Date.now()
+    }
+  };
+}
+function formatAgentContextForLLM(state) {
+  const sections = [];
+  sections.push("## Agent Context");
+  if (state.currentPlan) {
+    sections.push(`**Plan:** ${state.currentPlan}`);
+  }
+  if (state.facts.length > 0) {
+    sections.push(`
+**Collected Facts:**
+${state.facts.map((f) => `- ${f}`).join("\n")}`);
+  }
+  if (state.openQuestions.length > 0) {
+    sections.push(`
+**Open Questions:**
+${state.openQuestions.map((q) => `- ${q}`).join("\n")}`);
+  }
+  if (state.completedSteps.length > 0) {
+    sections.push(`
+**Completed Steps:** ${state.completedSteps.join(", ")}`);
+  }
+  return sections.join("\n");
+}
+export {
+  agentStateToUnified,
+  formatAgentContextForLLM,
+  unifiedToAgentState,
+  updateAgentContext
+};

--- a/packages/workflow-controller/dist/context-engine.js
+++ b/packages/workflow-controller/dist/context-engine.js
@@ -1,0 +1,94 @@
+import { PineconeContextEngine } from "@easy-flow/pinecone-context-engine";
+import { loadWorkflow, renderContextMarkdown } from "./store.js";
+class WorkflowContextEngine {
+  info = {
+    id: "workflow",
+    name: "Workflow Context Engine",
+    version: "0.1.0"
+  };
+  delegate;
+  agentDir;
+  activeWorkflowId;
+  constructor(params) {
+    this.delegate = params.pinecone ? new PineconeContextEngine({
+      pineconeClient: params.pinecone.client,
+      agentId: params.pinecone.agentId,
+      tokenBudget: params.pinecone.tokenBudget,
+      ingestRoles: params.pinecone.ingestRoles,
+      compactAfterDays: params.pinecone.compactAfterDays,
+      fallbackAdapter: params.pinecone.fallbackAdapter ?? params.delegate,
+      skipPatterns: params.pinecone.skipPatterns,
+      defaultCategory: params.pinecone.defaultCategory
+    }) : params.delegate;
+    this.agentDir = params.agentDir;
+    this.activeWorkflowId = params.activeWorkflowId;
+  }
+  /** アクティブなワークフロー ID を設定する */
+  setActiveWorkflow(workflowId) {
+    this.activeWorkflowId = workflowId;
+  }
+  /** エージェントディレクトリを設定する */
+  setAgentDir(agentDir) {
+    this.agentDir = agentDir;
+  }
+  async bootstrap(params) {
+    if (this.delegate.bootstrap) {
+      return this.delegate.bootstrap(params);
+    }
+    return { bootstrapped: false, reason: "delegate has no bootstrap" };
+  }
+  async ingest(params) {
+    return this.delegate.ingest(params);
+  }
+  async ingestBatch(params) {
+    if (this.delegate.ingestBatch) {
+      return this.delegate.ingestBatch(params);
+    }
+    return { ingestedCount: 0 };
+  }
+  async afterTurn(params) {
+    if (this.delegate.afterTurn) {
+      await this.delegate.afterTurn(params);
+    }
+  }
+  async assemble(params) {
+    const baseResult = await this.delegate.assemble(params);
+    const workflowAddition = this.buildWorkflowAddition();
+    if (!workflowAddition) {
+      return baseResult;
+    }
+    const existingAddition = baseResult.systemPromptAddition ?? "";
+    const separator = existingAddition ? "\n\n" : "";
+    return {
+      ...baseResult,
+      systemPromptAddition: `${existingAddition}${separator}${workflowAddition}`
+    };
+  }
+  async compact(params) {
+    return this.delegate.compact(params);
+  }
+  async dispose() {
+    if (this.delegate.dispose) {
+      await this.delegate.dispose();
+    }
+  }
+  /**
+   * アクティブなワークフロー状態を Markdown に変換する。
+   * bootstrap 予算外で systemPromptAddition として注入される。
+   */
+  buildWorkflowAddition() {
+    if (!this.agentDir || !this.activeWorkflowId) {
+      return null;
+    }
+    const state = loadWorkflow(this.agentDir, this.activeWorkflowId);
+    if (!state) {
+      return null;
+    }
+    return `# Active Workflow
+
+${renderContextMarkdown(state)}`;
+  }
+}
+export {
+  WorkflowContextEngine
+};

--- a/packages/workflow-controller/dist/index.js
+++ b/packages/workflow-controller/dist/index.js
@@ -1,0 +1,69 @@
+import { PineconeClient } from "@easy-flow/pinecone-client";
+import { emptyPluginConfigSchema } from "openclaw/plugin-sdk/core";
+import { WorkflowContextEngine } from "./context-engine.js";
+import { createNoopDelegate } from "./noop-delegate.js";
+import { createWorkflowTools } from "./tools.js";
+const workflowControllerPlugin = {
+  id: "workflow-controller",
+  name: "Workflow Controller",
+  description: "Step-based workflow execution control with context optimization (facts, questions, plan). Wraps Pinecone as delegate when configured.",
+  kind: "context-engine",
+  configSchema: emptyPluginConfigSchema(),
+  register(api) {
+    let sharedEngine;
+    api.registerContextEngine("workflow", async () => {
+      const cfg = api.pluginConfig ?? {};
+      const pineconeApiKey = cfg.pineconeApiKey ?? process.env.PINECONE_API_KEY;
+      if (pineconeApiKey) {
+        const agentId = cfg.agentId ?? process.env.OPENCLAW_AGENT_ID ?? "default";
+        const indexName = cfg.indexName ?? "easy-flow-memory";
+        const compactAfterDays = cfg.compactAfterDays ?? 7;
+        const pineconeClient = new PineconeClient({ apiKey: pineconeApiKey, indexName });
+        api.logger.info(
+          `workflow-controller: Pinecone delegate enabled (agentId: ${agentId}, index: ${indexName})`
+        );
+        sharedEngine = new WorkflowContextEngine({
+          delegate: createNoopDelegate(),
+          pinecone: { client: pineconeClient, agentId, compactAfterDays }
+        });
+      } else {
+        api.logger.warn(
+          "workflow-controller: PINECONE_API_KEY not set \u2014 using noop delegate (no long-term memory)"
+        );
+        sharedEngine = new WorkflowContextEngine({ delegate: createNoopDelegate() });
+      }
+      return sharedEngine;
+    });
+    api.registerTool(
+      ((ctx) => {
+        if (ctx.sandboxed) return null;
+        const agentDir = ctx.agentDir;
+        if (!agentDir) return null;
+        if (sharedEngine) {
+          sharedEngine.setAgentDir(agentDir);
+          return createWorkflowTools({ agentDir, contextEngine: sharedEngine });
+        }
+        const standalone = new WorkflowContextEngine({
+          delegate: createNoopDelegate(),
+          agentDir
+        });
+        return createWorkflowTools({ agentDir, contextEngine: standalone });
+      }),
+      {
+        names: [
+          "workflow_create",
+          "workflow_advance",
+          "workflow_block",
+          "workflow_status",
+          "workflow_update_context",
+          "workflow_branch"
+        ],
+        optional: true
+      }
+    );
+  }
+};
+var index_default = workflowControllerPlugin;
+export {
+  index_default as default
+};

--- a/packages/workflow-controller/dist/noop-delegate.js
+++ b/packages/workflow-controller/dist/noop-delegate.js
@@ -1,0 +1,21 @@
+function createNoopDelegate() {
+  return {
+    info: {
+      id: "noop",
+      name: "No-op Delegate",
+      version: "0.0.0"
+    },
+    async ingest() {
+      return { ingested: false };
+    },
+    async assemble(params) {
+      return { messages: params.messages, estimatedTokens: 0 };
+    },
+    async compact() {
+      return { ok: true, compacted: false, reason: "noop delegate" };
+    }
+  };
+}
+export {
+  createNoopDelegate
+};

--- a/packages/workflow-controller/dist/openclaw.plugin.json
+++ b/packages/workflow-controller/dist/openclaw.plugin.json
@@ -1,0 +1,40 @@
+{
+  "id": "workflow-controller",
+  "kind": "context-engine",
+  "name": "Workflow Controller",
+  "description": "Step-based workflow execution control with context optimization (facts, questions, plan). Wraps Pinecone as delegate when configured.",
+  "uiHints": {
+    "pineconeApiKey": {
+      "label": "Pinecone API Key",
+      "sensitive": true,
+      "placeholder": "pcsk_...",
+      "help": "Pinecone API key (or use ${PINECONE_API_KEY} env var). Leave empty to disable long-term memory (noop delegate)."
+    },
+    "agentId": {
+      "label": "Agent ID",
+      "placeholder": "mell",
+      "help": "Unique identifier for this agent (used as Pinecone namespace prefix). Falls back to OPENCLAW_AGENT_ID env var."
+    },
+    "indexName": {
+      "label": "Index Name",
+      "placeholder": "easy-flow-memory",
+      "help": "Pinecone index name (default: easy-flow-memory)"
+    },
+    "compactAfterDays": {
+      "label": "Compact After Days",
+      "placeholder": "7",
+      "help": "Days after which old turns are compacted into Pinecone",
+      "advanced": true
+    }
+  },
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "pineconeApiKey": { "type": "string" },
+      "agentId": { "type": "string" },
+      "indexName": { "type": "string" },
+      "compactAfterDays": { "type": "number", "minimum": 1, "maximum": 90 }
+    }
+  }
+}

--- a/packages/workflow-controller/dist/store.js
+++ b/packages/workflow-controller/dist/store.js
@@ -1,0 +1,232 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+function resolveWorkflowDir(agentDir) {
+  return path.join(agentDir, "workflow");
+}
+function resolveWorkflowPath(agentDir, workflowId) {
+  return path.join(resolveWorkflowDir(agentDir), `${workflowId}.json`);
+}
+function ensureDir(dirPath) {
+  if (!fs.existsSync(dirPath)) {
+    fs.mkdirSync(dirPath, { recursive: true, mode: 448 });
+  }
+}
+function loadWorkflow(agentDir, workflowId) {
+  const filePath = resolveWorkflowPath(agentDir, workflowId);
+  try {
+    const raw = fs.readFileSync(filePath, "utf-8");
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+function saveWorkflow(agentDir, state) {
+  const dir = resolveWorkflowDir(agentDir);
+  ensureDir(dir);
+  const filePath = resolveWorkflowPath(agentDir, state.workflowId);
+  const tmpPath = `${filePath}.tmp.${process.pid}`;
+  fs.writeFileSync(tmpPath, JSON.stringify(state, null, 2), { mode: 384 });
+  fs.renameSync(tmpPath, filePath);
+}
+function listWorkflows(agentDir) {
+  const dir = resolveWorkflowDir(agentDir);
+  try {
+    return fs.readdirSync(dir).filter((f) => f.endsWith(".json")).map((f) => f.replace(/\.json$/, ""));
+  } catch {
+    return [];
+  }
+}
+function findWorkflowByIssue(agentDir, issueNumber, issueRepo) {
+  const ids = listWorkflows(agentDir);
+  for (const id of ids) {
+    const state = loadWorkflow(agentDir, id);
+    if (!state) continue;
+    if (state.issueNumber !== issueNumber) continue;
+    if (issueRepo && state.issueRepo !== issueRepo) continue;
+    return state;
+  }
+  return null;
+}
+function closeWorkflow(agentDir, workflowId) {
+  const state = loadWorkflow(agentDir, workflowId);
+  if (!state) return null;
+  const updated = {
+    ...state,
+    closedAt: Date.now(),
+    updatedAt: Date.now()
+  };
+  saveWorkflow(agentDir, updated);
+  return updated;
+}
+function createWorkflow(agentDir, params) {
+  const now = Date.now();
+  const workflowId = crypto.randomUUID();
+  const firstStepId = params.steps[0]?.id;
+  if (!firstStepId) {
+    throw new Error("Workflow must have at least one step");
+  }
+  const state = {
+    workflowId,
+    label: params.label,
+    currentStepId: firstStepId,
+    steps: params.steps.map((s, i) => ({
+      id: s.id,
+      label: s.label,
+      status: i === 0 ? "running" : "pending",
+      ...s.nextStepId ? { nextStepId: s.nextStepId } : {},
+      ...s.conditions?.length ? { conditions: s.conditions } : {}
+    })),
+    completedStepIds: [],
+    facts: [],
+    openQuestions: [],
+    currentPlan: params.plan ?? "",
+    createdAt: now,
+    updatedAt: now,
+    sessionId: params.sessionId,
+    issueNumber: params.issueNumber,
+    issueRepo: params.issueRepo
+  };
+  saveWorkflow(agentDir, state);
+  return state;
+}
+function resolveNextStepId(step, conditionLabel) {
+  if (conditionLabel && step.conditions && step.conditions.length > 0) {
+    const matched = step.conditions.find((c) => c.label === conditionLabel);
+    if (matched) {
+      return matched.nextStepId;
+    }
+  }
+  if (step.nextStepId) {
+    return step.nextStepId;
+  }
+  return null;
+}
+function advanceStep(agentDir, params) {
+  const state = loadWorkflow(agentDir, params.workflowId);
+  if (!state) {
+    throw new Error(`Workflow not found: ${params.workflowId}`);
+  }
+  const targetStepId = params.stepId ?? state.currentStepId;
+  const stepIndex = state.steps.findIndex((s) => s.id === targetStepId);
+  if (stepIndex === -1) {
+    throw new Error(`Step not found: ${targetStepId}`);
+  }
+  const step = state.steps[stepIndex];
+  step.status = "completed";
+  step.completedAt = Date.now();
+  step.blockedReasons = void 0;
+  if (!state.completedStepIds.includes(targetStepId)) {
+    state.completedStepIds.push(targetStepId);
+  }
+  const nextStepId = resolveNextStepId(step, params.conditionLabel);
+  if (nextStepId) {
+    const nextStep = state.steps.find((s) => s.id === nextStepId);
+    if (!nextStep) {
+      throw new Error(`Branch target step not found: ${nextStepId}`);
+    }
+    nextStep.status = "running";
+    state.currentStepId = nextStep.id;
+  } else {
+    const nextStep = state.steps.find((s) => s.status === "pending");
+    if (nextStep) {
+      nextStep.status = "running";
+      state.currentStepId = nextStep.id;
+    }
+  }
+  if (params.newFacts) {
+    state.facts.push(...params.newFacts);
+  }
+  if (params.resolvedQuestions) {
+    const resolved = new Set(params.resolvedQuestions);
+    state.openQuestions = state.openQuestions.filter((q) => !resolved.has(q));
+  }
+  if (params.newQuestions) {
+    state.openQuestions.push(...params.newQuestions);
+  }
+  if (params.planUpdate) {
+    state.currentPlan = params.planUpdate;
+  }
+  state.updatedAt = Date.now();
+  saveWorkflow(agentDir, state);
+  return state;
+}
+function blockStep(agentDir, params) {
+  const state = loadWorkflow(agentDir, params.workflowId);
+  if (!state) {
+    throw new Error(`Workflow not found: ${params.workflowId}`);
+  }
+  const targetStepId = params.stepId ?? state.currentStepId;
+  const step = state.steps.find((s) => s.id === targetStepId);
+  if (!step) {
+    throw new Error(`Step not found: ${targetStepId}`);
+  }
+  step.status = "blocked";
+  step.blockedReasons = params.reasons;
+  state.updatedAt = Date.now();
+  saveWorkflow(agentDir, state);
+  return state;
+}
+function buildContextSummary(state) {
+  const completed = state.steps.filter((s) => s.status === "completed").length;
+  const total = state.steps.length;
+  const currentStep = state.steps.find((s) => s.id === state.currentStepId);
+  const blockedStep = state.steps.find((s) => s.status === "blocked");
+  return {
+    workflowId: state.workflowId,
+    label: state.label,
+    currentStep: currentStep ? `${currentStep.label} (${currentStep.id})` : "(none)",
+    progress: `${completed}/${total} steps completed`,
+    plan: state.currentPlan,
+    facts: state.facts,
+    openQuestions: state.openQuestions,
+    blockedReasons: blockedStep?.blockedReasons ?? []
+  };
+}
+function renderContextMarkdown(state) {
+  const summary = buildContextSummary(state);
+  const sections = [];
+  sections.push(`## Workflow: ${summary.label}`);
+  sections.push(`**Progress:** ${summary.progress}`);
+  sections.push(`**Current Step:** ${summary.currentStep}`);
+  if (summary.blockedReasons.length > 0) {
+    sections.push(`
+**Blocked:**
+${summary.blockedReasons.map((r) => `- ${r}`).join("\n")}`);
+  }
+  if (summary.plan) {
+    sections.push(`
+### Plan
+${summary.plan}`);
+  }
+  if (summary.facts.length > 0) {
+    sections.push(`
+### Known Facts
+${summary.facts.map((f) => `- ${f}`).join("\n")}`);
+  }
+  if (summary.openQuestions.length > 0) {
+    sections.push(`
+### Open Questions
+${summary.openQuestions.map((q) => `- ${q}`).join("\n")}`);
+  }
+  const stepLines = state.steps.map((s) => {
+    const icon = s.status === "completed" ? "[x]" : s.status === "running" ? "[>]" : s.status === "blocked" ? "[!]" : "[ ]";
+    return `- ${icon} ${s.label}`;
+  });
+  sections.push(`
+### Steps
+${stepLines.join("\n")}`);
+  return sections.join("\n");
+}
+export {
+  advanceStep,
+  blockStep,
+  buildContextSummary,
+  closeWorkflow,
+  createWorkflow,
+  findWorkflowByIssue,
+  listWorkflows,
+  loadWorkflow,
+  renderContextMarkdown,
+  saveWorkflow
+};

--- a/packages/workflow-controller/dist/taskflows/bug.js
+++ b/packages/workflow-controller/dist/taskflows/bug.js
@@ -1,0 +1,58 @@
+const bugFlow = {
+  flowId: "taskflow_bug",
+  trigger: "\u{1F41B}",
+  description: "\u30D0\u30B0\u30FB\u696D\u52D9\u4E0A\u306E\u554F\u984C\u30FB\u969C\u5BB3\u30FB\u30AF\u30EC\u30FC\u30E0\u306B\u5BFE\u5FDC\u3059\u308B\u6C4E\u7528\u30D5\u30ED\u30FC\u3002",
+  label: "\u{1F41B} \u30D0\u30B0\u30FB\u554F\u984C\u5831\u544A\u30D5\u30ED\u30FC",
+  steps: [
+    {
+      id: "issue_register",
+      label: "Issue \u767B\u9332 + \u554F\u984C\u30EC\u30DD\u30FC\u30C8\u4F5C\u6210\uFF08\u30C6\u30F3\u30D7\u30EC\u30FC\u30C8\u4F7F\u7528\uFF09"
+    },
+    {
+      id: "investigate",
+      label: "\u539F\u56E0\u8ABF\u67FB\u30FB\u5206\u6790\uFF08\u5206\u6790\u30C6\u30F3\u30D7\u30EC\u30FC\u30C8\u306B\u6CBF\u3063\u3066\u8A18\u9332\uFF09"
+    },
+    {
+      id: "triage",
+      label: "\u30C8\u30EA\u30A2\u30FC\u30B8\uFF08\u5F71\u97FF\u7BC4\u56F2\u30FB\u5BFE\u5FDC\u6848\u3092\u3088\u308A\u3061\u304B\u3055\u3093\u306B\u63D0\u793A\uFF09",
+      conditions: [
+        { label: "\u5BFE\u5FDC\u3059\u308B", nextStepId: "task_split" },
+        { label: "\u5BFE\u5FDC\u3057\u306A\u3044", nextStepId: "close_no_fix" },
+        { label: "\u518D\u8ABF\u67FB", nextStepId: "investigate" }
+      ]
+    },
+    {
+      id: "task_split",
+      label: "\u6307\u793A\u66F8\u4F5C\u6210\uFF08\u30A2\u30C8\u30DF\u30C3\u30AF\u57FA\u6E96 / task-validator \u30C1\u30A7\u30C3\u30AF\uFF09",
+      conditions: [
+        { label: "validator:PASS", nextStepId: "execution" },
+        { label: "validator:NG", nextStepId: "task_split" }
+      ]
+    },
+    {
+      id: "execution",
+      label: "\u3088\u308A\u3061\u304B\u3055\u3093\u304C\u5B9F\u884C"
+    },
+    {
+      id: "review",
+      label: "output-reviewer \u304C\u6210\u679C\u7269\u30EC\u30D3\u30E5\u30FC",
+      conditions: [
+        { label: "reviewer:PASS", nextStepId: "complete" },
+        { label: "reviewer:NG", nextStepId: "execution" }
+      ]
+    },
+    {
+      id: "complete",
+      label: "\u4FEE\u6B63\u5B8C\u4E86\u30FBIssue \u30AF\u30ED\u30FC\u30BA",
+      nextStepId: "complete"
+    },
+    {
+      id: "close_no_fix",
+      label: "\u5BFE\u5FDC\u4E0D\u8981\u306E\u7406\u7531\u3092\u8A18\u8F09 \u2192 Issue \u30AF\u30ED\u30FC\u30BA",
+      nextStepId: "close_no_fix"
+    }
+  ]
+};
+export {
+  bugFlow
+};

--- a/packages/workflow-controller/dist/taskflows/command.js
+++ b/packages/workflow-controller/dist/taskflows/command.js
@@ -1,0 +1,39 @@
+const commandFlow = {
+  flowId: "taskflow_command",
+  trigger: "\u{1F4E2}",
+  description: "\u6700\u512A\u5148\u30FB\u5373\u5B9F\u884C\u3002\u30D0\u30EA\u30C7\u30FC\u30B7\u30E7\u30F3\u306F task_split \u306E\u307F\u3002",
+  label: "\u{1F4E2} \u6307\u793A\u30FB\u547D\u4EE4\u30D5\u30ED\u30FC",
+  steps: [
+    {
+      id: "issue_register",
+      label: "Issue \u767B\u9332\uFF08\u512A\u5148\u5EA6\u30FB\u671F\u9650\u3092\u8A18\u8F09\uFF09"
+    },
+    {
+      id: "task_split",
+      label: "\u6307\u793A\u66F8\u4F5C\u6210\uFF08\u30A2\u30C8\u30DF\u30C3\u30AF\u57FA\u6E96 / task-validator \u30C1\u30A7\u30C3\u30AF\uFF09",
+      conditions: [
+        { label: "validator:PASS", nextStepId: "execution" },
+        { label: "validator:NG", nextStepId: "task_split" }
+      ]
+    },
+    {
+      id: "execution",
+      label: "\u3088\u308A\u3061\u304B\u3055\u3093\u304C\u5B9F\u884C"
+    },
+    {
+      id: "review",
+      label: "output-reviewer \u304C\u6210\u679C\u7269\u30EC\u30D3\u30E5\u30FC",
+      conditions: [
+        { label: "reviewer:PASS", nextStepId: "complete" },
+        { label: "reviewer:NG", nextStepId: "execution" }
+      ]
+    },
+    {
+      id: "complete",
+      label: "\u5B8C\u4E86\u5831\u544A\uFF08Issue \u30AF\u30ED\u30FC\u30BA\uFF09"
+    }
+  ]
+};
+export {
+  commandFlow
+};

--- a/packages/workflow-controller/dist/taskflows/consult.js
+++ b/packages/workflow-controller/dist/taskflows/consult.js
@@ -1,0 +1,33 @@
+const consultFlow = {
+  flowId: "taskflow_consult",
+  trigger: "\u{1F4AC}",
+  description: "\u76F8\u8AC7\u30FB\u8CEA\u554F\u3092\u53D7\u3051\u3066\u691C\u8A0E\u30FB\u56DE\u7B54\u3002\u30BF\u30B9\u30AF\u306B\u767A\u5C55\u3059\u308B\u5834\u5408\u306F taskflow_task \u3092\u8D77\u52D5\u3002",
+  label: "\u{1F4AC} \u76F8\u8AC7\u30FB\u8CEA\u554F\u30D5\u30ED\u30FC",
+  steps: [
+    {
+      id: "issue_register",
+      label: "Issue \u767B\u9332\uFF08\u30E9\u30D9\u30EB: consultation\uFF09"
+    },
+    {
+      id: "analysis",
+      label: "\u691C\u8A0E\u30FB\u8907\u6570\u6848\u63D0\u793A\uFF08\u63A8\u5968\u5EA6\u2605\u4ED8\u304D\uFF09",
+      conditions: [
+        { label: "\u30BF\u30B9\u30AF\u306B\u767A\u5C55\u3059\u308B", nextStepId: "task_spawn" },
+        { label: "\u56DE\u7B54\u3067\u5B8C\u7D50\u3059\u308B", nextStepId: "complete" }
+      ]
+    },
+    {
+      id: "task_spawn",
+      label: "\u{1F4CB} \u30BF\u30B9\u30AF\u4F9D\u983C\u30D5\u30ED\u30FC\u3092\u65B0\u898F\u8D77\u52D5",
+      nextStepId: "task_spawn"
+    },
+    {
+      id: "complete",
+      label: "\u56DE\u7B54\u5B8C\u4E86\u30FBIssue \u30AF\u30ED\u30FC\u30BA",
+      nextStepId: "complete"
+    }
+  ]
+};
+export {
+  consultFlow
+};

--- a/packages/workflow-controller/dist/taskflows/idea.js
+++ b/packages/workflow-controller/dist/taskflows/idea.js
@@ -1,0 +1,34 @@
+const ideaFlow = {
+  flowId: "taskflow_idea",
+  trigger: "\u{1F4A1}",
+  description: "\u30A2\u30A4\u30C7\u30A2\u30FB\u63D0\u6848\u3092\u8A55\u4FA1\u3057\u3066\u5B9F\u884C\u53EF\u5426\u3092\u5224\u65AD\u3002\u5B9F\u884C\u3059\u308B\u5834\u5408\u306F taskflow_task \u3092\u8D77\u52D5\u3002",
+  label: "\u{1F4A1} \u30A2\u30A4\u30C7\u30A2\u30FB\u63D0\u6848\u30D5\u30ED\u30FC",
+  steps: [
+    {
+      id: "issue_register",
+      label: "Issue \u767B\u9332\uFF08\u30E9\u30D9\u30EB: idea\uFF09"
+    },
+    {
+      id: "evaluation",
+      label: "\u8A55\u4FA1\uFF08\u30E1\u30EA\u30C3\u30C8\u30FB\u30C7\u30E1\u30EA\u30C3\u30C8\u30FB\u5B9F\u73FE\u96E3\u5EA6\u30FB\u63A8\u5968\u5EA6\u2605\u3092\u63D0\u793A\uFF09",
+      conditions: [
+        { label: "\u5B9F\u884C\u3059\u308B", nextStepId: "task_spawn" },
+        { label: "\u5374\u4E0B", nextStepId: "close_rejected" },
+        { label: "\u518D\u691C\u8A0E", nextStepId: "evaluation" }
+      ]
+    },
+    {
+      id: "task_spawn",
+      label: "\u{1F4CB} \u30BF\u30B9\u30AF\u4F9D\u983C\u30D5\u30ED\u30FC\u3092\u65B0\u898F\u8D77\u52D5",
+      nextStepId: "task_spawn"
+    },
+    {
+      id: "close_rejected",
+      label: "\u5374\u4E0B\u7406\u7531\u3092\u8A18\u8F09 \u2192 Issue \u30AF\u30ED\u30FC\u30BA",
+      nextStepId: "close_rejected"
+    }
+  ]
+};
+export {
+  ideaFlow
+};

--- a/packages/workflow-controller/dist/taskflows/index.js
+++ b/packages/workflow-controller/dist/taskflows/index.js
@@ -1,0 +1,37 @@
+import { bugFlow } from "./bug.js";
+import { commandFlow } from "./command.js";
+import { consultFlow } from "./consult.js";
+import { ideaFlow } from "./idea.js";
+import { reportFlow } from "./report.js";
+import { taskFlow } from "./task.js";
+export * from "./types.js";
+import { bugFlow as bugFlow2 } from "./bug.js";
+import { commandFlow as commandFlow2 } from "./command.js";
+import { consultFlow as consultFlow2 } from "./consult.js";
+import { ideaFlow as ideaFlow2 } from "./idea.js";
+import { reportFlow as reportFlow2 } from "./report.js";
+import { taskFlow as taskFlow2 } from "./task.js";
+const flowMap = {
+  taskflow_task: taskFlow2,
+  taskflow_command: commandFlow2,
+  taskflow_consult: consultFlow2,
+  taskflow_bug: bugFlow2,
+  taskflow_report: reportFlow2,
+  taskflow_idea: ideaFlow2
+};
+function getTaskFlow(flowId) {
+  return flowMap[flowId];
+}
+function listTaskFlows() {
+  return Object.values(flowMap);
+}
+export {
+  bugFlow,
+  commandFlow,
+  consultFlow,
+  getTaskFlow,
+  ideaFlow,
+  listTaskFlows,
+  reportFlow,
+  taskFlow
+};

--- a/packages/workflow-controller/dist/taskflows/report.js
+++ b/packages/workflow-controller/dist/taskflows/report.js
@@ -1,0 +1,23 @@
+const reportFlow = {
+  flowId: "taskflow_report",
+  trigger: "\u{1F4CA}",
+  description: "\u72B6\u6CC1\u78BA\u8A8D\u30FB\u5831\u544A\u4F9D\u983C\u3078\u306E\u5FDC\u7B54\u3002\u8ABF\u67FB\u30FB\u56DE\u7B54\u3057\u3066\u5B8C\u4E86\u3002",
+  label: "\u{1F4CA} \u5831\u544A\u30FB\u78BA\u8A8D\u30D5\u30ED\u30FC",
+  steps: [
+    {
+      id: "issue_register",
+      label: "Issue \u767B\u9332\uFF08\u30E9\u30D9\u30EB: report\uFF09"
+    },
+    {
+      id: "respond",
+      label: "\u78BA\u8A8D\u30FB\u8ABF\u67FB\u30FB\u56DE\u7B54\uFF08Issue + Slack DM \u306B\u8A18\u8F09\uFF09"
+    },
+    {
+      id: "complete",
+      label: "\u3088\u308A\u3061\u304B\u3055\u3093\u78BA\u8A8D \u2192 Issue \u30AF\u30ED\u30FC\u30BA"
+    }
+  ]
+};
+export {
+  reportFlow
+};

--- a/packages/workflow-controller/dist/taskflows/task.js
+++ b/packages/workflow-controller/dist/taskflows/task.js
@@ -1,0 +1,60 @@
+const taskFlow = {
+  flowId: "taskflow_task",
+  trigger: "\u{1F4CB}",
+  description: "\u8981\u4EF6\u6DF1\u6398\u308A \u2192 \u8A2D\u8A08 \u2192 \u30BF\u30B9\u30AF\u5206\u5272 \u2192 \u5B9F\u884C \u2192 \u30EC\u30D3\u30E5\u30FC \u2192 \u691C\u53CE\u306E\u6A19\u6E96\u30D5\u30ED\u30FC",
+  label: "\u{1F4CB} \u30BF\u30B9\u30AF\u4F9D\u983C\u30D5\u30ED\u30FC",
+  steps: [
+    {
+      id: "requirements",
+      label: "\u8981\u4EF6\u6DF1\u6398\u308A\uFF08\u76EE\u7684\u30FB\u7BC4\u56F2\u30FB\u5B8C\u4E86\u6761\u4EF6\u306E\u660E\u78BA\u5316\uFF09",
+      conditions: [
+        { label: "validator:PASS \u2192 \u3088\u308A\u3061\u304B\u3055\u3093OK", nextStepId: "issue_register" },
+        { label: "validator:NG \u2192 \u518D\u6DF1\u6398\u308A", nextStepId: "requirements" }
+      ]
+    },
+    {
+      id: "issue_register",
+      label: "GitHub Issue \u767B\u9332\uFF08\u8981\u4EF6\u30FB\u5B8C\u4E86\u6761\u4EF6\u3092\u8A18\u8F09\uFF09",
+      conditions: [
+        { label: "\u8A2D\u8A08\u30FB\u8ABF\u67FB\u304C\u5FC5\u8981", nextStepId: "design" },
+        { label: "\u8A2D\u8A08\u4E0D\u8981\u30FB\u5373\u5206\u5272", nextStepId: "task_split" }
+      ]
+    },
+    {
+      id: "design",
+      label: "\u8A2D\u8A08\u30FB\u8ABF\u67FB\uFF08\u65B9\u91DD\u30FB\u69CB\u6210\u30FB\u9078\u629E\u80A2\u3092 Issue \u306B\u8A18\u8F09\uFF09",
+      conditions: [
+        { label: "validator:PASS \u2192 \u3088\u308A\u3061\u304B\u3055\u3093OK", nextStepId: "task_split" },
+        { label: "validator:NG \u2192 \u518D\u8A2D\u8A08", nextStepId: "design" }
+      ]
+    },
+    {
+      id: "task_split",
+      label: "\u30BF\u30B9\u30AF\u5206\u5272\u30FB\u6307\u793A\u66F8\u4F5C\u6210\uFF08\u30A2\u30C8\u30DF\u30C3\u30AF\u57FA\u6E96\u3067\u5206\u5272\uFF09",
+      conditions: [
+        { label: "validator:PASS \u2192 \u3088\u308A\u3061\u304B\u3055\u3093\u5B9F\u884C", nextStepId: "execution" },
+        { label: "validator:NG \u2192 \u518D\u5206\u5272", nextStepId: "task_split" },
+        { label: "\u5B9F\u884C\u4E0D\u8981\u30FB\u5B8C\u4E86", nextStepId: "acceptance" }
+      ]
+    },
+    {
+      id: "execution",
+      label: "\u3088\u308A\u3061\u304B\u3055\u3093\u304C\u6307\u793A\u66F8\u306B\u57FA\u3065\u3044\u3066\u5B9F\u884C"
+    },
+    {
+      id: "review",
+      label: "output-reviewer \u304C\u6210\u679C\u7269\u30EC\u30D3\u30E5\u30FC\uFF08\u8981\u4EF6\u30FB\u8A2D\u8A08\u3068\u306E\u6574\u5408\u30C1\u30A7\u30C3\u30AF\uFF09",
+      conditions: [
+        { label: "reviewer:PASS", nextStepId: "acceptance" },
+        { label: "reviewer:NG", nextStepId: "execution" }
+      ]
+    },
+    {
+      id: "acceptance",
+      label: "\u691C\u53CE\u30FB\u5B8C\u4E86\uFF08\u3088\u308A\u3061\u304B\u3055\u3093\u304C\u6700\u7D42\u78BA\u8A8D \u2192 Issue \u30AF\u30ED\u30FC\u30BA\uFF09"
+    }
+  ]
+};
+export {
+  taskFlow
+};

--- a/packages/workflow-controller/dist/test-fixtures.js
+++ b/packages/workflow-controller/dist/test-fixtures.js
@@ -1,0 +1,64 @@
+function createMockWorkflowState(overrides) {
+  return {
+    workflowId: "wf-test-001",
+    label: "Test Workflow",
+    currentStepId: "step-2",
+    steps: [
+      {
+        id: "step-1",
+        label: "First Step",
+        status: "completed",
+        completedAt: Date.now() - 6e4
+      },
+      {
+        id: "step-2",
+        label: "Second Step",
+        status: "running"
+      },
+      {
+        id: "step-3",
+        label: "Third Step",
+        status: "pending"
+      }
+    ],
+    completedStepIds: ["step-1"],
+    facts: ["Fact 1", "Fact 2"],
+    openQuestions: ["Question 1"],
+    currentPlan: "Current plan text",
+    createdAt: Date.now() - 12e4,
+    updatedAt: Date.now(),
+    sessionId: "sess-001",
+    ...overrides
+  };
+}
+function createMockAgentState(overrides) {
+  return {
+    completedSteps: ["step-1"],
+    facts: ["Agent Fact 1", "Agent Fact 2"],
+    currentPlan: "Agent plan",
+    openQuestions: ["Agent Question 1"],
+    metadata: {
+      createdAt: Date.now() - 6e4,
+      updatedAt: Date.now(),
+      sessionId: "agent-sess-001"
+    },
+    ...overrides
+  };
+}
+function createMockUnifiedAgentState(overrides) {
+  return {
+    workflowId: "wf-test-001",
+    currentStepId: "step-2",
+    completedStepIds: ["step-1"],
+    blockedReasons: [],
+    facts: ["Fact 1", "Fact 2"],
+    openQuestions: ["Question 1"],
+    currentPlan: "Current plan text",
+    ...overrides
+  };
+}
+export {
+  createMockAgentState,
+  createMockUnifiedAgentState,
+  createMockWorkflowState
+};

--- a/packages/workflow-controller/dist/tools.js
+++ b/packages/workflow-controller/dist/tools.js
@@ -1,0 +1,420 @@
+import {
+  advanceStep,
+  blockStep,
+  closeWorkflow,
+  createWorkflow,
+  findWorkflowByIssue,
+  listWorkflows,
+  loadWorkflow,
+  renderContextMarkdown
+} from "./store.js";
+function createWorkflowTools(params) {
+  const { agentDir, contextEngine } = params;
+  const workflowCreateTool = {
+    name: "workflow_create",
+    description: "Create a new workflow with named steps. Use this when you need to track multi-step tasks with progress, facts, and open questions.",
+    parameters: {
+      type: "object",
+      properties: {
+        label: { type: "string", description: "Workflow display name" },
+        steps: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: {
+              id: { type: "string", description: "Step identifier (snake_case)" },
+              label: { type: "string", description: "Step display name" },
+              nextStepId: {
+                type: "string",
+                description: "Default next step ID (overrides sequential order)"
+              },
+              conditions: {
+                type: "array",
+                description: "Conditional branches from this step",
+                items: {
+                  type: "object",
+                  properties: {
+                    label: { type: "string", description: "Condition label (human-readable)" },
+                    nextStepId: {
+                      type: "string",
+                      description: "Target step ID if this condition matches"
+                    }
+                  },
+                  required: ["label", "nextStepId"]
+                }
+              }
+            },
+            required: ["id", "label"]
+          },
+          description: "Ordered list of steps"
+        },
+        plan: { type: "string", description: "Initial plan (natural language)" },
+        issueNumber: {
+          type: "number",
+          description: "GitHub Issue number to link with this workflow (for resume/tracking)"
+        },
+        issueRepo: {
+          type: "string",
+          description: "GitHub repository in owner/repo format (e.g. estack-inc/mell-workspace)"
+        }
+      },
+      required: ["label", "steps"]
+    },
+    execute: async (_callId, args) => {
+      const state = createWorkflow(agentDir, {
+        label: args.label,
+        steps: args.steps,
+        plan: args.plan ?? "",
+        issueNumber: args.issueNumber,
+        issueRepo: args.issueRepo
+      });
+      contextEngine.setActiveWorkflow(state.workflowId);
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Workflow created: ${state.workflowId}
+
+${renderContextMarkdown(state)}`
+          }
+        ]
+      };
+    }
+  };
+  const workflowAdvanceTool = {
+    name: "workflow_advance",
+    description: "Mark the current step as completed and advance to the next step. Optionally add facts, resolve questions, or update the plan.",
+    parameters: {
+      type: "object",
+      properties: {
+        workflowId: { type: "string", description: "Workflow ID" },
+        stepId: { type: "string", description: "Step to complete (defaults to current)" },
+        newFacts: {
+          type: "array",
+          items: { type: "string" },
+          description: "New facts discovered during this step"
+        },
+        resolvedQuestions: {
+          type: "array",
+          items: { type: "string" },
+          description: "Questions that have been answered (exact match to remove)"
+        },
+        newQuestions: {
+          type: "array",
+          items: { type: "string" },
+          description: "New questions that arose during this step"
+        },
+        planUpdate: { type: "string", description: "Updated plan text (replaces current)" }
+      },
+      required: ["workflowId"]
+    },
+    execute: async (_callId, args) => {
+      const state = advanceStep(agentDir, {
+        workflowId: args.workflowId,
+        stepId: args.stepId,
+        newFacts: args.newFacts,
+        resolvedQuestions: args.resolvedQuestions,
+        newQuestions: args.newQuestions,
+        planUpdate: args.planUpdate
+      });
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Step advanced.
+
+${renderContextMarkdown(state)}`
+          }
+        ]
+      };
+    }
+  };
+  const workflowBlockTool = {
+    name: "workflow_block",
+    description: "Mark a step as blocked with reasons. Use when a step cannot proceed due to missing information or dependencies.",
+    parameters: {
+      type: "object",
+      properties: {
+        workflowId: { type: "string", description: "Workflow ID" },
+        stepId: { type: "string", description: "Step to block (defaults to current)" },
+        reasons: {
+          type: "array",
+          items: { type: "string" },
+          description: "Reasons why the step is blocked"
+        }
+      },
+      required: ["workflowId", "reasons"]
+    },
+    execute: async (_callId, args) => {
+      const state = blockStep(agentDir, {
+        workflowId: args.workflowId,
+        stepId: args.stepId,
+        reasons: args.reasons
+      });
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Step blocked.
+
+${renderContextMarkdown(state)}`
+          }
+        ]
+      };
+    }
+  };
+  const workflowStatusTool = {
+    name: "workflow_status",
+    description: "Get the current status of a workflow, including progress, facts, and open questions.",
+    parameters: {
+      type: "object",
+      properties: {
+        workflowId: { type: "string", description: "Workflow ID (omit to list all)" }
+      }
+    },
+    execute: async (_callId, args) => {
+      const workflowId = args.workflowId;
+      if (!workflowId) {
+        const ids = listWorkflows(agentDir);
+        if (ids.length === 0) {
+          return {
+            content: [{ type: "text", text: "No active workflows." }]
+          };
+        }
+        const summaries = ids.map((id) => {
+          const s = loadWorkflow(agentDir, id);
+          if (!s) return null;
+          const completed = s.completedStepIds.length;
+          return `- **${s.label}** (${id}): ${completed}/${s.steps.length} steps completed`;
+        }).filter(Boolean);
+        return {
+          content: [{ type: "text", text: `## Workflows
+
+${summaries.join("\n")}` }]
+        };
+      }
+      const state = loadWorkflow(agentDir, workflowId);
+      if (!state) {
+        return {
+          content: [{ type: "text", text: `Workflow not found: ${workflowId}` }]
+        };
+      }
+      return {
+        content: [{ type: "text", text: renderContextMarkdown(state) }]
+      };
+    }
+  };
+  const workflowUpdateContextTool = {
+    name: "workflow_update_context",
+    description: "Update facts, open questions, or plan without advancing the step. Use for mid-step knowledge updates.",
+    parameters: {
+      type: "object",
+      properties: {
+        workflowId: { type: "string", description: "Workflow ID" },
+        addFacts: {
+          type: "array",
+          items: { type: "string" },
+          description: "Facts to add"
+        },
+        removeFacts: {
+          type: "array",
+          items: { type: "string" },
+          description: "Facts to remove (exact match)"
+        },
+        addQuestions: {
+          type: "array",
+          items: { type: "string" },
+          description: "Open questions to add"
+        },
+        resolveQuestions: {
+          type: "array",
+          items: { type: "string" },
+          description: "Questions to remove (exact match)"
+        },
+        plan: { type: "string", description: "Replace current plan" }
+      },
+      required: ["workflowId"]
+    },
+    execute: async (_callId, args) => {
+      const wfId = args.workflowId;
+      const state = loadWorkflow(agentDir, wfId);
+      if (!state) {
+        return {
+          content: [{ type: "text", text: `Workflow not found: ${wfId}` }]
+        };
+      }
+      const addFacts = args.addFacts;
+      const removeFacts = args.removeFacts;
+      const addQuestions = args.addQuestions;
+      const resolveQuestions = args.resolveQuestions;
+      const plan = args.plan;
+      if (addFacts) {
+        state.facts.push(...addFacts);
+      }
+      if (removeFacts) {
+        const toRemove = new Set(removeFacts);
+        state.facts = state.facts.filter((f) => !toRemove.has(f));
+      }
+      if (addQuestions) {
+        state.openQuestions.push(...addQuestions);
+      }
+      if (resolveQuestions) {
+        const toResolve = new Set(resolveQuestions);
+        state.openQuestions = state.openQuestions.filter((q) => !toResolve.has(q));
+      }
+      if (plan !== void 0) {
+        state.currentPlan = plan;
+      }
+      state.updatedAt = Date.now();
+      const { saveWorkflow } = await import("./store.js");
+      saveWorkflow(agentDir, state);
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Context updated.
+
+${renderContextMarkdown(state)}`
+          }
+        ]
+      };
+    }
+  };
+  const workflowBranchTool = {
+    name: "workflow_branch",
+    description: "Complete the current step and advance to a specific branch based on a condition label. Use when the current step has defined conditions and you need to choose a specific path. Example: if step has conditions ['\u627F\u8A8D\u304C\u5FC5\u8981', '\u81EA\u52D5\u51E6\u7406'], call with the matching label.",
+    parameters: {
+      type: "object",
+      properties: {
+        workflowId: { type: "string", description: "Workflow ID" },
+        conditionLabel: {
+          type: "string",
+          description: "The condition label to match (must exactly match one of the step's conditions[].label)"
+        },
+        stepId: { type: "string", description: "Step to complete (defaults to current)" },
+        newFacts: {
+          type: "array",
+          items: { type: "string" },
+          description: "New facts discovered"
+        },
+        planUpdate: { type: "string", description: "Updated plan text" }
+      },
+      required: ["workflowId", "conditionLabel"]
+    },
+    execute: async (_callId, args) => {
+      const state = advanceStep(agentDir, {
+        workflowId: args.workflowId,
+        stepId: args.stepId,
+        conditionLabel: args.conditionLabel,
+        newFacts: args.newFacts,
+        planUpdate: args.planUpdate
+      });
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Branched to: ${state.currentStepId}
+
+${renderContextMarkdown(state)}`
+          }
+        ]
+      };
+    }
+  };
+  const workflowResumeTool = {
+    name: "workflow_resume",
+    description: "Resume a previously interrupted workflow by GitHub Issue number. IMPORTANT: Before calling this, check the Issue state with: `gh issue view <issueNumber> -R <repo> --json state -q .state` and pass the result as issueState.",
+    parameters: {
+      type: "object",
+      properties: {
+        issueNumber: {
+          type: "number",
+          description: "GitHub Issue number linked to the workflow"
+        },
+        issueRepo: {
+          type: "string",
+          description: "GitHub repository in owner/repo format (e.g. estack-inc/mell-workspace)"
+        },
+        issueState: {
+          type: "string",
+          enum: ["open", "closed"],
+          description: "Current state of the GitHub Issue. Check via gh CLI before calling this tool."
+        }
+      },
+      required: ["issueNumber"]
+    },
+    execute: async (_callId, args) => {
+      const issueNumber = args.issueNumber;
+      const issueRepo = args.issueRepo;
+      const issueState = args.issueState ?? "open";
+      const state = findWorkflowByIssue(agentDir, issueNumber, issueRepo);
+      if (!state) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify({
+                found: false,
+                message: `Issue #${issueNumber} \u306B\u7D10\u3065\u304F\u30EF\u30FC\u30AF\u30D5\u30ED\u30FC\u304C\u898B\u3064\u304B\u308A\u307E\u305B\u3093`
+              })
+            }
+          ]
+        };
+      }
+      if (state.closedAt) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify({
+                found: true,
+                archived: true,
+                workflowId: state.workflowId,
+                message: `Issue #${issueNumber} \u306E\u30EF\u30FC\u30AF\u30D5\u30ED\u30FC\u306F\u3059\u3067\u306B\u30AF\u30ED\u30FC\u30BA\u6E08\u307F\u3067\u3059\uFF08${new Date(state.closedAt).toISOString()}\uFF09`
+              })
+            }
+          ]
+        };
+      }
+      if (issueState === "closed") {
+        closeWorkflow(agentDir, state.workflowId);
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify({
+                found: true,
+                archived: true,
+                workflowId: state.workflowId,
+                message: `Issue #${issueNumber} \u304C\u30AF\u30ED\u30FC\u30BA\u3055\u308C\u3066\u3044\u308B\u305F\u3081\u3001\u30EF\u30FC\u30AF\u30D5\u30ED\u30FC\u3092\u81EA\u52D5\u30A2\u30FC\u30AB\u30A4\u30D6\u3057\u307E\u3057\u305F`
+              })
+            }
+          ]
+        };
+      }
+      contextEngine.setActiveWorkflow(state.workflowId);
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Workflow resumed: ${state.workflowId}
+
+${renderContextMarkdown(state)}`
+          }
+        ]
+      };
+    }
+  };
+  return [
+    workflowCreateTool,
+    workflowAdvanceTool,
+    workflowBlockTool,
+    workflowStatusTool,
+    workflowUpdateContextTool,
+    workflowBranchTool,
+    workflowResumeTool
+  ];
+}
+export {
+  createWorkflowTools
+};

--- a/packages/workflow-controller/dist/types.js
+++ b/packages/workflow-controller/dist/types.js
@@ -1,0 +1,15 @@
+function toUnifiedAgentState(state) {
+  const blockedStep = state.steps.find((s) => s.status === "blocked");
+  return {
+    workflowId: state.workflowId,
+    currentStepId: state.currentStepId,
+    completedStepIds: [...state.completedStepIds],
+    blockedReasons: blockedStep?.blockedReasons ?? [],
+    facts: [...state.facts],
+    openQuestions: [...state.openQuestions],
+    currentPlan: state.currentPlan
+  };
+}
+export {
+  toUnifiedAgentState
+};

--- a/packages/workflow-controller/dist/validators/index.js
+++ b/packages/workflow-controller/dist/validators/index.js
@@ -1,0 +1,17 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+export * from "./types.js";
+const __dirname = dirname(fileURLToPath(import.meta.url));
+function readPrompt(name) {
+  return readFileSync(join(__dirname, `${name}.md`), "utf-8");
+}
+const validatorPrompts = {
+  requirements: readPrompt("requirements"),
+  design: readPrompt("design"),
+  task: readPrompt("task"),
+  outputReview: readPrompt("output-review")
+};
+export {
+  validatorPrompts
+};

--- a/packages/workflow-controller/dist/workflow-state-converter.js
+++ b/packages/workflow-controller/dist/workflow-state-converter.js
@@ -1,0 +1,132 @@
+function workflowStateToUnified(state) {
+  const blockedStep = state.steps.find((s) => s.status === "blocked");
+  return {
+    workflowId: state.workflowId,
+    currentStepId: state.currentStepId,
+    completedStepIds: [...state.completedStepIds],
+    blockedReasons: blockedStep?.blockedReasons ? [...blockedStep.blockedReasons] : [],
+    facts: [...state.facts],
+    openQuestions: [...state.openQuestions],
+    currentPlan: state.currentPlan
+  };
+}
+function advanceWorkflowStep(state, params) {
+  const targetStepId = params.stepId ?? state.currentStepId;
+  let nextStepId = targetStepId;
+  const updatedSteps = state.steps.map((step) => {
+    if (step.id === targetStepId) {
+      return {
+        ...step,
+        status: "completed",
+        completedAt: Date.now(),
+        blockedReasons: void 0
+      };
+    }
+    return { ...step };
+  });
+  const completedStep = state.steps.find((s) => s.id === targetStepId);
+  const resolvedId = completedStep ? resolveNextStepId(completedStep, params.conditionLabel) : null;
+  if (resolvedId) {
+    const target = updatedSteps.find((s) => s.id === resolvedId);
+    if (!target) {
+      throw new Error(`Branch target step not found: ${resolvedId}`);
+    }
+    target.status = "running";
+    nextStepId = target.id;
+  } else {
+    const nextPending = updatedSteps.find((s) => s.status === "pending");
+    if (nextPending) {
+      nextPending.status = "running";
+      nextStepId = nextPending.id;
+    }
+  }
+  const updatedCompletedIds = state.completedStepIds.includes(targetStepId) ? [...state.completedStepIds] : [...state.completedStepIds, targetStepId];
+  let updatedFacts = [...state.facts];
+  if (params.newFacts) {
+    updatedFacts = [...updatedFacts, ...params.newFacts];
+  }
+  let updatedQuestions = [...state.openQuestions];
+  if (params.resolvedQuestions) {
+    const resolved = new Set(params.resolvedQuestions);
+    updatedQuestions = updatedQuestions.filter((q) => !resolved.has(q));
+  }
+  if (params.newQuestions) {
+    updatedQuestions = [...updatedQuestions, ...params.newQuestions];
+  }
+  return {
+    ...state,
+    currentStepId: nextStepId,
+    steps: updatedSteps,
+    completedStepIds: updatedCompletedIds,
+    facts: updatedFacts,
+    openQuestions: updatedQuestions,
+    currentPlan: params.planUpdate ?? state.currentPlan,
+    updatedAt: Date.now()
+  };
+}
+function blockWorkflowStep(state, params) {
+  const targetStepId = params.stepId ?? state.currentStepId;
+  const updatedSteps = state.steps.map((step) => {
+    if (step.id === targetStepId) {
+      return {
+        ...step,
+        status: "blocked",
+        blockedReasons: [...params.reasons]
+      };
+    }
+    return { ...step };
+  });
+  return {
+    ...state,
+    steps: updatedSteps,
+    updatedAt: Date.now()
+  };
+}
+function resolveNextStepId(step, conditionLabel) {
+  if (conditionLabel && step.conditions && step.conditions.length > 0) {
+    const matched = step.conditions.find((c) => c.label === conditionLabel);
+    if (matched) {
+      return matched.nextStepId;
+    }
+  }
+  if (step.nextStepId) {
+    return step.nextStepId;
+  }
+  return null;
+}
+function getWorkflowSummary(state) {
+  const completed = state.completedStepIds.length;
+  const total = state.steps.length;
+  const currentStep = state.steps.find((s) => s.id === state.currentStepId);
+  const currentLabel = currentStep?.label ?? "Unknown";
+  const blockedStep = state.steps.find((s) => s.status === "blocked");
+  const sections = [];
+  sections.push(`## Workflow: ${state.label}`);
+  sections.push(`**Progress:** ${completed}/${total} steps completed`);
+  sections.push(`**Current:** ${currentLabel}`);
+  sections.push(`**Plan:** ${state.currentPlan}`);
+  if (state.facts.length > 0) {
+    sections.push(`
+**Facts:**
+${state.facts.map((f) => `- ${f}`).join("\n")}`);
+  }
+  if (state.openQuestions.length > 0) {
+    sections.push(`
+**Open Questions:**
+${state.openQuestions.map((q) => `- ${q}`).join("\n")}`);
+  }
+  if (blockedStep?.blockedReasons && blockedStep.blockedReasons.length > 0) {
+    sections.push(
+      `
+**Blocked Reasons:**
+${blockedStep.blockedReasons.map((r) => `- ${r}`).join("\n")}`
+    );
+  }
+  return sections.join("\n");
+}
+export {
+  advanceWorkflowStep,
+  blockWorkflowStep,
+  getWorkflowSummary,
+  workflowStateToUnified
+};

--- a/packages/workflow-controller/index.test.ts
+++ b/packages/workflow-controller/index.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import workflowControllerPlugin from "./index.js";
+import workflowControllerPlugin from "./src/index.js";
 
 vi.mock("@easy-flow/pinecone-client", () => ({
   PineconeClient: vi.fn().mockImplementation((config: { apiKey: string; indexName?: string }) => ({

--- a/packages/workflow-controller/package.json
+++ b/packages/workflow-controller/package.json
@@ -4,7 +4,19 @@
   "private": true,
   "description": "Workflow Controller plugin — step-based execution control with context optimization",
   "type": "module",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "main": "./dist/index.js",
+  "files": [
+    "dist",
+    "openclaw.plugin.json"
+  ],
   "scripts": {
+    "build": "node build.js",
     "test": "vitest run"
   },
   "dependencies": {
@@ -19,9 +31,7 @@
       "optional": true
     }
   },
-  "openclaw": {
-    "extensions": [
-      "./index.ts"
-    ]
+  "devDependencies": {
+    "esbuild": "^0.27.4"
   }
 }

--- a/packages/workflow-controller/src/index.ts
+++ b/packages/workflow-controller/src/index.ts
@@ -1,9 +1,9 @@
 import { PineconeClient } from "@easy-flow/pinecone-client";
 import type { OpenClawPluginApi, OpenClawPluginToolFactory } from "openclaw/plugin-sdk/core";
 import { emptyPluginConfigSchema } from "openclaw/plugin-sdk/core";
-import { WorkflowContextEngine } from "./src/context-engine.js";
-import { createNoopDelegate } from "./src/noop-delegate.js";
-import { createWorkflowTools } from "./src/tools.js";
+import { WorkflowContextEngine } from "./context-engine.js";
+import { createNoopDelegate } from "./noop-delegate.js";
+import { createWorkflowTools } from "./tools.js";
 
 /**
  * Workflow Controller プラグイン（Pinecone ラップ対応版）

--- a/packages/workflow-controller/tsconfig.json
+++ b/packages/workflow-controller/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
+}


### PR DESCRIPTION
## 問題
WC プラグインが TypeScript ソース (index.ts) をエントリポイントにしていたが、OpenClaw のプラグインローダーは .ts を直接ロードできず、ミライ・アクアで WC が完全にスキップされていた。

## 変更内容
- src/index.ts を追加（ルート index.ts からインポートパス修正版）
- esbuild でトランスパイルし dist/ にコンパイル済み JS を生成
- package.json に exports/main を追加して dist/index.js を指すよう変更
- .gitignore にプラグイン dist/ の例外を追加
- build.js スクリプトを追加（esbuild ベース、型チェック不要）

## テスト
- Fly.io (mell-dev) で esbuild トランスパイル成功確認済み
- dist/index.js の中身に正しいインポート文を確認