### PR TITLE
feat(migrate-memory): AGENTS.md チャンク分割・Pinecone 投入の agents サブコマンドを追加

### DIFF
--- a/packages/migrate-memory/src/cli.ts
+++ b/packages/migrate-memory/src/cli.ts
@@ -5,6 +5,7 @@ import { PineconeClient } from "@easy-flow/pinecone-client";
 import { bulkMigrate } from "./bulk-migrator.js";
 import { bulkUpdate } from "./bulk-updater.js";
 import { MemoryDeleter } from "./deleter.js";
+import { AgentsMigrator } from "./migrate-agents.js";
 import { Migrator } from "./migrator.js";
 import { validateExcludePatterns } from "./preflight.js";
 
@@ -13,6 +14,7 @@ function printUsage(): void {
 
 Commands:
   migrate-memory    Migrate markdown files to Pinecone
+  agents            Migrate AGENTS.md to Pinecone (section-based chunking)
   memory-delete     Delete memory from Pinecone
   bulk-migrate      Bulk migrate all EasyFlow instances to Pinecone
   bulk-update       Bulk update easy-flow-agent on all instances
@@ -131,6 +133,94 @@ async function runMigrate(args: string[]): Promise<void> {
       console.log(`  ${err.file}: ${err.error}`);
     }
     process.exit(1);
+  }
+}
+
+function printAgentsUsage(): void {
+  console.log(`Usage: easy-flow agents [options]
+
+Options:
+  --file <path>       AGENTS.md file path (required)
+  --agent-id <id>     Agent ID (required)
+  --dry-run           Preview chunking without writing to Pinecone
+  --help              Show this help message`);
+}
+
+async function runAgents(args: string[]): Promise<void> {
+  const { values } = parseArgs({
+    args,
+    options: {
+      file: { type: "string" },
+      "agent-id": { type: "string" },
+      "dry-run": { type: "boolean", default: false },
+      help: { type: "boolean", default: false },
+    },
+    strict: true,
+  });
+
+  if (values.help) {
+    printAgentsUsage();
+    process.exit(0);
+  }
+
+  const filePath = values.file as string | undefined;
+  const agentId = values["agent-id"] as string | undefined;
+  const dryRun = values["dry-run"] as boolean;
+
+  if (!filePath) {
+    console.error("Error: --file is required");
+    process.exit(1);
+  }
+  if (!agentId) {
+    console.error("Error: --agent-id is required");
+    process.exit(1);
+  }
+
+  const apiKey = process.env.PINECONE_API_KEY;
+  if (!apiKey && !dryRun) {
+    console.error("Error: PINECONE_API_KEY environment variable is required");
+    process.exit(1);
+  }
+
+  const client = apiKey ? new PineconeClient({ apiKey }) : noopClient();
+  const migrator = new AgentsMigrator({ pineconeClient: client, agentId, dryRun });
+
+  const namespace = `agent:${agentId}`;
+
+  if (dryRun) {
+    console.log(`📄 Parsing: ${filePath}`);
+    console.log(`   Agent ID: ${agentId}`);
+    console.log(`   Namespace: ${namespace}\n`);
+
+    const result = await migrator.migrate(filePath);
+
+    console.log("   Chunks:");
+    for (let i = 0; i < result.sections.length; i++) {
+      const s = result.sections[i];
+      console.log(`   [${i + 1}] ${s.heading} (${s.tokens} tokens)`);
+    }
+
+    console.log(
+      `\n   Total: ${result.chunks} chunks, ~${result.totalTokens.toLocaleString()} tokens`,
+    );
+    console.log("   (dry-run: no data written to Pinecone)");
+  } else {
+    console.log(`📄 Migrating: ${filePath} → Pinecone`);
+    console.log(`   Agent ID: ${agentId}`);
+    console.log(`   Namespace: ${namespace}\n`);
+
+    const start = Date.now();
+    const result = await migrator.migrate(filePath);
+    const elapsed = ((Date.now() - start) / 1000).toFixed(1);
+
+    const avgTokens = result.chunks > 0 ? Math.round(result.totalTokens / result.chunks) : 0;
+    console.log(`   Chunking... done (${result.chunks} chunks, avg ${avgTokens} tokens)`);
+    console.log(`   Upserting... done (${result.upsertedChunks}/${result.chunks})`);
+
+    console.log(`\n✅ Migration complete`);
+    console.log(`   Chunks: ${result.chunks}`);
+    console.log(`   Total tokens: ~${result.totalTokens.toLocaleString()}`);
+    console.log(`   Time: ${elapsed}s`);
   }
 }
 
@@ -281,6 +371,8 @@ async function main(): Promise<void> {
 
   if (subcommand === "migrate-memory") {
     await runMigrate(process.argv.slice(3));
+  } else if (subcommand === "agents") {
+    await runAgents(process.argv.slice(3));
   } else if (subcommand === "memory-delete") {
     await runDelete(process.argv.slice(3));
   } else if (subcommand === "bulk-migrate") {

--- a/packages/migrate-memory/src/migrate-agents.test.ts
+++ b/packages/migrate-memory/src/migrate-agents.test.ts
@@ -132,18 +132,23 @@ describe("parseMarkdownSections", () => {
 });
 
 describe("estimateTokens", () => {
-  it("テキストのトークン数を推定する", () => {
-    const text = "Hello World"; // 11 chars → ceil(11/3) = 4
-    expect(estimateTokens(text)).toBe(4);
+  it("ASCII テキストは ~4 chars/token で推定する", () => {
+    const text = "Hello World"; // 11 ASCII chars → ceil(11 * 0.25) = 3
+    expect(estimateTokens(text)).toBe(3);
   });
 
   it("空文字列は 0 を返す", () => {
     expect(estimateTokens("")).toBe(0);
   });
 
-  it("日本語テキストのトークン数を推定する", () => {
-    const text = "日本語テスト"; // 6 chars → ceil(6/3) = 2
-    expect(estimateTokens(text)).toBe(2);
+  it("日本語テキストは ~1.5 tokens/char で推定する", () => {
+    const text = "日本語テスト"; // 6 CJK chars → ceil(6 * 1.5) = 9
+    expect(estimateTokens(text)).toBe(9);
+  });
+
+  it("日本語と ASCII の混在テキストを正しく推定する", () => {
+    const text = "Hello日本語"; // 5 ASCII + 3 CJK → ceil(5*0.25 + 3*1.5) = ceil(5.75) = 6
+    expect(estimateTokens(text)).toBe(6);
   });
 });
 
@@ -158,7 +163,7 @@ describe("AgentsMigrator", () => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  it("dry-run モードでは upsert を呼ばない", async () => {
+  it("dry-run モードでは upsert も deleteBySource も呼ばない", async () => {
     const client = createMockClient();
     const migrator = new AgentsMigrator({
       pineconeClient: client,
@@ -174,9 +179,10 @@ describe("AgentsMigrator", () => {
     expect(result.chunks).toBe(2);
     expect(result.upsertedChunks).toBe(0);
     expect(client.upsert).not.toHaveBeenCalled();
+    expect(client.deleteBySource).not.toHaveBeenCalled();
   });
 
-  it("通常モードでは upsert を呼ぶ", async () => {
+  it("通常モードでは deleteBySource → upsert の順で呼ぶ", async () => {
     const client = createMockClient();
     const migrator = new AgentsMigrator({
       pineconeClient: client,
@@ -191,7 +197,13 @@ describe("AgentsMigrator", () => {
 
     expect(result.chunks).toBe(2);
     expect(result.upsertedChunks).toBe(2);
+    expect(client.deleteBySource).toHaveBeenCalledWith("mel", "AGENTS.md");
     expect(client.upsert).toHaveBeenCalledOnce();
+
+    // deleteBySource が upsert より先に呼ばれていることを確認
+    const deleteOrder = client.deleteBySource.mock.invocationCallOrder[0];
+    const upsertOrder = client.upsert.mock.invocationCallOrder[0];
+    expect(deleteOrder).toBeLessThan(upsertOrder);
   });
 
   it("メタデータに agents_rule と agentId を正しく設定する", async () => {

--- a/packages/migrate-memory/src/migrate-agents.test.ts
+++ b/packages/migrate-memory/src/migrate-agents.test.ts
@@ -258,6 +258,7 @@ describe("AgentsMigrator", () => {
     expect(result.chunks).toBe(0);
     expect(result.totalTokens).toBe(0);
     expect(client.upsert).not.toHaveBeenCalled();
+    expect(client.deleteBySource).not.toHaveBeenCalled();
   });
 
   it("空白のみのファイルでは 0 チャンクを返す", async () => {
@@ -274,6 +275,7 @@ describe("AgentsMigrator", () => {
 
     expect(result.chunks).toBe(0);
     expect(client.upsert).not.toHaveBeenCalled();
+    expect(client.deleteBySource).not.toHaveBeenCalled();
   });
 
   it("見出しなしファイルは 1 チャンクになる", async () => {

--- a/packages/migrate-memory/src/migrate-agents.test.ts
+++ b/packages/migrate-memory/src/migrate-agents.test.ts
@@ -1,0 +1,318 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { IPineconeClient, MemoryChunk } from "@easy-flow/pinecone-client";
+import { afterEach, beforeEach, describe, expect, it, type Mock, vi } from "vitest";
+import { AgentsMigrator, estimateTokens, parseMarkdownSections } from "./migrate-agents.js";
+
+function createMockClient(): IPineconeClient & {
+  [K in keyof IPineconeClient]: Mock;
+} {
+  return {
+    upsert: vi.fn().mockResolvedValue(undefined),
+    query: vi.fn().mockResolvedValue([]),
+    delete: vi.fn().mockResolvedValue(undefined),
+    deleteBySource: vi.fn().mockResolvedValue(undefined),
+    deleteNamespace: vi.fn().mockResolvedValue(undefined),
+    ensureIndex: vi.fn().mockResolvedValue(undefined),
+  } as IPineconeClient & { [K in keyof IPineconeClient]: Mock };
+}
+
+describe("parseMarkdownSections", () => {
+  it("## 見出しで分割する", () => {
+    const text = `## セクション 1
+内容 1
+
+## セクション 2
+内容 2`;
+
+    const sections = parseMarkdownSections(text);
+
+    expect(sections).toHaveLength(2);
+    expect(sections[0].heading).toBe("## セクション 1");
+    expect(sections[0].text).toContain("内容 1");
+    expect(sections[1].heading).toBe("## セクション 2");
+    expect(sections[1].text).toContain("内容 2");
+  });
+
+  it("### 見出しで分割する", () => {
+    const text = `### サブセクション A
+内容 A
+
+### サブセクション B
+内容 B`;
+
+    const sections = parseMarkdownSections(text);
+
+    expect(sections).toHaveLength(2);
+    expect(sections[0].heading).toBe("### サブセクション A");
+    expect(sections[1].heading).toBe("### サブセクション B");
+  });
+
+  it("#### 以下の見出しは親セクションに含める", () => {
+    const text = `## 親セクション
+親の内容
+
+#### 深い見出し
+深い内容
+
+##### さらに深い
+さらに深い内容`;
+
+    const sections = parseMarkdownSections(text);
+
+    expect(sections).toHaveLength(1);
+    expect(sections[0].heading).toBe("## 親セクション");
+    expect(sections[0].text).toContain("#### 深い見出し");
+    expect(sections[0].text).toContain("深い内容");
+    expect(sections[0].text).toContain("##### さらに深い");
+  });
+
+  it("最初の ## / ### より前のテキストをプリアンブルとして扱う", () => {
+    const text = `# タイトル
+導入テキスト
+
+## セクション 1
+内容 1`;
+
+    const sections = parseMarkdownSections(text);
+
+    expect(sections).toHaveLength(2);
+    expect(sections[0].heading).toBe("");
+    expect(sections[0].text).toContain("# タイトル");
+    expect(sections[0].text).toContain("導入テキスト");
+    expect(sections[1].heading).toBe("## セクション 1");
+  });
+
+  it("空のテキストでは空配列を返す", () => {
+    expect(parseMarkdownSections("")).toHaveLength(0);
+    expect(parseMarkdownSections("   ")).toHaveLength(0);
+  });
+
+  it("見出しなしのテキストは 1 チャンクになる", () => {
+    const text = "見出しのないプレーンテキスト\n複数行ある";
+
+    const sections = parseMarkdownSections(text);
+
+    expect(sections).toHaveLength(1);
+    expect(sections[0].heading).toBe("");
+    expect(sections[0].text).toContain("見出しのないプレーンテキスト");
+  });
+
+  it("## と ### が混在するドキュメントを正しく分割する", () => {
+    const text = `## 大セクション
+大の内容
+
+### サブセクション
+サブの内容
+
+## 次の大セクション
+次の内容`;
+
+    const sections = parseMarkdownSections(text);
+
+    expect(sections).toHaveLength(3);
+    expect(sections[0].heading).toBe("## 大セクション");
+    expect(sections[1].heading).toBe("### サブセクション");
+    expect(sections[2].heading).toBe("## 次の大セクション");
+  });
+
+  it("見出しのみ（本文なし）のセクションも含める", () => {
+    const text = `## 見出しのみ
+
+## 次のセクション
+内容あり`;
+
+    const sections = parseMarkdownSections(text);
+
+    expect(sections).toHaveLength(2);
+    expect(sections[0].heading).toBe("## 見出しのみ");
+    expect(sections[1].heading).toBe("## 次のセクション");
+  });
+});
+
+describe("estimateTokens", () => {
+  it("テキストのトークン数を推定する", () => {
+    const text = "Hello World"; // 11 chars → ceil(11/3) = 4
+    expect(estimateTokens(text)).toBe(4);
+  });
+
+  it("空文字列は 0 を返す", () => {
+    expect(estimateTokens("")).toBe(0);
+  });
+
+  it("日本語テキストのトークン数を推定する", () => {
+    const text = "日本語テスト"; // 6 chars → ceil(6/3) = 2
+    expect(estimateTokens(text)).toBe(2);
+  });
+});
+
+describe("AgentsMigrator", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agents-migrate-test-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("dry-run モードでは upsert を呼ばない", async () => {
+    const client = createMockClient();
+    const migrator = new AgentsMigrator({
+      pineconeClient: client,
+      agentId: "mel",
+      dryRun: true,
+    });
+
+    const file = path.join(tmpDir, "AGENTS.md");
+    fs.writeFileSync(file, "## ルール 1\n内容 1\n\n## ルール 2\n内容 2", "utf-8");
+
+    const result = await migrator.migrate(file);
+
+    expect(result.chunks).toBe(2);
+    expect(result.upsertedChunks).toBe(0);
+    expect(client.upsert).not.toHaveBeenCalled();
+  });
+
+  it("通常モードでは upsert を呼ぶ", async () => {
+    const client = createMockClient();
+    const migrator = new AgentsMigrator({
+      pineconeClient: client,
+      agentId: "mel",
+      dryRun: false,
+    });
+
+    const file = path.join(tmpDir, "AGENTS.md");
+    fs.writeFileSync(file, "## ルール 1\n内容 1\n\n## ルール 2\n内容 2", "utf-8");
+
+    const result = await migrator.migrate(file);
+
+    expect(result.chunks).toBe(2);
+    expect(result.upsertedChunks).toBe(2);
+    expect(client.upsert).toHaveBeenCalledOnce();
+  });
+
+  it("メタデータに agents_rule と agentId を正しく設定する", async () => {
+    const client = createMockClient();
+    const migrator = new AgentsMigrator({
+      pineconeClient: client,
+      agentId: "mel",
+    });
+
+    const file = path.join(tmpDir, "AGENTS.md");
+    fs.writeFileSync(file, "## テストルール\nルール内容", "utf-8");
+
+    await migrator.migrate(file);
+
+    const chunks = client.upsert.mock.calls[0][0] as MemoryChunk[];
+    expect(chunks[0].metadata.sourceType).toBe("agents_rule");
+    expect(chunks[0].metadata.agentId).toBe("mel");
+    expect(chunks[0].metadata.sourceFile).toBe("AGENTS.md");
+    expect(chunks[0].metadata.createdAt).toBeTypeOf("number");
+    expect(chunks[0].metadata.chunkIndex).toBe(0);
+  });
+
+  it("チャンク ID が正しい形式で生成される", async () => {
+    const client = createMockClient();
+    const migrator = new AgentsMigrator({
+      pineconeClient: client,
+      agentId: "mel",
+    });
+
+    const file = path.join(tmpDir, "AGENTS.md");
+    fs.writeFileSync(file, "## セクション 1\n内容 1\n\n## セクション 2\n内容 2", "utf-8");
+
+    await migrator.migrate(file);
+
+    const chunks = client.upsert.mock.calls[0][0] as MemoryChunk[];
+    expect(chunks[0].id).toBe("mel:AGENTS.md:0");
+    expect(chunks[1].id).toBe("mel:AGENTS.md:1");
+  });
+
+  it("空ファイルでは 0 チャンクを返す", async () => {
+    const client = createMockClient();
+    const migrator = new AgentsMigrator({
+      pineconeClient: client,
+      agentId: "mel",
+    });
+
+    const file = path.join(tmpDir, "AGENTS.md");
+    fs.writeFileSync(file, "", "utf-8");
+
+    const result = await migrator.migrate(file);
+
+    expect(result.chunks).toBe(0);
+    expect(result.totalTokens).toBe(0);
+    expect(client.upsert).not.toHaveBeenCalled();
+  });
+
+  it("空白のみのファイルでは 0 チャンクを返す", async () => {
+    const client = createMockClient();
+    const migrator = new AgentsMigrator({
+      pineconeClient: client,
+      agentId: "mel",
+    });
+
+    const file = path.join(tmpDir, "AGENTS.md");
+    fs.writeFileSync(file, "   \n\n  ", "utf-8");
+
+    const result = await migrator.migrate(file);
+
+    expect(result.chunks).toBe(0);
+    expect(client.upsert).not.toHaveBeenCalled();
+  });
+
+  it("見出しなしファイルは 1 チャンクになる", async () => {
+    const client = createMockClient();
+    const migrator = new AgentsMigrator({
+      pineconeClient: client,
+      agentId: "mel",
+    });
+
+    const file = path.join(tmpDir, "AGENTS.md");
+    fs.writeFileSync(file, "見出しのないルール記述\n複数行に渡る内容", "utf-8");
+
+    const result = await migrator.migrate(file);
+
+    expect(result.chunks).toBe(1);
+    expect(result.upsertedChunks).toBe(1);
+  });
+
+  it("sections に見出しとトークン数が含まれる", async () => {
+    const client = createMockClient();
+    const migrator = new AgentsMigrator({
+      pineconeClient: client,
+      agentId: "mel",
+      dryRun: true,
+    });
+
+    const file = path.join(tmpDir, "AGENTS.md");
+    fs.writeFileSync(file, "## コミュニケーション\nルール内容\n\n## レビュー\n基準内容", "utf-8");
+
+    const result = await migrator.migrate(file);
+
+    expect(result.sections).toHaveLength(2);
+    expect(result.sections[0].heading).toBe("## コミュニケーション");
+    expect(result.sections[0].tokens).toBeGreaterThan(0);
+    expect(result.sections[1].heading).toBe("## レビュー");
+  });
+
+  it("totalTokens がすべてのセクションのトークン数の合計になる", async () => {
+    const client = createMockClient();
+    const migrator = new AgentsMigrator({
+      pineconeClient: client,
+      agentId: "mel",
+      dryRun: true,
+    });
+
+    const file = path.join(tmpDir, "AGENTS.md");
+    fs.writeFileSync(file, "## セクション A\n内容 A\n\n## セクション B\n内容 B", "utf-8");
+
+    const result = await migrator.migrate(file);
+
+    const sumTokens = result.sections.reduce((sum, s) => sum + s.tokens, 0);
+    expect(result.totalTokens).toBe(sumTokens);
+  });
+});

--- a/packages/migrate-memory/src/migrate-agents.ts
+++ b/packages/migrate-memory/src/migrate-agents.ts
@@ -1,0 +1,121 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import type { IPineconeClient, MemoryChunk } from "@easy-flow/pinecone-client";
+
+export interface ParsedSection {
+  heading: string;
+  text: string;
+}
+
+export interface AgentsMigrateResult {
+  chunks: number;
+  totalTokens: number;
+  upsertedChunks: number;
+  sections: { heading: string; tokens: number }[];
+}
+
+export function estimateTokens(text: string): number {
+  return Math.ceil(text.length / 3);
+}
+
+export function parseMarkdownSections(text: string): ParsedSection[] {
+  const lines = text.split("\n");
+  const sections: ParsedSection[] = [];
+  let currentHeading = "";
+  let currentLines: string[] = [];
+
+  for (const line of lines) {
+    if (/^#{2,3}\s/.test(line)) {
+      if (currentHeading || currentLines.length > 0) {
+        const body = currentLines.join("\n").trim();
+        if (currentHeading || body) {
+          sections.push({
+            heading: currentHeading,
+            text: currentHeading ? `${currentHeading}\n\n${body}`.trim() : body,
+          });
+        }
+      }
+      currentHeading = line;
+      currentLines = [];
+    } else {
+      currentLines.push(line);
+    }
+  }
+
+  if (currentHeading || currentLines.length > 0) {
+    const body = currentLines.join("\n").trim();
+    if (currentHeading || body) {
+      sections.push({
+        heading: currentHeading,
+        text: currentHeading ? `${currentHeading}\n\n${body}`.trim() : body,
+      });
+    }
+  }
+
+  return sections;
+}
+
+export class AgentsMigrator {
+  private readonly client: IPineconeClient;
+  private readonly agentId: string;
+  private readonly dryRun: boolean;
+
+  constructor(params: {
+    pineconeClient: IPineconeClient;
+    agentId: string;
+    dryRun?: boolean;
+  }) {
+    this.client = params.pineconeClient;
+    this.agentId = params.agentId;
+    this.dryRun = params.dryRun ?? false;
+  }
+
+  async migrate(filePath: string): Promise<AgentsMigrateResult> {
+    const content = await readFile(filePath, "utf-8");
+
+    if (!content.trim()) {
+      return { chunks: 0, totalTokens: 0, upsertedChunks: 0, sections: [] };
+    }
+
+    const sections = parseMarkdownSections(content);
+
+    if (sections.length === 0) {
+      return { chunks: 0, totalTokens: 0, upsertedChunks: 0, sections: [] };
+    }
+
+    const sourceFile = path.basename(filePath);
+    const now = Date.now();
+
+    const chunks: MemoryChunk[] = sections.map((section, index) => ({
+      id: `${this.agentId}:${sourceFile}:${index}`,
+      text: section.text,
+      metadata: {
+        agentId: this.agentId,
+        sourceFile,
+        sourceType: "agents_rule" as const,
+        chunkIndex: index,
+        createdAt: now,
+      },
+    }));
+
+    const sectionSummaries = sections.map((s) => ({
+      heading: s.heading || "(preamble)",
+      tokens: estimateTokens(s.text),
+    }));
+
+    const totalTokens = sectionSummaries.reduce((sum, s) => sum + s.tokens, 0);
+
+    let upsertedChunks = 0;
+    if (!this.dryRun && chunks.length > 0) {
+      await this.client.upsert(chunks);
+      upsertedChunks = chunks.length;
+    }
+
+    return {
+      chunks: chunks.length,
+      totalTokens,
+      upsertedChunks,
+      sections: sectionSummaries,
+    };
+  }
+}

--- a/packages/migrate-memory/src/migrate-agents.ts
+++ b/packages/migrate-memory/src/migrate-agents.ts
@@ -14,8 +14,34 @@ export interface AgentsMigrateResult {
   sections: { heading: string; tokens: number }[];
 }
 
+/**
+ * Estimate token count from text.
+ *
+ * Based on Claude tokenizer empirical data:
+ * - ASCII (U+0000–U+007F): ~4 chars/token → 0.25 tokens/char
+ * - Japanese/CJK: ~1–2 tokens/char → 1.5 tokens/char (avg)
+ * - Fullwidth/Halfwidth forms: ~1 token/char
+ * - Other non-ASCII: ~1 token/char
+ */
 export function estimateTokens(text: string): number {
-  return Math.ceil(text.length / 3);
+  let tokens = 0;
+  for (const char of text) {
+    const code = char.codePointAt(0)!;
+    if (code <= 0x7f) {
+      tokens += 0.25;
+    } else if (
+      (code >= 0x3000 && code <= 0x9fff) ||
+      (code >= 0xf900 && code <= 0xfaff) ||
+      (code >= 0xac00 && code <= 0xd7af)
+    ) {
+      tokens += 1.5;
+    } else if (code >= 0xff00 && code <= 0xffef) {
+      tokens += 1.0;
+    } else {
+      tokens += 1.0;
+    }
+  }
+  return Math.ceil(tokens);
 }
 
 export function parseMarkdownSections(text: string): ParsedSection[] {
@@ -107,6 +133,7 @@ export class AgentsMigrator {
 
     let upsertedChunks = 0;
     if (!this.dryRun && chunks.length > 0) {
+      await this.client.deleteBySource(this.agentId, sourceFile);
       await this.client.upsert(chunks);
       upsertedChunks = chunks.length;
     }

--- a/packages/pinecone-client/src/types.ts
+++ b/packages/pinecone-client/src/types.ts
@@ -8,7 +8,7 @@ export interface MemoryChunk {
 export interface ChunkMetadata {
   agentId: string;
   sourceFile: string;
-  sourceType: "memory_file" | "session_turn" | "workflow_state";
+  sourceType: "memory_file" | "session_turn" | "workflow_state" | "agents_rule";
   chunkIndex: number;
   createdAt: number;
   turnId?: string;


### PR DESCRIPTION
## Summary

Issue: #134

AGENTS.md を Markdown セクション（`##` / `###`）単位でチャンク分割し、Pinecone にアップサートする CLI サブコマンドを `migrate-memory` パッケージに追加。

### 変更内容

- **`packages/migrate-memory/src/migrate-agents.ts`** (新規)
  - `parseMarkdownSections()`: `##` / `###` を境界としたセクション分割。`####` 以下は親セクションに含有
  - `AgentsMigrator` クラス: sourceType `"agents_rule"` でメタデータ付与、Pinecone upsert
  - 再移行時は `deleteBySource` で既存チャンクを削除してから upsert（完全置き換え）
  - `estimateTokens()`: Claude トークナイザー実測値ベースのトークン数推定

- **`packages/migrate-memory/src/cli.ts`**
  - `agents` サブコマンド追加（`--file`, `--agent-id`, `--dry-run` オプション）
  - dry-run 時はチャンク分割結果を表示、通常時は Pinecone に投入

- **`packages/pinecone-client/src/types.ts`**
  - `ChunkMetadata.sourceType` に `"agents_rule"` を追加

- **`packages/migrate-memory/src/migrate-agents.test.ts`** (新規)
  - チャンク分割ロジック、メタデータ付与、dry-run、deleteBySource 呼び出し順序、エッジケース

### 使用法

```bash
# ドライラン
npx easy-flow agents --file ./AGENTS.md --agent-id mel --dry-run

# 実行
npx easy-flow agents --file ./AGENTS.md --agent-id mel
```

## AI レビュースキップ理由

### `estimateTokens` の重複実装について

`estimateTokens` を `@easy-flow/pinecone-client` に共通化する修正案は、`pinecone-client`（新規ユーティリティ追加 + export）、`pinecone-context-engine`（import 元変更）、`migrate-memory` の 3 パッケージにまたがるリファクタリングとなる。本 PR のスコープ（Task 1.1: `migrate-memory` パッケージへの `agents` サブコマンド追加）を超えるため、別途リファクタリング PR で対応する。

なお、初回 AI レビューで「ロジックのコピーが現実的」と推奨されたため、`pinecone-context-engine/src/token-estimator.ts` と同一ロジックをインライン複製している。

## Test plan

- [x] `parseMarkdownSections` が `##` / `###` で正しく分割すること
- [x] `####` 以下が親セクションに含まれること
- [x] プリアンブル（最初の `##` より前のテキスト）が別チャンクになること
- [x] メタデータに `sourceType: "agents_rule"`, `agentId`, `createdAt` が設定されること
- [x] dry-run で Pinecone API が呼ばれないこと（`deleteBySource` も含む）
- [x] 通常モードで `deleteBySource` → `upsert` の順で実行されること
- [x] 空ファイル、空白のみ、見出しなしのエッジケース
- [x] `npm test` 全件パス
- [x] `npm run lint` クリーン