### PR TITLE
fix: tesseract.js dataPath を削除（仮想FS mkdir クラッシュの解消）

### DIFF
--- a/scripts/daily_process.js
+++ b/scripts/daily_process.js
@@ -367,8 +367,8 @@ async function extractText(buf, filePath, options = {}) {
       const tessdataPath = process.env.TESSDATA_PREFIX || "/data/workspace";
       const worker = await createWorker("jpn+eng", 1, {
         logger: () => {},
-        langPath: tessdataPath,  // traineddata ファイルの読み込み元ディレクトリ
-        dataPath: tessdataPath,  // Emscripten 仮想FS への書き込み先（未指定だと ./ になりエラー）
+        langPath: tessdataPath,  // traineddata ファイルの読み込み元ディレクトリ（実ファイルシステム）
+        // dataPath は Emscripten 仮想FS 内パスのため指定しない（mkdir が失敗してクラッシュする）
       });
       try {
         const {

--- a/scripts/daily_process.test.js
+++ b/scripts/daily_process.test.js
@@ -935,7 +935,7 @@ function createTmpDb() {
   );
 
   await testAsync(
-    "extractText: 画像 OCR 時に dataPath が langPath と同じパスで指定されること（v7 仮想FS修正）",
+    "extractText: 画像 OCR 時に dataPath が指定されないこと（仮想FS mkdir クラッシュ防止）",
     async () => {
       let capturedOpts;
       const mockCreateWorker = async (_lang, _oem, opts) => {
@@ -950,8 +950,8 @@ function createTmpDb() {
       });
       assert.strictEqual(
         capturedOpts.dataPath,
-        capturedOpts.langPath,
-        "dataPath は langPath と同じパスが指定されること",
+        undefined,
+        "dataPath は指定されないこと",
       );
     },
   );


### PR DESCRIPTION
## 問題

PR #110 で追加した `dataPath: tessdataPath` が原因でクラッシュが発生。

```
Error: [object Object]
    at Worker.<anonymous> (.../tesseract.js/src/createWorker.js:217:15)
```

## 原因分析

tesseract.js の `worker-script/index.js` では `dataPath` が指定された場合、
**Emscripten 仮想FS** 内に `TessModule.FS.mkdir(dataPath)` でディレクトリを作成しようとする。

`/data/workspace` は実ファイルシステムのパスであり仮想FS内には存在しないため
`mkdir` が失敗 → `res.reject(err.toString())` → クラッシュ。

## 修正

`dataPath` の指定を削除。`langPath`（実ファイルシステムの読み込み元）のみ指定する。

```js
// Before (PR #110, クラッシュする)
const worker = await createWorker('jpn+eng', 1, {
  langPath: tessdataPath,
  dataPath: tessdataPath,  // ← これが原因
});

// After (本PR)
const worker = await createWorker('jpn+eng', 1, {
  langPath: tessdataPath,  // 実ファイルシステムの読み込み元のみ
});
```

## 補足

PR #109 の状態（langPath のみ）では OCR 処理自体は成功（1148文字抽出）していた。
PR #110 の dataPath 追加が逆効果だったため、本PRで reverts する。