### PR TITLE
fix(file-serve): LINE ファイル配信を Flex Message からテキスト URL に変更

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,8 +15,6 @@
       },
       "devDependencies": {
         "@biomejs/biome": "^2.4.7",
-        "@types/mime-types": "^3.0.1",
-        "mime-types": "^3.0.2",
         "tsx": "^4.21.0"
       }
     },
@@ -1036,13 +1034,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/mime-types": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@types/mime-types/-/mime-types-3.0.1.tgz",
-      "integrity": "sha512-xRMsfuQbnRq1Ef+C+RKaENOxXX87Ygl38W1vDfPHRku02TgQr+Qd8iivLtAMcR0KF5/29xlnFihkTlbqFrGOVQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/node": {
       "version": "22.19.15",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
@@ -1387,33 +1378,6 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
-      }
-    },
-    "node_modules/mime-db": {
-      "version": "1.54.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
-      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
-      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "^1.54.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/model-router": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,8 @@
       },
       "devDependencies": {
         "@biomejs/biome": "^2.4.7",
+        "@types/mime-types": "^3.0.1",
+        "mime-types": "^3.0.2",
         "tsx": "^4.21.0"
       }
     },
@@ -1035,9 +1037,9 @@
       "license": "MIT"
     },
     "node_modules/@types/mime-types": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@types/mime-types/-/mime-types-2.1.4.tgz",
-      "integrity": "sha512-lfU4b34HOri+kAY5UheuFMWPDOI+OPceBSHZKp69gEyTL/mmJ4cnU6Y/rlme3UL3GyOn6Y42hyIEw0/q8sWx5w==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/mime-types/-/mime-types-3.0.1.tgz",
+      "integrity": "sha512-xRMsfuQbnRq1Ef+C+RKaENOxXX87Ygl38W1vDfPHRku02TgQr+Qd8iivLtAMcR0KF5/29xlnFihkTlbqFrGOVQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -1388,24 +1390,30 @@
       }
     },
     "node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "mime-db": "1.52.0"
+        "mime-db": "^1.54.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/model-router": {
@@ -1915,6 +1923,34 @@
         "openclaw": {
           "optional": true
         }
+      }
+    },
+    "packages/file-serve/node_modules/@types/mime-types": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@types/mime-types/-/mime-types-2.1.4.tgz",
+      "integrity": "sha512-lfU4b34HOri+kAY5UheuFMWPDOI+OPceBSHZKp69gEyTL/mmJ4cnU6Y/rlme3UL3GyOn6Y42hyIEw0/q8sWx5w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "packages/file-serve/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "packages/file-serve/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "packages/migrate-memory": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.7",
+    "@types/mime-types": "^3.0.1",
+    "mime-types": "^3.0.2",
     "tsx": "^4.21.0"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -15,8 +15,6 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.7",
-    "@types/mime-types": "^3.0.1",
-    "mime-types": "^3.0.2",
     "tsx": "^4.21.0"
   },
   "dependencies": {

--- a/packages/file-serve/src/hook-before-tool-call.ts
+++ b/packages/file-serve/src/hook-before-tool-call.ts
@@ -4,7 +4,11 @@ import type { FileServeConfig } from "./config.js";
 import type { PluginLogger } from "./index.js";
 import { saveFile } from "./storage.js";
 
-const IMAGE_MIME_TYPES = new Set(["image/png", "image/jpeg", "image/gif", "image/webp"]);
+/** LINE が画像メッセージ（media）として送信可能な MIME タイプ（JPEG/PNG のみ公式サポート） */
+const LINE_IMAGE_MIME_TYPES = new Set(["image/png", "image/jpeg"]);
+
+/** media 送信時のプレビュー画像サイズ上限（LINE 仕様: 1 MB） */
+const LINE_PREVIEW_IMAGE_MAX_BYTES = 1 * 1024 * 1024;
 
 function formatFileSize(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`;
@@ -12,34 +16,13 @@ function formatFileSize(bytes: number): string {
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }
 
-function buildFlexMessage(filename: string, sizeBytes: number, downloadUrl: string): object {
-  return {
-    type: "flex",
-    altText: `ファイル: ${filename}`,
-    contents: {
-      type: "bubble",
-      body: {
-        type: "box",
-        layout: "vertical",
-        contents: [
-          { type: "text", text: "📄 ファイル", weight: "bold", size: "sm", color: "#999999" },
-          { type: "text", text: filename, weight: "bold", size: "md", wrap: true },
-          { type: "text", text: formatFileSize(sizeBytes), size: "sm", color: "#999999" },
-        ],
-      },
-      footer: {
-        type: "box",
-        layout: "vertical",
-        contents: [
-          {
-            type: "button",
-            action: { type: "uri", label: "ダウンロード", uri: downloadUrl },
-            style: "primary",
-          },
-        ],
-      },
-    },
-  };
+function buildDownloadText(
+  filename: string,
+  sizeBytes: number,
+  downloadUrl: string,
+  ttlDays: number,
+): string {
+  return `📄 ${filename}（${formatFileSize(sizeBytes)}）\n${downloadUrl}\n有効期限: ${ttlDays}日間`;
 }
 
 export type PluginHookBeforeToolCallEvent = {
@@ -112,14 +95,21 @@ export function createBeforeToolCallHook(config: FileServeConfig, logger: Plugin
 
     const updatedParams = { ...event.params };
 
-    if (IMAGE_MIME_TYPES.has(detectedMime)) {
-      // 画像: media を配信 URL に書き換え
+    const isLineImage =
+      LINE_IMAGE_MIME_TYPES.has(detectedMime) &&
+      saveResult.sizeBytes <= LINE_PREVIEW_IMAGE_MAX_BYTES;
+
+    if (isLineImage) {
+      // JPEG/PNG かつ 1 MB 以下: LINE 画像メッセージとして送信
       updatedParams.media = saveResult.servedUrl;
       delete updatedParams.filePath;
     } else {
-      // PDF/Excel 等: Flex Message に変換（sizeBytes は saveFile が stat 済みの値を使用）
-      updatedParams.message = JSON.stringify(
-        buildFlexMessage(filename, saveResult.sizeBytes, saveResult.servedUrl),
+      // それ以外（PDF/Excel/大きい画像/GIF/WebP 等）: テキスト URL で案内
+      updatedParams.message = buildDownloadText(
+        filename,
+        saveResult.sizeBytes,
+        saveResult.servedUrl,
+        config.ttlDays,
       );
       delete updatedParams.filePath;
       delete updatedParams.media;

--- a/packages/file-serve/test/hook-before-tool-call.test.ts
+++ b/packages/file-serve/test/hook-before-tool-call.test.ts
@@ -69,6 +69,25 @@ describe("createBeforeToolCallHook", () => {
     expect(result?.params?.filePath).toBeUndefined();
   });
 
+  it("LINE + JPEG → params.media が配信 URL に書き換わる、params.filePath が undefined", async () => {
+    const servedUrl = "https://example.fly.dev/files/uuid-6/photo.jpg";
+    (saveFile as ReturnType<typeof vi.fn>).mockResolvedValue({
+      uuid: "uuid-6",
+      servedUrl,
+      sizeBytes: 4096,
+    });
+
+    const hook = createBeforeToolCallHook(baseConfig, mockLogger);
+    const result = await hook(
+      makeEvent({ params: { filePath: "/tmp/photo.jpg" } }),
+      makeCtx({ sessionKey: "line:user123" }),
+    );
+
+    expect(result).toBeDefined();
+    expect(result?.params?.media).toBe(servedUrl);
+    expect(result?.params?.filePath).toBeUndefined();
+  });
+
   it("LINE + PDF → params.message がダウンロード URL テキスト、params.filePath/media が undefined", async () => {
     const servedUrl = "https://example.fly.dev/files/uuid-2/document.pdf";
     (saveFile as ReturnType<typeof vi.fn>).mockResolvedValue({

--- a/packages/file-serve/test/hook-before-tool-call.test.ts
+++ b/packages/file-serve/test/hook-before-tool-call.test.ts
@@ -69,7 +69,7 @@ describe("createBeforeToolCallHook", () => {
     expect(result?.params?.filePath).toBeUndefined();
   });
 
-  it("LINE + PDF → params.message が Flex Message JSON、type === 'flex'、params.filePath が undefined", async () => {
+  it("LINE + PDF → params.message がダウンロード URL テキスト、params.filePath/media が undefined", async () => {
     const servedUrl = "https://example.fly.dev/files/uuid-2/document.pdf";
     (saveFile as ReturnType<typeof vi.fn>).mockResolvedValue({
       uuid: "uuid-2",
@@ -85,9 +85,50 @@ describe("createBeforeToolCallHook", () => {
 
     expect(result).toBeDefined();
     expect(typeof result?.params?.message).toBe("string");
-    const flexMsg = JSON.parse(result?.params?.message as string);
-    expect(flexMsg.type).toBe("flex");
+    expect(result?.params?.message).toContain(servedUrl);
+    expect(result?.params?.message).toContain("document.pdf");
+    expect(result?.params?.message).toContain("7日間");
     expect(result?.params?.filePath).toBeUndefined();
+    expect(result?.params?.media).toBeUndefined();
+  });
+
+  it("LINE + PNG（1 MB 超）→ テキスト URL で案内（LINE プレビュー制限回避）", async () => {
+    const servedUrl = "https://example.fly.dev/files/uuid-4/large.png";
+    (saveFile as ReturnType<typeof vi.fn>).mockResolvedValue({
+      uuid: "uuid-4",
+      servedUrl,
+      sizeBytes: 2 * 1024 * 1024, // 2 MB
+    });
+
+    const hook = createBeforeToolCallHook(baseConfig, mockLogger);
+    const result = await hook(
+      makeEvent({ params: { filePath: "/tmp/large.png" } }),
+      makeCtx({ sessionKey: "line:user123" }),
+    );
+
+    expect(result).toBeDefined();
+    expect(typeof result?.params?.message).toBe("string");
+    expect(result?.params?.message).toContain(servedUrl);
+    expect(result?.params?.media).toBeUndefined();
+  });
+
+  it("LINE + GIF → テキスト URL で案内（LINE 公式未サポート）", async () => {
+    const servedUrl = "https://example.fly.dev/files/uuid-5/anim.gif";
+    (saveFile as ReturnType<typeof vi.fn>).mockResolvedValue({
+      uuid: "uuid-5",
+      servedUrl,
+      sizeBytes: 512,
+    });
+
+    const hook = createBeforeToolCallHook(baseConfig, mockLogger);
+    const result = await hook(
+      makeEvent({ params: { filePath: "/tmp/anim.gif" } }),
+      makeCtx({ sessionKey: "line:user123" }),
+    );
+
+    expect(result).toBeDefined();
+    expect(typeof result?.params?.message).toBe("string");
+    expect(result?.params?.message).toContain(servedUrl);
     expect(result?.params?.media).toBeUndefined();
   });
 


### PR DESCRIPTION
## Summary
- LINE Messaging API の Flex Message ボタン UI が Bot 非対応のため、ファイル配信をテキスト URL 方式に変更
- 画像送信対象を JPEG/PNG のみに限定（LINE 公式サポート形式）
- 1 MB 超の画像はテキスト URL にフォールバック（LINE プレビューサイズ制限回避）
- GIF/WebP は LINE 公式未サポートのためテキスト URL で案内

## 変更内容
- `hook-before-tool-call.ts`: `buildFlexMessage()` → `buildDownloadText()` に置換、LINE 画像制約（MIME + サイズ）を追加
- `hook-before-tool-call.test.ts`: PDF テストを Flex → テキスト URL に更新、大サイズ PNG・GIF のテストケース追加（計 9 テスト）

## ルーティングロジック
| 条件 | 動作 |
|------|------|
| JPEG/PNG かつ ≤1 MB | `params.media` に配信 URL を設定（LINE 画像メッセージ） |
| 上記以外（PDF/Excel/GIF/WebP/大画像等） | `params.message` にテキスト URL を設定 |

## Test plan
- [x] 全 9 テストケース通過
- [ ] LINE チャネルで PNG 送信 → 画像プレビューで表示されること
- [ ] LINE チャネルで PDF 送信 → テキスト URL が表示されること
- [ ] LINE チャネルで 1 MB 超 PNG → テキスト URL にフォールバックすること

Related: estack-inc/easy-flow#93