### PR TITLE
feat: 全インスタンスに memoryHint パラメータを設定

### DIFF
--- a/easy-flow-instances.json
+++ b/easy-flow-instances.json
@@ -68,7 +68,7 @@
         "**/mail-rules.md",
         "**/node_modules/**"
       ],
-      "memoryHint": "AI agent for BUZZ. MEMORY.md + memory/ (1 file only)."
+      "memoryHint": "AI agent for BUZZ (バズ)."
     },
     {
       "name": "umito-openclaw",
@@ -83,7 +83,7 @@
         "**/spec/**",
         "**/node_modules/**"
       ],
-      "memoryHint": "AI agent for UMITO (WithSea). PAT in MEMORY.md has been REDACTED on 2026-03-15."
+      "memoryHint": "AI agent for UMITO/WithSea (ウミト)."
     },
     {
       "name": "estack-soumu-openclaw",
@@ -100,6 +100,149 @@
         "**/downloads/**"
       ],
       "memoryHint": "AI agent for eSTACK SOUMU (accounting/payroll). KOT->freee journal automation."
+    },
+    {
+      "name": "baniyan-tsuri-agent",
+      "flyApp": "baniyan-tsuri-agent",
+      "agentId": "baniyan-tsuri",
+      "index": "easy-flow-memory",
+      "sources": [
+        "/data/workspace/"
+      ],
+      "excludePatterns": [
+        "**/node_modules/**"
+      ],
+      "memoryHint": "AI agent for バニヤンパートナーズ (baniyan-partners). DX 支援・OEM パートナー。"
+    },
+    {
+      "name": "dev-and-test-agent",
+      "flyApp": "dev-and-test-agent",
+      "agentId": "dev-and-test",
+      "index": "easy-flow-memory",
+      "sources": [
+        "/data/workspace/"
+      ],
+      "excludePatterns": [
+        "**/node_modules/**"
+      ],
+      "memoryHint": "Easy Flow 開発・テスト用エージェント。eSTACK 社内利用。"
+    },
+    {
+      "name": "free-standrd-core-agent",
+      "flyApp": "free-standrd-core-agent",
+      "agentId": "free-standrd-core",
+      "index": "easy-flow-memory",
+      "sources": [
+        "/data/workspace/"
+      ],
+      "excludePatterns": [
+        "**/node_modules/**"
+      ],
+      "memoryHint": "AI agent for Free Standard (フリースタンダード). リコマース事業のチームディスカッション支援。"
+    },
+    {
+      "name": "fs-harimoto-agent",
+      "flyApp": "fs-harimoto-agent",
+      "agentId": "fs-harimoto",
+      "index": "easy-flow-memory",
+      "sources": [
+        "/data/workspace/"
+      ],
+      "excludePatterns": [
+        "**/node_modules/**"
+      ],
+      "memoryHint": "AI agent for Free Standard (フリースタンダード). 張本氏の経営参謀エージェント。"
+    },
+    {
+      "name": "hongmong-ochi-agent",
+      "flyApp": "hongmong-ochi-agent",
+      "agentId": "hongmong-ochi",
+      "index": "easy-flow-memory",
+      "sources": [
+        "/data/workspace/"
+      ],
+      "excludePatterns": [
+        "**/node_modules/**"
+      ],
+      "memoryHint": "AI agent for 越智氏. 経営参謀エージェント。"
+    },
+    {
+      "name": "hub-spoke-agent",
+      "flyApp": "hub-spoke-agent",
+      "agentId": "hub-spoke",
+      "index": "easy-flow-memory",
+      "sources": [
+        "/data/workspace/"
+      ],
+      "excludePatterns": [
+        "**/node_modules/**"
+      ],
+      "memoryHint": "AI agent for ハブアンドスポーク (hub-spoke.jp). 遠藤氏の経営参謀エージェント。"
+    },
+    {
+      "name": "mofumofu-agent",
+      "flyApp": "mofumofu-agent",
+      "agentId": "mofumofu",
+      "index": "easy-flow-memory",
+      "sources": [
+        "/data/workspace/"
+      ],
+      "excludePatterns": [
+        "**/node_modules/**"
+      ],
+      "memoryHint": "AI agent for もふもふ不動産. YouTube 配信向けパワーポイント作成支援。"
+    },
+    {
+      "name": "namiki-ai-test-agent",
+      "flyApp": "namiki-ai-test-agent",
+      "agentId": "namiki-ai-test",
+      "index": "easy-flow-memory",
+      "sources": [
+        "/data/workspace/"
+      ],
+      "excludePatterns": [
+        "**/node_modules/**"
+      ],
+      "memoryHint": "Easy Flow テスト用エージェント。eSTACK 社内利用。"
+    },
+    {
+      "name": "techno-japan-koga-agent",
+      "flyApp": "techno-japan-koga-agent",
+      "agentId": "techno-japan-koga",
+      "index": "easy-flow-memory",
+      "sources": [
+        "/data/workspace/"
+      ],
+      "excludePatterns": [
+        "**/node_modules/**"
+      ],
+      "memoryHint": "AI agent for テクノジャパン (techno-japan.co.jp). 甲賀氏の経営参謀エージェント。"
+    },
+    {
+      "name": "voice-ai-agent-agent",
+      "flyApp": "voice-ai-agent-agent",
+      "agentId": "voice-ai-agent",
+      "index": "easy-flow-memory",
+      "sources": [
+        "/data/workspace/"
+      ],
+      "excludePatterns": [
+        "**/node_modules/**"
+      ],
+      "memoryHint": "AI agent for ヴォイス (voice-ai). PDF ファイル処理・UnitBase 連携。"
+    },
+    {
+      "name": "tom-openclaw",
+      "flyApp": "tom-openclaw",
+      "agentId": "tom",
+      "index": "easy-flow-memory",
+      "sources": [
+        "/data/workspace/"
+      ],
+      "excludePatterns": [
+        "**/node_modules/**"
+      ],
+      "memoryHint": "AI agent for TOM. eSTACK 社内利用。"
     }
   ],
   "compactAfterDays": 7


### PR DESCRIPTION
## Summary

- 未設定の 11 インスタンスに `memoryHint` フィールドを新規追加
- 既存 2 インスタンス（`buzz-openclaw`, `umito-openclaw`）の `memoryHint` から不要情報を削除し簡潔化
- 既存 4 インスタンスは変更なし

薄いクエリの Pinecone 検索 recall 向上が目的。

Ref: estack-inc/easy-flow#185

## 変更内容

### 新規追加（11 インスタンス）
- `baniyan-tsuri-agent` — バニヤンパートナーズ
- `dev-and-test-agent` — 開発・テスト用
- `free-standrd-core-agent` — フリースタンダード
- `fs-harimoto-agent` — フリースタンダード（張本氏）
- `hongmong-ochi-agent` — 越智氏
- `hub-spoke-agent` — ハブアンドスポーク
- `mofumofu-agent` — もふもふ不動産
- `namiki-ai-test-agent` — テスト用
- `techno-japan-koga-agent` — テクノジャパン
- `voice-ai-agent-agent` — ヴォイス
- `tom-openclaw` — TOM

### 更新（2 インスタンス）
- `buzz-openclaw`: 不要な構成情報を削除
- `umito-openclaw`: REDACTED 情報を削除

## Test plan
- [x] `npm run lint` パス
- [x] `npm test` パス（`file-serve` の既存失敗は `mime-types` 欠如による main ブランチの既存問題）
- [x] JSON 構文が正しいことを確認
- [x] 既存インスタンスのフィールドが意図しない変更を含まないことを diff で確認