### PR TITLE
feat(model-router): Sticky Default Guard によるセッションコンテキスト対応 (Phase 1.5)

### DIFF
--- a/packages/model-router/src/classifier.test.ts
+++ b/packages/model-router/src/classifier.test.ts
@@ -198,6 +198,16 @@ describe("shouldStickyDefault", () => {
     expect(shouldStickyDefault(ctx, 2)).toBe(false);
   });
 
+  it("windowSize=0 → false（Sticky Guard 無効化、slice(-0) の罠を回避）", () => {
+    const ctx = session("force_default", "force_default");
+    expect(shouldStickyDefault(ctx, 0)).toBe(false);
+  });
+
+  it("windowSize=-1 → false（負数も無効化）", () => {
+    const ctx = session("force_default");
+    expect(shouldStickyDefault(ctx, -1)).toBe(false);
+  });
+
   it("「〜を確認して」はパターン未一致で default（複雑タスク）", () => {
     expect(classifyMessage("このPRを確認して", DEFAULT_CONFIG)).toEqual({
       result: "default",

--- a/packages/model-router/src/classifier.test.ts
+++ b/packages/model-router/src/classifier.test.ts
@@ -1,60 +1,200 @@
 import { describe, expect, it } from "vitest";
-import { classifyMessage } from "./classifier.js";
+import { classifyMessage, shouldStickyDefault } from "./classifier.js";
 import { DEFAULT_CONFIG } from "./config.js";
+import type { SessionContext } from "./session-store.js";
+
+/** SessionContext ヘルパー */
+function session(
+  ...reasons: Array<
+    "force_default" | "token_exceeded" | "sticky_default" | "light_match" | "unmatched"
+  >
+): SessionContext {
+  return {
+    recentTurns: reasons.map((reason) => ({ reason, timestamp: Date.now() })),
+  };
+}
 
 describe("classifyMessage", () => {
-  it("挨拶（短文・preferLight）→ light", () => {
-    expect(classifyMessage("おはよう", DEFAULT_CONFIG)).toBe("light");
+  // --- 既存テスト（返り値を ClassificationDetail に更新）---
+
+  it("挨拶（短文・preferLight）→ light / light_match", () => {
+    expect(classifyMessage("おはよう", DEFAULT_CONFIG)).toEqual({
+      result: "light",
+      reason: "light_match",
+    });
   });
 
-  it("感謝（短文・preferLight）→ light", () => {
-    expect(classifyMessage("ありがとう！", DEFAULT_CONFIG)).toBe("light");
+  it("感謝（短文・preferLight）→ light / light_match", () => {
+    expect(classifyMessage("ありがとう！", DEFAULT_CONFIG)).toEqual({
+      result: "light",
+      reason: "light_match",
+    });
   });
 
-  it("了解（短文・preferLight）→ light", () => {
-    expect(classifyMessage("了解です", DEFAULT_CONFIG)).toBe("light");
+  it("了解（短文・preferLight）→ light / light_match", () => {
+    expect(classifyMessage("了解です", DEFAULT_CONFIG)).toEqual({
+      result: "light",
+      reason: "light_match",
+    });
   });
 
-  it("forceDefault パターン（設計）→ default", () => {
-    expect(classifyMessage("設計を見直して", DEFAULT_CONFIG)).toBe("default");
+  it("forceDefault パターン（設計）→ default / force_default", () => {
+    expect(classifyMessage("設計を見直して", DEFAULT_CONFIG)).toEqual({
+      result: "default",
+      reason: "force_default",
+    });
   });
 
-  it("forceDefault パターン（コード）→ default", () => {
-    expect(classifyMessage("このコードをレビューして", DEFAULT_CONFIG)).toBe("default");
+  it("forceDefault パターン（コード）→ default / force_default", () => {
+    expect(classifyMessage("このコードをレビューして", DEFAULT_CONFIG)).toEqual({
+      result: "default",
+      reason: "force_default",
+    });
   });
 
-  it("長文（100トークン超）→ default", () => {
-    const longMessage = "あ".repeat(101); // 日本語 101 文字 = 101 トークン（maxTokensForLight: 100 超）
-    expect(classifyMessage(longMessage, DEFAULT_CONFIG)).toBe("default");
+  it("長文（100 トークン超）→ default / token_exceeded", () => {
+    const longMessage = "あ".repeat(101);
+    expect(classifyMessage(longMessage, DEFAULT_CONFIG)).toEqual({
+      result: "default",
+      reason: "token_exceeded",
+    });
   });
 
-  it("パターン未一致（短文）→ default", () => {
-    expect(classifyMessage("うん", DEFAULT_CONFIG)).toBe("default");
+  it("パターン未一致（短文）→ default / unmatched", () => {
+    expect(classifyMessage("うん", DEFAULT_CONFIG)).toEqual({
+      result: "default",
+      reason: "unmatched",
+    });
   });
 
-  it("空文字列 → default", () => {
-    expect(classifyMessage("", DEFAULT_CONFIG)).toBe("default");
+  it("空文字列 → default / unmatched", () => {
+    expect(classifyMessage("", DEFAULT_CONFIG)).toEqual({
+      result: "default",
+      reason: "unmatched",
+    });
   });
 
   it("forceDefault が preferLight に勝つ（優先順位確認）", () => {
-    // 「ありがとう」+ 「コード」が混在 → forceDefault 優先で default
-    expect(classifyMessage("ありがとう、このコードで大丈夫です", DEFAULT_CONFIG)).toBe("default");
+    expect(classifyMessage("ありがとう、このコードで大丈夫です", DEFAULT_CONFIG)).toEqual({
+      result: "default",
+      reason: "force_default",
+    });
   });
 
   it("英語 forceDefault（code）が preferLight（ok）に勝つ", () => {
-    // "ok" が preferLight にマッチするが "code" が forceDefault にマッチ → default
-    expect(classifyMessage("ok, let's write some code", DEFAULT_CONFIG)).toBe("default");
+    expect(classifyMessage("ok, let's write some code", DEFAULT_CONFIG)).toEqual({
+      result: "default",
+      reason: "force_default",
+    });
   });
 
   it("英語 forceDefault（review）が preferLight（ok）に勝つ", () => {
-    expect(classifyMessage("ok review this", DEFAULT_CONFIG)).toBe("default");
+    expect(classifyMessage("ok review this", DEFAULT_CONFIG)).toEqual({
+      result: "default",
+      reason: "force_default",
+    });
   });
 
   it("大文字 forceDefault（Review）が preferLight（ok）に勝つ", () => {
-    expect(classifyMessage("ok Review this", DEFAULT_CONFIG)).toBe("default");
+    expect(classifyMessage("ok Review this", DEFAULT_CONFIG)).toEqual({
+      result: "default",
+      reason: "force_default",
+    });
   });
 
   it("文頭大文字 Fix が preferLight（ok）に勝つ", () => {
-    expect(classifyMessage("ok Fix this bug", DEFAULT_CONFIG)).toBe("default");
+    expect(classifyMessage("ok Fix this bug", DEFAULT_CONFIG)).toEqual({
+      result: "default",
+      reason: "force_default",
+    });
+  });
+
+  // --- Phase 1.5: sessionContext なし → Phase 1 互換 ---
+
+  it("sessionContext 未指定 → Phase 1 と同等の動作", () => {
+    // Sticky Guard はスキップされ、preferLight が通常通り動作
+    expect(classifyMessage("おはよう", DEFAULT_CONFIG)).toEqual({
+      result: "light",
+      reason: "light_match",
+    });
+  });
+
+  // --- Phase 1.5: Sticky Default Guard ---
+
+  it("直前が force_default → preferLight でも default 維持（sticky）", () => {
+    const ctx = session("force_default");
+    expect(classifyMessage("おはよう", DEFAULT_CONFIG, ctx)).toEqual({
+      result: "default",
+      reason: "sticky_default",
+    });
+  });
+
+  it("直前が token_exceeded → preferLight でも default 維持（sticky）", () => {
+    const ctx = session("token_exceeded");
+    expect(classifyMessage("おはよう", DEFAULT_CONFIG, ctx)).toEqual({
+      result: "default",
+      reason: "sticky_default",
+    });
+  });
+
+  it("直前が unmatched → sticky 不発動、preferLight が通る", () => {
+    const ctx = session("unmatched");
+    expect(classifyMessage("おはよう", DEFAULT_CONFIG, ctx)).toEqual({
+      result: "light",
+      reason: "light_match",
+    });
+  });
+
+  it("直前 3 ターンすべて sticky_default → sticky 不発動（非伝播）", () => {
+    const ctx = session("sticky_default", "sticky_default", "sticky_default");
+    expect(classifyMessage("おはよう", DEFAULT_CONFIG, ctx)).toEqual({
+      result: "light",
+      reason: "light_match",
+    });
+  });
+
+  it("直前 3 ターンすべて light_match → sticky 不発動", () => {
+    const ctx = session("light_match", "light_match", "light_match");
+    expect(classifyMessage("おはよう", DEFAULT_CONFIG, ctx)).toEqual({
+      result: "light",
+      reason: "light_match",
+    });
+  });
+
+  it("forceDefault は Sticky Guard より優先される", () => {
+    // forceDefault パターンは Layer 1 で先に判定されるため、
+    // sessionContext の内容に関わらず force_default が返る
+    const ctx = session("light_match", "light_match");
+    expect(classifyMessage("コードをレビューして", DEFAULT_CONFIG, ctx)).toEqual({
+      result: "default",
+      reason: "force_default",
+    });
+  });
+});
+
+describe("shouldStickyDefault", () => {
+  it("空の recentTurns → false", () => {
+    expect(shouldStickyDefault({ recentTurns: [] }, 3)).toBe(false);
+  });
+
+  it("force_default が window 内にある → true", () => {
+    const ctx = session("light_match", "force_default", "sticky_default");
+    expect(shouldStickyDefault(ctx, 3)).toBe(true);
+  });
+
+  it("token_exceeded が window 内にある → true", () => {
+    const ctx = session("token_exceeded");
+    expect(shouldStickyDefault(ctx, 3)).toBe(true);
+  });
+
+  it("sticky_default のみ → false（非伝播）", () => {
+    const ctx = session("sticky_default", "sticky_default");
+    expect(shouldStickyDefault(ctx, 3)).toBe(false);
+  });
+
+  it("force_default が window 外 → false", () => {
+    // windowSize=2 で、force_default は 3 ターン前
+    const ctx = session("force_default", "sticky_default", "light_match");
+    expect(shouldStickyDefault(ctx, 2)).toBe(false);
   });
 });

--- a/packages/model-router/src/classifier.ts
+++ b/packages/model-router/src/classifier.ts
@@ -1,42 +1,90 @@
 import type { ModelRouterConfig } from "./config.js";
+import type { SessionContext } from "./session-store.js";
 
 export type ClassificationResult = "light" | "default";
+
+export type ClassificationReason =
+  | "force_default"
+  | "token_exceeded"
+  | "sticky_default"
+  | "light_match"
+  | "unmatched";
+
+export type ClassificationDetail = {
+  result: ClassificationResult;
+  reason: ClassificationReason;
+};
 
 /**
  * ユーザープロンプトを分類し、軽量モデルで処理可能かを判定する。
  *
  * 判定優先順位:
  * 1. forceDefault パターンに一致 → "default"（Sonnet 維持）
- * 2. トークン数超過 → "default"
- * 3. preferLight パターンに一致 → "light"（Haiku）
- * 4. いずれにも該当しない → "default"
+ * 2. Sticky Default Guard（直近ターンに複雑タスクがあれば default 維持）
+ * 3. トークン数超過 → "default"
+ * 4. preferLight パターンに一致 → "light"（Haiku）
+ * 5. いずれにも該当しない → "default"
  */
 export function classifyMessage(
   prompt: string,
   config: Required<ModelRouterConfig>,
-): ClassificationResult {
+  sessionContext?: SessionContext,
+): ClassificationDetail {
   // 1. forceDefault パターンに一致する場合は Sonnet 維持
-  const forceDefaultPatterns = config.patterns.forceDefault ?? [];
-  if (forceDefaultPatterns.some((p) => prompt.toLowerCase().includes(p.toLowerCase()))) {
-    return "default";
+  if (matchesForceDefault(prompt, config)) {
+    return { result: "default", reason: "force_default" };
   }
 
-  // 2. トークン数チェック（近似推定）
-  // 日本語（ひらがな・カタカナ・漢字）は 1 文字 ≈ 1 トークン、
-  // ASCII 英数字は 1 文字 ≈ 0.25 トークンで算出（PoC 段階の近似）
+  // 2. Sticky Default Guard: 直近ターンに複雑タスクがあれば default 維持
+  if (sessionContext && shouldStickyDefault(sessionContext, config.stickyWindowSize)) {
+    return { result: "default", reason: "sticky_default" };
+  }
+
+  // 3. トークン数超過
+  if (exceedsTokenLimit(prompt, config)) {
+    return { result: "default", reason: "token_exceeded" };
+  }
+
+  // 4. preferLight パターンに一致する場合は Haiku
+  if (matchesPreferLight(prompt, config)) {
+    return { result: "light", reason: "light_match" };
+  }
+
+  // 5. デフォルトは Sonnet 維持
+  return { result: "default", reason: "unmatched" };
+}
+
+/** forceDefault パターンのいずれかに一致するか（case-insensitive） */
+function matchesForceDefault(prompt: string, config: Required<ModelRouterConfig>): boolean {
+  const patterns = config.patterns.forceDefault ?? [];
+  const lower = prompt.toLowerCase();
+  return patterns.some((p) => lower.includes(p.toLowerCase()));
+}
+
+/**
+ * Sticky Default Guard: 直近ターンに force_default または token_exceeded があれば true。
+ * sticky_default 自体は伝播しない（無限ループ防止）。
+ */
+export function shouldStickyDefault(ctx: SessionContext, windowSize: number): boolean {
+  const window = ctx.recentTurns.slice(-windowSize);
+  return window.some((t) => t.reason === "force_default" || t.reason === "token_exceeded");
+}
+
+/**
+ * トークン数の近似推定。
+ * 日本語（ひらがな・カタカナ・漢字）: 1 文字 ≈ 1 トークン
+ * ASCII 英数字: 1 文字 ≈ 0.25 トークン
+ */
+function exceedsTokenLimit(prompt: string, config: Required<ModelRouterConfig>): boolean {
   const japaneseChars = (prompt.match(/[\u3040-\u9fff\uff00-\uffef]/g) ?? []).length;
   const otherChars = prompt.length - japaneseChars;
   const estimatedTokens = Math.ceil(japaneseChars + otherChars / 4);
-  if (estimatedTokens > config.maxTokensForLight) {
-    return "default";
-  }
+  return estimatedTokens > config.maxTokensForLight;
+}
 
-  // 3. preferLight パターンに一致する場合は Haiku
-  const preferLightPatterns = config.patterns.preferLight ?? [];
-  if (preferLightPatterns.some((p) => prompt.toLowerCase().includes(p.toLowerCase()))) {
-    return "light";
-  }
-
-  // 4. デフォルトは Sonnet 維持
-  return "default";
+/** preferLight パターンのいずれかに一致するか（case-insensitive） */
+function matchesPreferLight(prompt: string, config: Required<ModelRouterConfig>): boolean {
+  const patterns = config.patterns.preferLight ?? [];
+  const lower = prompt.toLowerCase();
+  return patterns.some((p) => lower.includes(p.toLowerCase()));
 }

--- a/packages/model-router/src/classifier.ts
+++ b/packages/model-router/src/classifier.ts
@@ -1,19 +1,13 @@
 import type { ModelRouterConfig } from "./config.js";
-import type { SessionContext } from "./session-store.js";
+import type {
+  ClassificationDetail,
+  ClassificationReason,
+  ClassificationResult,
+  SessionContext,
+} from "./types.js";
 
-export type ClassificationResult = "light" | "default";
-
-export type ClassificationReason =
-  | "force_default"
-  | "token_exceeded"
-  | "sticky_default"
-  | "light_match"
-  | "unmatched";
-
-export type ClassificationDetail = {
-  result: ClassificationResult;
-  reason: ClassificationReason;
-};
+// 後方互換: 型を re-export（既存の import { ClassificationDetail } from "./classifier.js" を維持）
+export type { ClassificationDetail, ClassificationReason, ClassificationResult };
 
 /**
  * ユーザープロンプトを分類し、軽量モデルで処理可能かを判定する。
@@ -66,6 +60,8 @@ function matchesForceDefault(prompt: string, config: Required<ModelRouterConfig>
  * sticky_default 自体は伝播しない（無限ループ防止）。
  */
 export function shouldStickyDefault(ctx: SessionContext, windowSize: number): boolean {
+  // windowSize <= 0 は Sticky Guard 無効化（slice(-0) が全配列を返す JS の罠を回避）
+  if (windowSize <= 0) return false;
   const window = ctx.recentTurns.slice(-windowSize);
   return window.some((t) => t.reason === "force_default" || t.reason === "token_exceeded");
 }

--- a/packages/model-router/src/config.ts
+++ b/packages/model-router/src/config.ts
@@ -9,6 +9,14 @@ export type ModelRouterConfig = {
     preferLight?: string[];
   };
   logging?: boolean;
+  /** セッションコンテキストによる Sticky Default Guard の有効/無効 */
+  enableSessionContext?: boolean;
+  /** Sticky Default Guard が参照する直近ターン数 */
+  stickyWindowSize?: number;
+  /** セッション TTL（ミリ秒）。超過したセッションは自動削除 */
+  sessionTtlMs?: number;
+  /** インメモリに保持する最大セッション数 */
+  maxSessions?: number;
 };
 
 export const DEFAULT_CONFIG: Required<ModelRouterConfig> = {
@@ -56,4 +64,8 @@ export const DEFAULT_CONFIG: Required<ModelRouterConfig> = {
     ],
   },
   logging: true,
+  enableSessionContext: true,
+  stickyWindowSize: 3,
+  sessionTtlMs: 30 * 60 * 1000, // 30 分
+  maxSessions: 1000,
 };

--- a/packages/model-router/src/index.test.ts
+++ b/packages/model-router/src/index.test.ts
@@ -181,4 +181,20 @@ describe("model-router plugin", () => {
     callHook(api, "おはよう", { sessionKey: "line:user1", runId: "r1" });
     expect(api.logger.info).toHaveBeenCalledWith(expect.stringContaining("ctx shape:"));
   });
+
+  it("sessionKey 不明時はセッション追跡をスキップする(セッション汚染防止)", () => {
+    const api = registerPlugin();
+
+    // ユーザー A 相当: ctx に sessionKey なし → 追跡されない
+    const r1 = callHook(api, "コードをレビューして", {});
+    expect(r1).toBeUndefined(); // force_default
+
+    // ユーザー B 相当: ctx に sessionKey なし → 前の force_default は記録されていない
+    // → Sticky Guard が発動せず、preferLight が通常通り light を返す
+    const r2 = callHook(api, "おはよう", {});
+    expect(r2).toEqual({
+      modelOverride: "claude-haiku-4-5",
+      providerOverride: "anthropic",
+    });
+  });
 });

--- a/packages/model-router/src/index.test.ts
+++ b/packages/model-router/src/index.test.ts
@@ -31,36 +31,44 @@ function createMockApi(pluginConfig: Record<string, unknown> = {}): MockApi {
   };
 }
 
-/** 登録済みの before_model_resolve ハンドラを取得して呼び出す */
-function callHook(api: MockApi, prompt: string) {
-  const [, handler] = api.registerHook.mock.calls[0] as [
-    string[],
-    (e: { prompt: string }, ctx: unknown) => unknown,
-  ];
-  return handler({ prompt }, {});
+type HookHandler = (
+  e: { prompt?: string } | null,
+  ctx: Record<string, unknown> | undefined,
+) => unknown;
+
+/** 登録済みの before_model_resolve ハンドラを取得 */
+function getHandler(api: MockApi): HookHandler {
+  const [, handler] = api.registerHook.mock.calls[0] as [string[], HookHandler];
+  return handler;
+}
+
+/** ハンドラを呼び出す（ctx 付き） */
+function callHook(api: MockApi, prompt: string, ctx: Record<string, unknown> = {}) {
+  return getHandler(api)({ prompt }, ctx);
+}
+
+function registerPlugin(pluginConfig: Record<string, unknown> = {}): MockApi {
+  const api = createMockApi(pluginConfig);
+  (plugin as unknown as { register: (api: unknown) => void }).register(api);
+  return api;
 }
 
 describe("model-router plugin", () => {
-  it("before_model_resolve フックを登録する", () => {
-    const api = createMockApi();
-    (plugin as unknown as { register: (api: unknown) => void }).register(api);
+  // --- 既存テスト ---
 
+  it("before_model_resolve フックを登録する", () => {
+    const api = registerPlugin();
     expect(api.registerHook).toHaveBeenCalledWith(["before_model_resolve"], expect.any(Function));
   });
 
   it("登録後に info ログを出力する", () => {
-    const api = createMockApi();
-    (plugin as unknown as { register: (api: unknown) => void }).register(api);
-
+    const api = registerPlugin();
     expect(api.logger.info).toHaveBeenCalledWith("[model-router] plugin registered");
   });
 
   it("軽量タスク → { modelOverride, providerOverride } を返す", () => {
-    const api = createMockApi();
-    (plugin as unknown as { register: (api: unknown) => void }).register(api);
-
+    const api = registerPlugin();
     const result = callHook(api, "おはよう");
-
     expect(result).toEqual({
       modelOverride: "claude-haiku-4-5",
       providerOverride: "anthropic",
@@ -68,77 +76,127 @@ describe("model-router plugin", () => {
   });
 
   it("複雑タスク → void（デフォルトモデル維持）", () => {
-    const api = createMockApi();
-    (plugin as unknown as { register: (api: unknown) => void }).register(api);
-
+    const api = registerPlugin();
     const result = callHook(api, "このコードをレビューして");
-
     expect(result).toBeUndefined();
   });
 
-  it("logging: true のとき軽量ルーティングで info ログを出力する", () => {
-    const api = createMockApi({ logging: true });
-    (plugin as unknown as { register: (api: unknown) => void }).register(api);
+  it("logging: true のとき軽量ルーティングで reason 付き info ログを出力する", () => {
+    const api = registerPlugin({ logging: true });
     callHook(api, "おはよう");
-
-    expect(api.logger.info).toHaveBeenCalledWith(
-      expect.stringContaining("anthropic/claude-haiku-4-5"),
-    );
+    expect(api.logger.info).toHaveBeenCalledWith(expect.stringContaining("reason: light_match"));
   });
 
   it("logging: false のとき軽量ルーティングで info ログを出力しない", () => {
-    const api = createMockApi({ logging: false });
-    (plugin as unknown as { register: (api: unknown) => void }).register(api);
-
-    // info は "plugin registered" のみ呼ばれる
+    const api = registerPlugin({ logging: false });
     const infoCallsBefore = api.logger.info.mock.calls.length;
     callHook(api, "おはよう");
-
     expect(api.logger.info.mock.calls.length).toBe(infoCallsBefore);
   });
 
   it("pluginConfig.patterns でデフォルト設定を上書きできる", () => {
-    const api = createMockApi({
-      patterns: {
-        preferLight: ["hello"],
-        forceDefault: [],
-      },
+    const api = registerPlugin({
+      patterns: { preferLight: ["hello"], forceDefault: [] },
     });
-    (plugin as unknown as { register: (api: unknown) => void }).register(api);
 
-    // カスタム preferLight にマッチ → light
     const lightResult = callHook(api, "hello");
     expect(lightResult).toEqual({
       modelOverride: "claude-haiku-4-5",
       providerOverride: "anthropic",
     });
 
-    // デフォルトの preferLight（おはよう）はオーバーライドされているのでマッチしない → void
-    const api2 = createMockApi({
-      patterns: {
-        preferLight: ["hello"],
-        forceDefault: [],
-      },
+    const api2 = registerPlugin({
+      patterns: { preferLight: ["hello"], forceDefault: [] },
     });
-    (plugin as unknown as { register: (api: unknown) => void }).register(api2);
     const defaultResult = callHook(api2, "おはよう");
     expect(defaultResult).toBeUndefined();
   });
 
   it("ハンドラ内で例外が発生しても void を返す（デフォルトモデル維持）", () => {
-    const api = createMockApi();
-    (plugin as unknown as { register: (api: unknown) => void }).register(api);
-
-    // ハンドラに null を渡して event.prompt アクセスで例外を発生させる
-    const [, handler] = api.registerHook.mock.calls[0] as [
-      string[],
-      (e: unknown, ctx: unknown) => unknown,
-    ];
+    const api = registerPlugin();
+    const handler = getHandler(api);
     const result = handler(null, {});
-
     expect(result).toBeUndefined();
     expect(api.logger.warn).toHaveBeenCalledWith(
       expect.stringContaining("[model-router] classify error:"),
     );
+  });
+
+  // --- Phase 1.5: セッションコンテキスト統合テスト ---
+
+  it("Sticky Default: 複雑タスク後の軽量メッセージが default 維持", () => {
+    const api = registerPlugin();
+    const ctx = { sessionKey: "line:user1" };
+
+    // ターン 1: 複雑タスク
+    const r1 = callHook(api, "このコードをレビューして", ctx);
+    expect(r1).toBeUndefined(); // default
+
+    // ターン 2: 軽量メッセージ → sticky で default 維持
+    const r2 = callHook(api, "おはよう", ctx);
+    expect(r2).toBeUndefined(); // sticky_default
+  });
+
+  it("Sticky Default: sticky_default は伝播せず自然解除される", () => {
+    const api = registerPlugin({ stickyWindowSize: 2 });
+    const ctx = { sessionKey: "line:user1" };
+
+    // ターン 1: 複雑タスク → force_default
+    callHook(api, "コードをレビューして", ctx);
+    // ターン 2: sticky → sticky_default（window=[force_default] → sticky 発動）
+    callHook(api, "はい", ctx);
+    // ターン 3: window=[force_default, sticky_default] → force_default が window 内 → まだ sticky
+    callHook(api, "了解", ctx);
+    // ターン 4: window=[sticky_default, sticky_default] → force_default が window 外 → sticky 解除
+    const r4 = callHook(api, "おはよう", ctx);
+    expect(r4).toEqual({
+      modelOverride: "claude-haiku-4-5",
+      providerOverride: "anthropic",
+    });
+  });
+
+  it("異なる sessionKey は独立したセッションとして扱われる", () => {
+    const api = registerPlugin();
+
+    // セッション A: 複雑タスク
+    callHook(api, "コードをレビューして", { sessionKey: "line:userA" });
+
+    // セッション B: 軽量メッセージ → sticky の影響を受けない
+    const result = callHook(api, "おはよう", { sessionKey: "slack:C123" });
+    expect(result).toEqual({
+      modelOverride: "claude-haiku-4-5",
+      providerOverride: "anthropic",
+    });
+  });
+
+  it("enableSessionContext: false → Sticky Guard 無効（Phase 1 互換）", () => {
+    const api = registerPlugin({ enableSessionContext: false });
+    const ctx = { sessionKey: "line:user1" };
+
+    // 複雑タスク
+    callHook(api, "コードをレビューして", ctx);
+
+    // Sticky Guard 無効なので、直後の軽量メッセージは light に
+    const result = callHook(api, "おはよう", ctx);
+    expect(result).toEqual({
+      modelOverride: "claude-haiku-4-5",
+      providerOverride: "anthropic",
+    });
+  });
+
+  it("ctx が undefined でもエラーにならない", () => {
+    const api = registerPlugin();
+    const handler = getHandler(api);
+    const result = handler({ prompt: "おはよう" }, undefined);
+    expect(result).toEqual({
+      modelOverride: "claude-haiku-4-5",
+      providerOverride: "anthropic",
+    });
+  });
+
+  it("初回フック呼び出し時に ctx shape をログ出力する", () => {
+    const api = registerPlugin({ logging: true });
+    callHook(api, "おはよう", { sessionKey: "line:user1", runId: "r1" });
+    expect(api.logger.info).toHaveBeenCalledWith(expect.stringContaining("ctx shape:"));
   });
 });

--- a/packages/model-router/src/index.ts
+++ b/packages/model-router/src/index.ts
@@ -37,13 +37,13 @@ export default function register(api: OpenClawPluginApi): void {
       const prompt = (event as { prompt?: string }).prompt ?? "";
       const sessionKey = resolveSessionKey(ctxObj);
 
-      // セッションコンテキスト取得
-      const sessionContext = sessionStore ? sessionStore.get(sessionKey) : undefined;
+      // セッションコンテキスト取得（sessionKey 不明時はセッション追跡をスキップ）
+      const sessionContext = sessionStore && sessionKey ? sessionStore.get(sessionKey) : undefined;
 
       const detail = classifyMessage(prompt, cfg, sessionContext);
 
-      // 分類結果を記録
-      if (sessionStore) {
+      // 分類結果を記録（sessionKey 不明時は記録しない = セッション汚染防止）
+      if (sessionStore && sessionKey) {
         sessionStore.record(sessionKey, detail);
       }
 
@@ -76,10 +76,14 @@ export default function register(api: OpenClawPluginApi): void {
   api.logger.info("[model-router] plugin registered");
 }
 
-/** ctx からセッション識別キーを取得。未定義時は "unknown" にフォールバック */
-function resolveSessionKey(ctx: Record<string, unknown> | undefined): string {
-  if (!ctx) return "unknown";
+/**
+ * ctx からセッション識別キーを取得。
+ * キーが不明な場合は null を返し、呼び出し側でセッション追跡をスキップする。
+ * （null フォールバックがないと、異なるユーザー・会話の履歴が混在しセッション汚染を引き起こす）
+ */
+function resolveSessionKey(ctx: Record<string, unknown> | undefined): string | null {
+  if (!ctx) return null;
   if (typeof ctx.sessionKey === "string" && ctx.sessionKey) return ctx.sessionKey;
   if (typeof ctx.sessionId === "string" && ctx.sessionId) return ctx.sessionId;
-  return "unknown";
+  return null;
 }

--- a/packages/model-router/src/index.ts
+++ b/packages/model-router/src/index.ts
@@ -1,6 +1,7 @@
 import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
 import { classifyMessage } from "./classifier.js";
 import { DEFAULT_CONFIG, type ModelRouterConfig } from "./config.js";
+import { SessionStore } from "./session-store.js";
 
 export default definePluginEntry({
   id: "model-router",
@@ -17,35 +18,75 @@ export default definePluginEntry({
       },
     };
 
-    // before_model_resolve: プロンプトを分類してモデルをオーバーライド
-    api.registerHook(["before_model_resolve"], (event, _ctx) => {
-      try {
-        const prompt = event.prompt ?? "";
-        const result = classifyMessage(prompt, cfg);
+    const sessionStore = cfg.enableSessionContext
+      ? new SessionStore({
+          stickyWindowSize: cfg.stickyWindowSize,
+          sessionTtlMs: cfg.sessionTtlMs,
+          maxSessions: cfg.maxSessions,
+        })
+      : null;
 
-        if (result === "light") {
+    let ctxLogged = false;
+
+    // before_model_resolve: プロンプトを分類してモデルをオーバーライド
+    api.registerHook(
+      ["before_model_resolve"],
+      (event: { prompt?: string }, ctx: Record<string, unknown> | undefined) => {
+        try {
+          // 初回のみ ctx のキー一覧をログ出力（診断用）
+          if (!ctxLogged && cfg.logging) {
+            api.logger.info(`[model-router] ctx shape: ${JSON.stringify(Object.keys(ctx ?? {}))}`);
+            ctxLogged = true;
+          }
+
+          const prompt = event.prompt ?? "";
+          const sessionKey = resolveSessionKey(ctx);
+
+          // セッションコンテキスト取得
+          const sessionContext = sessionStore ? sessionStore.get(sessionKey) : undefined;
+
+          const detail = classifyMessage(prompt, cfg, sessionContext);
+
+          // 分類結果を記録
+          if (sessionStore) {
+            sessionStore.record(sessionKey, detail);
+          }
+
+          if (detail.result === "light") {
+            if (cfg.logging) {
+              api.logger.info(
+                `[model-router] → ${cfg.lightProvider}/${cfg.lightModel}` +
+                  ` (reason: ${detail.reason}, prompt: "${prompt.slice(0, 50)}${prompt.length > 50 ? "..." : ""}")`,
+              );
+            }
+            return {
+              modelOverride: cfg.lightModel,
+              providerOverride: cfg.lightProvider,
+            };
+          }
+
           if (cfg.logging) {
-            api.logger.info(
-              `[model-router] → ${cfg.lightProvider}/${cfg.lightModel}` +
-                ` (prompt: "${prompt.slice(0, 50)}${prompt.length > 50 ? "..." : ""}")`,
+            api.logger.debug(
+              `[model-router] → ${cfg.defaultProvider}/${cfg.defaultModel}` +
+                ` (reason: ${detail.reason})`,
             );
           }
-          return {
-            modelOverride: cfg.lightModel,
-            providerOverride: cfg.lightProvider,
-          };
+          // void return = デフォルトモデル維持
+        } catch (err) {
+          // 例外時はデフォルトモデルを維持（void return）
+          api.logger.warn(`[model-router] classify error: ${err}`);
         }
-
-        if (cfg.logging) {
-          api.logger.debug(`[model-router] → ${cfg.defaultProvider}/${cfg.defaultModel} (default)`);
-        }
-        // void return = デフォルトモデル維持
-      } catch (err) {
-        // 例外時はデフォルトモデルを維持（void return）
-        api.logger.warn(`[model-router] classify error: ${err}`);
-      }
-    });
+      },
+    );
 
     api.logger.info("[model-router] plugin registered");
   },
 });
+
+/** ctx からセッション識別キーを取得。未定義時は "unknown" にフォールバック */
+function resolveSessionKey(ctx: Record<string, unknown> | undefined): string {
+  if (!ctx) return "unknown";
+  if (typeof ctx.sessionKey === "string" && ctx.sessionKey) return ctx.sessionKey;
+  if (typeof ctx.sessionId === "string" && ctx.sessionId) return ctx.sessionId;
+  return "unknown";
+}

--- a/packages/model-router/src/session-store.test.ts
+++ b/packages/model-router/src/session-store.test.ts
@@ -1,0 +1,139 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ClassificationDetail } from "./classifier.js";
+import { SessionStore } from "./session-store.js";
+
+function createStore(
+  overrides: { stickyWindowSize?: number; sessionTtlMs?: number; maxSessions?: number } = {},
+) {
+  return new SessionStore({
+    stickyWindowSize: overrides.stickyWindowSize ?? 3,
+    sessionTtlMs: overrides.sessionTtlMs ?? 30 * 60 * 1000,
+    maxSessions: overrides.maxSessions ?? 1000,
+  });
+}
+
+function detail(
+  reason: ClassificationDetail["reason"],
+  result: "light" | "default" = "default",
+): ClassificationDetail {
+  return { result, reason };
+}
+
+describe("SessionStore", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("未登録キー → 空の SessionContext を返す", () => {
+    const store = createStore();
+    const ctx = store.get("unknown-key");
+    expect(ctx).toEqual({ recentTurns: [] });
+  });
+
+  it("record() + get() で記録が反映される", () => {
+    const store = createStore();
+    store.record("session-1", detail("force_default"));
+
+    const ctx = store.get("session-1");
+    expect(ctx.recentTurns).toHaveLength(1);
+    expect(ctx.recentTurns[0].reason).toBe("force_default");
+  });
+
+  it("windowSize 超過 → 古いターンが切り捨てられる", () => {
+    const store = createStore({ stickyWindowSize: 2 });
+
+    store.record("s1", detail("force_default"));
+    store.record("s1", detail("sticky_default"));
+    store.record("s1", detail("light_match", "light"));
+
+    const ctx = store.get("s1");
+    expect(ctx.recentTurns).toHaveLength(2);
+    expect(ctx.recentTurns[0].reason).toBe("sticky_default");
+    expect(ctx.recentTurns[1].reason).toBe("light_match");
+  });
+
+  it("TTL 超過 → エントリが削除され空が返る", () => {
+    const store = createStore({ sessionTtlMs: 1000 });
+
+    store.record("s1", detail("force_default"));
+    expect(store.get("s1").recentTurns).toHaveLength(1);
+
+    // TTL 超過
+    vi.advanceTimersByTime(1001);
+
+    const ctx = store.get("s1");
+    expect(ctx.recentTurns).toHaveLength(0);
+    expect(store.size).toBe(0);
+  });
+
+  it("maxSessions 超過 → 最古セッションが削除される", () => {
+    const store = createStore({ maxSessions: 2 });
+
+    store.record("s1", detail("force_default"));
+    store.record("s2", detail("light_match", "light"));
+    expect(store.size).toBe(2);
+
+    // 3 つ目のセッションを追加 → s1 が削除される
+    store.record("s3", detail("unmatched"));
+    expect(store.size).toBe(2);
+    expect(store.get("s1").recentTurns).toHaveLength(0); // 削除済み
+    expect(store.get("s2").recentTurns).toHaveLength(1);
+    expect(store.get("s3").recentTurns).toHaveLength(1);
+  });
+
+  it("異なる sessionKey → セッションが分離される", () => {
+    const store = createStore();
+
+    store.record("line:user1", detail("force_default"));
+    store.record("slack:C123", detail("light_match", "light"));
+
+    const ctx1 = store.get("line:user1");
+    const ctx2 = store.get("slack:C123");
+
+    expect(ctx1.recentTurns).toHaveLength(1);
+    expect(ctx1.recentTurns[0].reason).toBe("force_default");
+    expect(ctx2.recentTurns).toHaveLength(1);
+    expect(ctx2.recentTurns[0].reason).toBe("light_match");
+  });
+
+  it("get() は recentTurns のコピーを返す（参照共有しない）", () => {
+    const store = createStore();
+    store.record("s1", detail("force_default"));
+
+    const ctx = store.get("s1");
+    ctx.recentTurns.push({ reason: "unmatched", timestamp: 0 });
+
+    // store 内部のデータは変更されていないこと
+    expect(store.get("s1").recentTurns).toHaveLength(1);
+  });
+
+  it("TTL 超過後に record() → 新規セッションとして再開", () => {
+    const store = createStore({ sessionTtlMs: 1000 });
+
+    store.record("s1", detail("force_default"));
+    vi.advanceTimersByTime(1001);
+
+    // TTL 超過後に新しい記録
+    store.record("s1", detail("light_match", "light"));
+
+    const ctx = store.get("s1");
+    expect(ctx.recentTurns).toHaveLength(1);
+    expect(ctx.recentTurns[0].reason).toBe("light_match");
+  });
+
+  it("既存セッションへの record() は maxSessions を消費しない", () => {
+    const store = createStore({ maxSessions: 2 });
+
+    store.record("s1", detail("force_default"));
+    store.record("s2", detail("light_match", "light"));
+
+    // 既存セッション s1 に追加 → maxSessions に引っかからない
+    store.record("s1", detail("sticky_default"));
+    expect(store.size).toBe(2);
+    expect(store.get("s1").recentTurns).toHaveLength(2);
+  });
+});

--- a/packages/model-router/src/session-store.ts
+++ b/packages/model-router/src/session-store.ts
@@ -1,0 +1,84 @@
+import type { ClassificationDetail, ClassificationReason } from "./classifier.js";
+
+export type TurnRecord = {
+  reason: ClassificationReason;
+  timestamp: number;
+};
+
+export type SessionContext = {
+  recentTurns: TurnRecord[];
+};
+
+type StoreEntry = {
+  recentTurns: TurnRecord[];
+  lastUpdated: number;
+};
+
+type SessionStoreConfig = {
+  stickyWindowSize: number;
+  sessionTtlMs: number;
+  maxSessions: number;
+};
+
+/**
+ * セッション単位の分類履歴をインメモリで管理するストア。
+ *
+ * - キー: sessionKey（例: "line:user123", "slack:C0123456"）
+ * - プロセス再起動でリセット（意図的。再起動後は default から再開）
+ * - TTL 超過エントリは get() 時に遅延削除
+ * - maxSessions 超過時に最古エントリを削除
+ */
+export class SessionStore {
+  private readonly store = new Map<string, StoreEntry>();
+  private readonly windowSize: number;
+  private readonly ttlMs: number;
+  private readonly maxSessions: number;
+
+  constructor(config: SessionStoreConfig) {
+    this.windowSize = config.stickyWindowSize;
+    this.ttlMs = config.sessionTtlMs;
+    this.maxSessions = config.maxSessions;
+  }
+
+  /** セッションの分類履歴を取得。TTL 超過時は空を返す。 */
+  get(sessionKey: string): SessionContext {
+    const entry = this.store.get(sessionKey);
+    if (!entry) {
+      return { recentTurns: [] };
+    }
+    if (Date.now() - entry.lastUpdated > this.ttlMs) {
+      this.store.delete(sessionKey);
+      return { recentTurns: [] };
+    }
+    return { recentTurns: [...entry.recentTurns] };
+  }
+
+  /** 分類結果を記録。windowSize を超えた古いターンは切り捨て。 */
+  record(sessionKey: string, detail: ClassificationDetail): void {
+    const ctx = this.get(sessionKey);
+    ctx.recentTurns.push({
+      reason: detail.reason,
+      timestamp: Date.now(),
+    });
+    // windowSize を超えた古いターンを切り捨て
+    if (ctx.recentTurns.length > this.windowSize) {
+      ctx.recentTurns = ctx.recentTurns.slice(-this.windowSize);
+    }
+    // maxSessions 超過時に最古エントリを削除
+    if (!this.store.has(sessionKey) && this.store.size >= this.maxSessions) {
+      const oldest = this.store.keys().next().value;
+      if (oldest !== undefined) {
+        this.store.delete(oldest);
+      }
+    }
+    this.store.set(sessionKey, {
+      recentTurns: ctx.recentTurns,
+      lastUpdated: Date.now(),
+    });
+  }
+
+  /** 現在の保持セッション数（テスト用） */
+  get size(): number {
+    return this.store.size;
+  }
+}

--- a/packages/model-router/src/session-store.ts
+++ b/packages/model-router/src/session-store.ts
@@ -1,13 +1,7 @@
-import type { ClassificationDetail, ClassificationReason } from "./classifier.js";
+import type { ClassificationDetail, SessionContext, TurnRecord } from "./types.js";
 
-export type TurnRecord = {
-  reason: ClassificationReason;
-  timestamp: number;
-};
-
-export type SessionContext = {
-  recentTurns: TurnRecord[];
-};
+// 後方互換: 型を re-export（既存の import { SessionContext } from "./session-store.js" を維持）
+export type { SessionContext, TurnRecord };
 
 type StoreEntry = {
   recentTurns: TurnRecord[];

--- a/packages/model-router/src/types.ts
+++ b/packages/model-router/src/types.ts
@@ -1,0 +1,28 @@
+/**
+ * model-router パッケージのドメイン型定義。
+ * classifier.ts と session-store.ts の循環依存を避けるため、
+ * 共通型はこのファイルに集約する。
+ */
+
+export type ClassificationResult = "light" | "default";
+
+export type ClassificationReason =
+  | "force_default"
+  | "token_exceeded"
+  | "sticky_default"
+  | "light_match"
+  | "unmatched";
+
+export type ClassificationDetail = {
+  result: ClassificationResult;
+  reason: ClassificationReason;
+};
+
+export type TurnRecord = {
+  reason: ClassificationReason;
+  timestamp: number;
+};
+
+export type SessionContext = {
+  recentTurns: TurnRecord[];
+};


### PR DESCRIPTION
## 概要

PR #102 で実装された model-router に **Sticky Default Guard** を追加し、複雑タスク途中の軽量メッセージ（「はい」「了解」等）が Haiku に誤ルーティングされる問題を解決します。

## 背景

Phase 1 PoC のレビューで以下の課題が指摘されていました。

- 会話コンテキスト無視: 直前のターンが複雑な設計議論中の「はい」も、単独の挨拶と同じく Haiku に流れてしまう
- false positive の非対称コスト: Haiku 誤ルーティングの品質劣化コスト >> Sonnet 過剰利用のコスト

## 設計

### Sticky Default Guard

直近 N ターンに `force_default` または `token_exceeded` があれば、保守的に `default` を維持します。

```
T1: "コードレビューして" → force_default
T2: "はい"              → sticky 発動 → sticky_default (Sonnet 維持)
T3: "ありがとう"         → sticky 発動 → sticky_default (Sonnet 維持)
T4: (window 外に出る)   → sticky 解除 → light (Haiku)
```

**重要な設計判断**: `sticky_default` は **非伝播**。`shouldStickyDefault()` のトリガー条件から除外することで無限ループを防止しています。

### ClassificationDetail 型導入

理由を追跡できるよう、分類結果を `{ result, reason }` 形式に変更:

```typescript
type ClassificationReason =
  | \"force_default\"     // forceDefault パターンに明示的マッチ
  | \"token_exceeded\"    // トークン数超過
  | \"sticky_default\"    // Sticky Guard 経由（非伝播）
  | \"light_match\"       // preferLight パターンにマッチ
  | \"unmatched\";        // どのパターンにも未マッチ
```

### SessionStore

- インメモリ Map（`sessionKey` でキーイング、例: \"line:user1\", \"slack:C123\"）
- TTL 30 分（超過時に遅延削除）
- maxSessions 1000（超過時に最古を削除）
- プロセス再起動でリセット（意図的）

### ロールバック戦略

`enableSessionContext: false` で Layer 2 を完全に無効化し、Phase 1 と同等動作に戻せます。

## 変更内容

### 新規ファイル
- \`packages/model-router/src/session-store.ts\` — SessionStore クラス
- \`packages/model-router/src/session-store.test.ts\` — 9 件のテスト

### 既存変更
- \`config.ts\` — \`enableSessionContext\`, \`stickyWindowSize\`, \`sessionTtlMs\`, \`maxSessions\` 追加
- \`classifier.ts\` — \`ClassificationDetail\` 導入、\`shouldStickyDefault()\` 追加、内部関数を分離
- \`classifier.test.ts\` — 既存 13 件更新 + Sticky Guard テスト 12 件追加
- \`index.ts\` — SessionStore 統合、\`ctx\` パラメータ活用、初回診断ログ
- \`index.test.ts\` — 既存 8 件更新 + セッション統合テスト 6 件追加

## テスト結果

\`\`\`
Test Files  3 passed (3)
Tests  48 passed (48)
\`\`\`

- session-store.test.ts: 9 件
- classifier.test.ts: 25 件
- index.test.ts: 14 件

Lint (Biome) もエラーゼロ。

## openclaw.json への影響

なし。Phase 1.5 の追加 config はすべてオプショナルでデフォルト値を持つため、既存の \`pluginConfig\` をそのまま使えます。

必要に応じて以下のオーバーライドが可能:

\`\`\`json
\"model-router\": {
  \"enabled\": true,
  \"config\": {
    \"enableSessionContext\": true,
    \"stickyWindowSize\": 3,
    \"sessionTtlMs\": 1800000,
    \"maxSessions\": 1000
  }
}
\`\`\`

## レビュー観点

- Sticky Guard の \`stickyWindowSize: 3\` がデフォルトとして妥当か
- \`ctx.sessionKey\` が OpenClaw の \`before_model_resolve\` フックで実際に提供されるか（初回デプロイ時に診断ログで要確認）
- Phase 2 として検討中の項目: マルチプロバイダー対応（Gemini Flash 等）、Embedding ベース分類

Resolves estack-inc/easy-flow#87

<!-- n8n Slack通知連携 -->
<!-- slack_channel: C0AM4DY5B5G -->
<!-- slack_thread_ts: -->
<!-- slack_agent_mention: -->