### PR TITLE
fix: tesseract.js v7 で dataPath も指定し仮想FS書き込み先エラーを解消

### DIFF
--- a/scripts/daily_process.js
+++ b/scripts/daily_process.js
@@ -367,7 +367,8 @@ async function extractText(buf, filePath, options = {}) {
       const tessdataPath = process.env.TESSDATA_PREFIX || "/data/workspace";
       const worker = await createWorker("jpn+eng", 1, {
         logger: () => {},
-        langPath: tessdataPath,  // v7: dataPath → langPath に変更
+        langPath: tessdataPath,  // traineddata ファイルの読み込み元ディレクトリ
+        dataPath: tessdataPath,  // Emscripten 仮想FS への書き込み先（未指定だと ./ になりエラー）
       });
       try {
         const {

--- a/scripts/daily_process.test.js
+++ b/scripts/daily_process.test.js
@@ -935,7 +935,7 @@ function createTmpDb() {
   );
 
   await testAsync(
-    "extractText: 画像 OCR 時に dataPath が使われないこと（v7 互換確認）",
+    "extractText: 画像 OCR 時に dataPath が langPath と同じパスで指定されること（v7 仮想FS修正）",
     async () => {
       let capturedOpts;
       const mockCreateWorker = async (_lang, _oem, opts) => {
@@ -950,8 +950,8 @@ function createTmpDb() {
       });
       assert.strictEqual(
         capturedOpts.dataPath,
-        undefined,
-        "dataPath は使われないこと",
+        capturedOpts.langPath,
+        "dataPath は langPath と同じパスが指定されること",
       );
     },
   );


### PR DESCRIPTION
## 問題

DRY_RUN で OCR 処理は成功しているが、以下のエラーログが出ている：

```
Error opening data file ./.traineddata
Please make sure the TESSDATA_PREFIX environment variable is set to your "tessdata" directory.
Failed loading language ''
```

## 原因

tesseract.js v7 では：
- `langPath`: traineddata ファイルの**読み込み元**ディレクトリ（PR #109 で修正済み）
- `dataPath`: Emscripten 仮想FS への**書き込み先**ディレクトリ（未指定だと `./` になる）

`langPath` のみ指定していたため、仮想FSへの書き込み先が `./` になりエラーが発生していた。

## 修正

`langPath` と `dataPath` を同じパス（`TESSDATA_PREFIX`）に設定する。

```js
const worker = await createWorker('jpn+eng', 1, {
  logger: () => {},
  langPath: tessdataPath,  // traineddata ファイルの読み込み元
  dataPath: tessdataPath,  // 仮想FS書き込み先（未指定だと ./ になりエラー）
});
```

## 補足

PR #108 DRY_RUN で OCR 自体は成功（1148文字抽出）しており、本修正はエラーログの解消が目的。