### PR TITLE
fix: tesseract.js v7 の langPath オプション名に修正（dataPath→langPath）

### DIFF
--- a/scripts/daily_process.js
+++ b/scripts/daily_process.js
@@ -329,7 +329,8 @@ function extractExcelText(buf) {
 // ----------------------------
 // ファイル種別に応じてテキスト抽出
 // ----------------------------
-async function extractText(buf, filePath) {
+async function extractText(buf, filePath, options = {}) {
+  const { _createWorker } = options;
   const ext = filePath.split(".").pop().toLowerCase();
   if (ext === "pdf") {
     const text = await extractPdfText(buf);
@@ -358,7 +359,9 @@ async function extractText(buf, filePath) {
   }
   if (["jpg", "jpeg", "png", "gif"].includes(ext)) {
     try {
-      const { createWorker } = require("tesseract.js");
+      const { createWorker } = _createWorker
+        ? { createWorker: _createWorker }
+        : require("tesseract.js");
       // tesseract.js v7 では langPath で traineddata ディレクトリを指定する
       // TESSDATA_PREFIX 環境変数 → /data/workspace の順でフォールバック
       const tessdataPath = process.env.TESSDATA_PREFIX || "/data/workspace";
@@ -825,6 +828,7 @@ module.exports = {
   parseFilePath,
   formatText,
   MAX_RETRY_COUNT,
+  extractText,
   main,
 };
 

--- a/scripts/daily_process.js
+++ b/scripts/daily_process.js
@@ -359,12 +359,12 @@ async function extractText(buf, filePath) {
   if (["jpg", "jpeg", "png", "gif"].includes(ext)) {
     try {
       const { createWorker } = require("tesseract.js");
-      // TESSDATA_PREFIX が未設定の場合は /data/workspace にフォールバック
+      // tesseract.js v7 では langPath で traineddata ディレクトリを指定する
+      // TESSDATA_PREFIX 環境変数 → /data/workspace の順でフォールバック
       const tessdataPath = process.env.TESSDATA_PREFIX || "/data/workspace";
       const worker = await createWorker("jpn+eng", 1, {
         logger: () => {},
-        gzip: false,         // traineddata は非圧縮形式（.traineddata）
-        dataPath: tessdataPath,
+        langPath: tessdataPath,  // v7: dataPath → langPath に変更
       });
       try {
         const {

--- a/scripts/daily_process.test.js
+++ b/scripts/daily_process.test.js
@@ -23,6 +23,7 @@ const {
   parseFilePath,
   formatText,
   MAX_RETRY_COUNT,
+  extractText,
   main,
 } = require(path.join(__dirname, "daily_process.js"));
 
@@ -904,6 +905,69 @@ function createTmpDb() {
     process.env.UNITBASE_USERNAME = origUbUser;
     process.env.UNITBASE_PASSWORD = origUbPass;
   }
+
+  // ==============================
+  // extractText: 画像 OCR テスト
+  // ==============================
+  console.log("\n--- extractText: 画像 OCR テスト ---");
+
+  await testAsync(
+    "extractText: 画像 OCR 時に langPath オプションが渡されること",
+    async () => {
+      let capturedOpts;
+      const mockCreateWorker = async (_lang, _oem, opts) => {
+        capturedOpts = opts;
+        return {
+          recognize: async () => ({ data: { text: "OCRテキスト" } }),
+          terminate: async () => {},
+        };
+      };
+      const buf = Buffer.from([0xff, 0xd8, 0xff]); // fake JPEG header
+      const result = await extractText(buf, "resume.jpg", {
+        _createWorker: mockCreateWorker,
+      });
+      assert.strictEqual(result.method, "image_ocr");
+      assert.ok(
+        capturedOpts.langPath !== undefined,
+        "langPath が指定されていること",
+      );
+    },
+  );
+
+  await testAsync(
+    "extractText: 画像 OCR 時に dataPath が使われないこと（v7 互換確認）",
+    async () => {
+      let capturedOpts;
+      const mockCreateWorker = async (_lang, _oem, opts) => {
+        capturedOpts = opts;
+        return {
+          recognize: async () => ({ data: { text: "test" } }),
+          terminate: async () => {},
+        };
+      };
+      await extractText(Buffer.from([0]), "resume.png", {
+        _createWorker: mockCreateWorker,
+      });
+      assert.strictEqual(
+        capturedOpts.dataPath,
+        undefined,
+        "dataPath は使われないこと",
+      );
+    },
+  );
+
+  await testAsync(
+    "extractText: 画像 OCR エラー時に image_ocr_failed を返すこと",
+    async () => {
+      const failingWorker = async () => {
+        throw new Error("OCR init failed");
+      };
+      const result = await extractText(Buffer.from([0]), "photo.gif", {
+        _createWorker: failingWorker,
+      });
+      assert.strictEqual(result.method, "image_ocr_failed");
+    },
+  );
 
   // ==============================
   // 結果サマリー


### PR DESCRIPTION
## 概要

PR #108 でtesseract OCRの修正を行いましたが、オプション名が誤っていました。

## 問題

tesseract.js **v7** では traineddata のパス指定オプションは `langPath` です。
PR #108 では `dataPath` を使用していたためクラッシュが継続していました。

## 修正

`dataPath` → `langPath` に変更。

```js
// Before
const worker = await createWorker('jpn+eng', 1, { dataPath: tessdataPath });

// After
const worker = await createWorker('jpn+eng', 1, { langPath: tessdataPath });
```

## テスト結果（PR #108 適用後のDRY_RUN）

```
全レコード数: 669件  ✅ （ページング修正が正常に動作）
ファイル付きレコード数: 886件  ✅
DB同期: 新規0件, 差し替え0件  ✅
処理対象（pending）: 886件  ✅
tesseract OCRクラッシュ  ❌ → 本PRで修正
```