### PR TITLE
feat(context-engine): assemble() 動的検索強化 + AGENTS-CORE.md 固定注入

### DIFF
--- a/packages/openclaw-pinecone-plugin/src/index.test.ts
+++ b/packages/openclaw-pinecone-plugin/src/index.test.ts
@@ -214,4 +214,18 @@ describe("pinecone-memory plugin", () => {
       process.env.RAG_TOP_K = originalTopK;
     }
   });
+
+  it("logs mode: rag when ragEnabled is true via pluginConfig", () => {
+    const api = createMockApi({ apiKey: "test-key", agentId: "mell", ragEnabled: true });
+    register(api as any);
+
+    expect(api.logger.info).toHaveBeenCalledWith(expect.stringContaining("mode: rag"));
+
+    const factory = api.registerContextEngine.mock.calls[0][1];
+    factory();
+
+    expect(PineconeContextEngine).toHaveBeenCalledWith(
+      expect.objectContaining({ ragEnabled: true }),
+    );
+  });
 });

--- a/packages/openclaw-pinecone-plugin/src/index.test.ts
+++ b/packages/openclaw-pinecone-plugin/src/index.test.ts
@@ -97,7 +97,7 @@ describe("pinecone-memory plugin", () => {
     register(api as any);
 
     expect(api.logger.info).toHaveBeenCalledWith(expect.stringContaining("index: custom-index"));
-    expect(api.logger.info).toHaveBeenCalledWith(expect.stringContaining("compactAfterDays: 14"));
+    expect(api.logger.info).toHaveBeenCalledWith(expect.stringContaining("mode: classic"));
   });
 
   it("passes memoryHint and minQueryTokens to PineconeContextEngine", () => {
@@ -137,13 +137,16 @@ describe("pinecone-memory plugin", () => {
       apiKey: "test-key",
       indexName: "custom-index",
     });
-    expect(PineconeContextEngine).toHaveBeenCalledWith({
-      pineconeClient: expect.objectContaining({
-        _config: { apiKey: "test-key", indexName: "custom-index" },
+    expect(PineconeContextEngine).toHaveBeenCalledWith(
+      expect.objectContaining({
+        pineconeClient: expect.objectContaining({
+          _config: { apiKey: "test-key", indexName: "custom-index" },
+        }),
+        agentId: "mell",
+        compactAfterDays: 14,
+        ragEnabled: false,
       }),
-      agentId: "mell",
-      compactAfterDays: 14,
-    });
+    );
     expect(engine).toBeDefined();
   });
 });

--- a/packages/openclaw-pinecone-plugin/src/index.test.ts
+++ b/packages/openclaw-pinecone-plugin/src/index.test.ts
@@ -149,4 +149,32 @@ describe("pinecone-memory plugin", () => {
     );
     expect(engine).toBeDefined();
   });
+
+  it("ignores NaN from invalid env var values and falls back to undefined", () => {
+    const originalBudget = process.env.RAG_TOKEN_BUDGET;
+    const originalScore = process.env.RAG_MIN_SCORE;
+    const originalTopK = process.env.RAG_TOP_K;
+
+    process.env.RAG_TOKEN_BUDGET = "abc";
+    process.env.RAG_MIN_SCORE = "not-a-number";
+    process.env.RAG_TOP_K = "";
+
+    const api = createMockApi({ apiKey: "test-key", agentId: "mell" });
+    register(api as any);
+
+    const factory = api.registerContextEngine.mock.calls[0][1];
+    factory();
+
+    expect(PineconeContextEngine).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ragTokenBudget: undefined,
+        ragMinScore: undefined,
+        ragTopK: undefined,
+      }),
+    );
+
+    process.env.RAG_TOKEN_BUDGET = originalBudget;
+    process.env.RAG_MIN_SCORE = originalScore;
+    process.env.RAG_TOP_K = originalTopK;
+  });
 });

--- a/packages/openclaw-pinecone-plugin/src/index.test.ts
+++ b/packages/openclaw-pinecone-plugin/src/index.test.ts
@@ -191,7 +191,7 @@ describe("pinecone-memory plugin", () => {
     }
   });
 
-  it("rounds float RAG_TOP_K env var to integer", () => {
+  it("rounds float RAG_TOP_K env var to positive integer", () => {
     const originalTopK = process.env.RAG_TOP_K;
 
     process.env.RAG_TOP_K = "5.7";
@@ -207,6 +207,31 @@ describe("pinecone-memory plugin", () => {
         ragTopK: 6,
       }),
     );
+
+    if (originalTopK === undefined) {
+      delete process.env.RAG_TOP_K;
+    } else {
+      process.env.RAG_TOP_K = originalTopK;
+    }
+  });
+
+  it("rejects zero and negative RAG_TOP_K env var values", () => {
+    const originalTopK = process.env.RAG_TOP_K;
+
+    for (const val of ["0", "-5"]) {
+      process.env.RAG_TOP_K = val;
+      vi.mocked(PineconeContextEngine).mockClear();
+
+      const api = createMockApi({ apiKey: "test-key", agentId: "mell" });
+      register(api as any);
+
+      const factory = api.registerContextEngine.mock.calls[0][1];
+      factory();
+
+      expect(PineconeContextEngine).toHaveBeenCalledWith(
+        expect.objectContaining({ ragTopK: undefined }),
+      );
+    }
 
     if (originalTopK === undefined) {
       delete process.env.RAG_TOP_K;

--- a/packages/openclaw-pinecone-plugin/src/index.test.ts
+++ b/packages/openclaw-pinecone-plugin/src/index.test.ts
@@ -173,8 +173,20 @@ describe("pinecone-memory plugin", () => {
       }),
     );
 
-    process.env.RAG_TOKEN_BUDGET = originalBudget;
-    process.env.RAG_MIN_SCORE = originalScore;
-    process.env.RAG_TOP_K = originalTopK;
+    if (originalBudget === undefined) {
+      delete process.env.RAG_TOKEN_BUDGET;
+    } else {
+      process.env.RAG_TOKEN_BUDGET = originalBudget;
+    }
+    if (originalScore === undefined) {
+      delete process.env.RAG_MIN_SCORE;
+    } else {
+      process.env.RAG_MIN_SCORE = originalScore;
+    }
+    if (originalTopK === undefined) {
+      delete process.env.RAG_TOP_K;
+    } else {
+      process.env.RAG_TOP_K = originalTopK;
+    }
   });
 });

--- a/packages/openclaw-pinecone-plugin/src/index.test.ts
+++ b/packages/openclaw-pinecone-plugin/src/index.test.ts
@@ -240,6 +240,56 @@ describe("pinecone-memory plugin", () => {
     }
   });
 
+  it("rejects negative and out-of-range RAG_MIN_SCORE env var values", () => {
+    const originalScore = process.env.RAG_MIN_SCORE;
+
+    for (const val of ["-0.5", "1.5"]) {
+      process.env.RAG_MIN_SCORE = val;
+      vi.mocked(PineconeContextEngine).mockClear();
+
+      const api = createMockApi({ apiKey: "test-key", agentId: "mell" });
+      register(api as any);
+
+      const factory = api.registerContextEngine.mock.calls[0][1];
+      factory();
+
+      expect(PineconeContextEngine).toHaveBeenCalledWith(
+        expect.objectContaining({ ragMinScore: undefined }),
+      );
+    }
+
+    if (originalScore === undefined) {
+      delete process.env.RAG_MIN_SCORE;
+    } else {
+      process.env.RAG_MIN_SCORE = originalScore;
+    }
+  });
+
+  it("rejects zero and negative RAG_TOKEN_BUDGET env var values", () => {
+    const originalBudget = process.env.RAG_TOKEN_BUDGET;
+
+    for (const val of ["0", "-100"]) {
+      process.env.RAG_TOKEN_BUDGET = val;
+      vi.mocked(PineconeContextEngine).mockClear();
+
+      const api = createMockApi({ apiKey: "test-key", agentId: "mell" });
+      register(api as any);
+
+      const factory = api.registerContextEngine.mock.calls[0][1];
+      factory();
+
+      expect(PineconeContextEngine).toHaveBeenCalledWith(
+        expect.objectContaining({ ragTokenBudget: undefined }),
+      );
+    }
+
+    if (originalBudget === undefined) {
+      delete process.env.RAG_TOKEN_BUDGET;
+    } else {
+      process.env.RAG_TOKEN_BUDGET = originalBudget;
+    }
+  });
+
   it("logs mode: rag when ragEnabled is true via pluginConfig", () => {
     const api = createMockApi({ apiKey: "test-key", agentId: "mell", ragEnabled: true });
     register(api as any);

--- a/packages/openclaw-pinecone-plugin/src/index.test.ts
+++ b/packages/openclaw-pinecone-plugin/src/index.test.ts
@@ -87,7 +87,7 @@ describe("pinecone-memory plugin", () => {
     expect(api.logger.info).toHaveBeenCalledWith(expect.stringContaining("agentId: default"));
   });
 
-  it("uses custom indexName and logs mode: classic", () => {
+  it("uses custom indexName, compactAfterDays, and logs mode: classic", () => {
     const api = createMockApi({
       apiKey: "test-key",
       agentId: "mell",
@@ -98,6 +98,7 @@ describe("pinecone-memory plugin", () => {
 
     expect(api.logger.info).toHaveBeenCalledWith(expect.stringContaining("index: custom-index"));
     expect(api.logger.info).toHaveBeenCalledWith(expect.stringContaining("mode: classic"));
+    expect(api.logger.info).toHaveBeenCalledWith(expect.stringContaining("compactAfterDays: 14"));
   });
 
   it("passes memoryHint and minQueryTokens to PineconeContextEngine", () => {

--- a/packages/openclaw-pinecone-plugin/src/index.test.ts
+++ b/packages/openclaw-pinecone-plugin/src/index.test.ts
@@ -87,7 +87,7 @@ describe("pinecone-memory plugin", () => {
     expect(api.logger.info).toHaveBeenCalledWith(expect.stringContaining("agentId: default"));
   });
 
-  it("uses custom indexName and compactAfterDays", () => {
+  it("uses custom indexName and logs mode: classic", () => {
     const api = createMockApi({
       apiKey: "test-key",
       agentId: "mell",
@@ -183,6 +183,30 @@ describe("pinecone-memory plugin", () => {
     } else {
       process.env.RAG_MIN_SCORE = originalScore;
     }
+    if (originalTopK === undefined) {
+      delete process.env.RAG_TOP_K;
+    } else {
+      process.env.RAG_TOP_K = originalTopK;
+    }
+  });
+
+  it("rounds float RAG_TOP_K env var to integer", () => {
+    const originalTopK = process.env.RAG_TOP_K;
+
+    process.env.RAG_TOP_K = "5.7";
+
+    const api = createMockApi({ apiKey: "test-key", agentId: "mell" });
+    register(api as any);
+
+    const factory = api.registerContextEngine.mock.calls[0][1];
+    factory();
+
+    expect(PineconeContextEngine).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ragTopK: 6,
+      }),
+    );
+
     if (originalTopK === undefined) {
       delete process.env.RAG_TOP_K;
     } else {

--- a/packages/openclaw-pinecone-plugin/src/index.ts
+++ b/packages/openclaw-pinecone-plugin/src/index.ts
@@ -9,6 +9,11 @@ type PluginConfig = {
   compactAfterDays?: number;
   memoryHint?: string;
   minQueryTokens?: number;
+  ragEnabled?: boolean;
+  agentsCorePath?: string;
+  ragTokenBudget?: number;
+  ragMinScore?: number;
+  ragTopK?: number;
 };
 
 export default function register(api: OpenClawPluginApi): void {
@@ -24,6 +29,16 @@ export default function register(api: OpenClawPluginApi): void {
   const indexName = cfg.indexName ?? "easy-flow-memory";
   const compactAfterDays = cfg.compactAfterDays ?? 7;
 
+  const ragEnabled = cfg.ragEnabled ?? process.env.RAG_ENABLED === "true";
+  const agentsCorePath = cfg.agentsCorePath ?? process.env.RAG_AGENTS_CORE_PATH;
+  const ragTokenBudget =
+    cfg.ragTokenBudget ??
+    (process.env.RAG_TOKEN_BUDGET ? Number(process.env.RAG_TOKEN_BUDGET) : undefined);
+  const ragMinScore =
+    cfg.ragMinScore ?? (process.env.RAG_MIN_SCORE ? Number(process.env.RAG_MIN_SCORE) : undefined);
+  const ragTopK =
+    cfg.ragTopK ?? (process.env.RAG_TOP_K ? Number(process.env.RAG_TOP_K) : undefined);
+
   api.registerContextEngine("pinecone-memory", () => {
     const client = new PineconeClient({ apiKey, indexName });
     return new PineconeContextEngine({
@@ -32,10 +47,16 @@ export default function register(api: OpenClawPluginApi): void {
       compactAfterDays,
       memoryHint: cfg.memoryHint,
       minQueryTokens: cfg.minQueryTokens,
+      ragEnabled,
+      agentsCorePath,
+      ragTokenBudget,
+      ragMinScore,
+      ragTopK,
     });
   });
 
+  const mode = ragEnabled ? "rag" : "classic";
   api.logger.info(
-    `pinecone-memory: registered (agentId: ${agentId}, index: ${indexName}, compactAfterDays: ${compactAfterDays})`,
+    `pinecone-memory: registered (agentId: ${agentId}, index: ${indexName}, mode: ${mode})`,
   );
 }

--- a/packages/openclaw-pinecone-plugin/src/index.ts
+++ b/packages/openclaw-pinecone-plugin/src/index.ts
@@ -29,6 +29,12 @@ function parsePositiveInt(value: string | undefined): number | undefined {
   return rounded >= 1 ? rounded : undefined;
 }
 
+function parseScoreFloat(value: string | undefined): number | undefined {
+  const n = parseFiniteNumber(value);
+  if (n === undefined) return undefined;
+  return n >= 0 && n <= 1 ? n : undefined;
+}
+
 export default function register(api: OpenClawPluginApi): void {
   const cfg = (api.pluginConfig ?? {}) as PluginConfig;
 
@@ -44,8 +50,8 @@ export default function register(api: OpenClawPluginApi): void {
 
   const ragEnabled = cfg.ragEnabled ?? process.env.RAG_ENABLED === "true";
   const agentsCorePath = cfg.agentsCorePath ?? process.env.RAG_AGENTS_CORE_PATH;
-  const ragTokenBudget = cfg.ragTokenBudget ?? parseFiniteNumber(process.env.RAG_TOKEN_BUDGET);
-  const ragMinScore = cfg.ragMinScore ?? parseFiniteNumber(process.env.RAG_MIN_SCORE);
+  const ragTokenBudget = cfg.ragTokenBudget ?? parsePositiveInt(process.env.RAG_TOKEN_BUDGET);
+  const ragMinScore = cfg.ragMinScore ?? parseScoreFloat(process.env.RAG_MIN_SCORE);
   const ragTopK = cfg.ragTopK ?? parsePositiveInt(process.env.RAG_TOP_K);
 
   api.registerContextEngine("pinecone-memory", () => {

--- a/packages/openclaw-pinecone-plugin/src/index.ts
+++ b/packages/openclaw-pinecone-plugin/src/index.ts
@@ -22,6 +22,11 @@ function parseFiniteNumber(value: string | undefined): number | undefined {
   return Number.isFinite(n) ? n : undefined;
 }
 
+function parseFiniteInt(value: string | undefined): number | undefined {
+  const n = parseFiniteNumber(value);
+  return n !== undefined ? Math.round(n) : undefined;
+}
+
 export default function register(api: OpenClawPluginApi): void {
   const cfg = (api.pluginConfig ?? {}) as PluginConfig;
 
@@ -39,7 +44,7 @@ export default function register(api: OpenClawPluginApi): void {
   const agentsCorePath = cfg.agentsCorePath ?? process.env.RAG_AGENTS_CORE_PATH;
   const ragTokenBudget = cfg.ragTokenBudget ?? parseFiniteNumber(process.env.RAG_TOKEN_BUDGET);
   const ragMinScore = cfg.ragMinScore ?? parseFiniteNumber(process.env.RAG_MIN_SCORE);
-  const ragTopK = cfg.ragTopK ?? parseFiniteNumber(process.env.RAG_TOP_K);
+  const ragTopK = cfg.ragTopK ?? parseFiniteInt(process.env.RAG_TOP_K);
 
   api.registerContextEngine("pinecone-memory", () => {
     const client = new PineconeClient({ apiKey, indexName });

--- a/packages/openclaw-pinecone-plugin/src/index.ts
+++ b/packages/openclaw-pinecone-plugin/src/index.ts
@@ -17,7 +17,7 @@ type PluginConfig = {
 };
 
 function parseFiniteNumber(value: string | undefined): number | undefined {
-  if (value === undefined) return undefined;
+  if (value === undefined || value === "") return undefined;
   const n = Number(value);
   return Number.isFinite(n) ? n : undefined;
 }

--- a/packages/openclaw-pinecone-plugin/src/index.ts
+++ b/packages/openclaw-pinecone-plugin/src/index.ts
@@ -22,9 +22,11 @@ function parseFiniteNumber(value: string | undefined): number | undefined {
   return Number.isFinite(n) ? n : undefined;
 }
 
-function parseFiniteInt(value: string | undefined): number | undefined {
+function parsePositiveInt(value: string | undefined): number | undefined {
   const n = parseFiniteNumber(value);
-  return n !== undefined ? Math.round(n) : undefined;
+  if (n === undefined) return undefined;
+  const rounded = Math.round(n);
+  return rounded >= 1 ? rounded : undefined;
 }
 
 export default function register(api: OpenClawPluginApi): void {
@@ -44,7 +46,7 @@ export default function register(api: OpenClawPluginApi): void {
   const agentsCorePath = cfg.agentsCorePath ?? process.env.RAG_AGENTS_CORE_PATH;
   const ragTokenBudget = cfg.ragTokenBudget ?? parseFiniteNumber(process.env.RAG_TOKEN_BUDGET);
   const ragMinScore = cfg.ragMinScore ?? parseFiniteNumber(process.env.RAG_MIN_SCORE);
-  const ragTopK = cfg.ragTopK ?? parseFiniteInt(process.env.RAG_TOP_K);
+  const ragTopK = cfg.ragTopK ?? parsePositiveInt(process.env.RAG_TOP_K);
 
   api.registerContextEngine("pinecone-memory", () => {
     const client = new PineconeClient({ apiKey, indexName });

--- a/packages/openclaw-pinecone-plugin/src/index.ts
+++ b/packages/openclaw-pinecone-plugin/src/index.ts
@@ -64,6 +64,6 @@ export default function register(api: OpenClawPluginApi): void {
 
   const mode = ragEnabled ? "rag" : "classic";
   api.logger.info(
-    `pinecone-memory: registered (agentId: ${agentId}, index: ${indexName}, mode: ${mode})`,
+    `pinecone-memory: registered (agentId: ${agentId}, index: ${indexName}, mode: ${mode}, compactAfterDays: ${compactAfterDays})`,
   );
 }

--- a/packages/openclaw-pinecone-plugin/src/index.ts
+++ b/packages/openclaw-pinecone-plugin/src/index.ts
@@ -16,6 +16,12 @@ type PluginConfig = {
   ragTopK?: number;
 };
 
+function parseFiniteNumber(value: string | undefined): number | undefined {
+  if (value === undefined) return undefined;
+  const n = Number(value);
+  return Number.isFinite(n) ? n : undefined;
+}
+
 export default function register(api: OpenClawPluginApi): void {
   const cfg = (api.pluginConfig ?? {}) as PluginConfig;
 
@@ -31,13 +37,9 @@ export default function register(api: OpenClawPluginApi): void {
 
   const ragEnabled = cfg.ragEnabled ?? process.env.RAG_ENABLED === "true";
   const agentsCorePath = cfg.agentsCorePath ?? process.env.RAG_AGENTS_CORE_PATH;
-  const ragTokenBudget =
-    cfg.ragTokenBudget ??
-    (process.env.RAG_TOKEN_BUDGET ? Number(process.env.RAG_TOKEN_BUDGET) : undefined);
-  const ragMinScore =
-    cfg.ragMinScore ?? (process.env.RAG_MIN_SCORE ? Number(process.env.RAG_MIN_SCORE) : undefined);
-  const ragTopK =
-    cfg.ragTopK ?? (process.env.RAG_TOP_K ? Number(process.env.RAG_TOP_K) : undefined);
+  const ragTokenBudget = cfg.ragTokenBudget ?? parseFiniteNumber(process.env.RAG_TOKEN_BUDGET);
+  const ragMinScore = cfg.ragMinScore ?? parseFiniteNumber(process.env.RAG_MIN_SCORE);
+  const ragTopK = cfg.ragTopK ?? parseFiniteNumber(process.env.RAG_TOP_K);
 
   api.registerContextEngine("pinecone-memory", () => {
     const client = new PineconeClient({ apiKey, indexName });

--- a/packages/pinecone-context-engine/src/index.ts
+++ b/packages/pinecone-context-engine/src/index.ts
@@ -4,6 +4,8 @@ export {
 } from "./fallback-adapter.js";
 export { PineconeContextEngine } from "./pinecone-context-engine.js";
 export { PineconeContextEngineParallel } from "./pinecone-context-engine-parallel.js";
+export type { RankedChunk } from "./reranker.js";
+export { rerankChunks } from "./reranker.js";
 export { estimateTokens } from "./token-estimator.js";
 export type {
   IPineconeClient,

--- a/packages/pinecone-context-engine/src/pinecone-context-engine-parallel.test.ts
+++ b/packages/pinecone-context-engine/src/pinecone-context-engine-parallel.test.ts
@@ -185,4 +185,41 @@ describe("PineconeContextEngineParallel", () => {
       expect(result.compacted).toBe(false);
     });
   });
+
+  describe("ragEnabled warning", () => {
+    it("warns when ragEnabled=true is passed", () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      new PineconeContextEngineParallel({
+        pineconeClient: mockPineconeClient,
+        agentId: "test-agent",
+        ragEnabled: true,
+      });
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("ragEnabled=true は Parallel 実装では未サポート"),
+      );
+
+      warnSpy.mockRestore();
+    });
+
+    it("does not warn when ragEnabled is false or omitted", () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      new PineconeContextEngineParallel({
+        pineconeClient: mockPineconeClient,
+        agentId: "test-agent",
+        ragEnabled: false,
+      });
+
+      new PineconeContextEngineParallel({
+        pineconeClient: mockPineconeClient,
+        agentId: "test-agent",
+      });
+
+      expect(warnSpy).not.toHaveBeenCalled();
+
+      warnSpy.mockRestore();
+    });
+  });
 });

--- a/packages/pinecone-context-engine/src/pinecone-context-engine-parallel.ts
+++ b/packages/pinecone-context-engine/src/pinecone-context-engine-parallel.ts
@@ -64,6 +64,11 @@ export class PineconeContextEngineParallel implements ContextEngine {
   private readonly minQueryTokens: number;
 
   constructor(params: PineconeContextEngineParams) {
+    if (params.ragEnabled) {
+      console.warn(
+        "[PineconeContextEngineParallel] ragEnabled=true は Parallel 実装では未サポートです。PineconeContextEngine を使用してください。",
+      );
+    }
     this.client = params.pineconeClient;
     this.agentId = params.agentId;
     this.tokenBudget = params.tokenBudget ?? DEFAULT_TOKEN_BUDGET;

--- a/packages/pinecone-context-engine/src/pinecone-context-engine.ts
+++ b/packages/pinecone-context-engine/src/pinecone-context-engine.ts
@@ -11,21 +11,28 @@ import type {
   IngestResult,
 } from "openclaw/plugin-sdk";
 import { EmptyFallbackContextEngine, FallbackContextEngine } from "./fallback-adapter.js";
+import { rerankChunks } from "./reranker.js";
 import {
   ASSEMBLE_TIMEOUT_MS,
   buildEnrichedQuery,
   buildQueryFromRecentTurns,
+  buildRagSystemPromptAddition,
   buildSystemPromptAddition,
   DEFAULT_COMPACT_AFTER_DAYS,
   DEFAULT_INGEST_ROLES,
   DEFAULT_MIN_QUERY_TOKENS,
   DEFAULT_MIN_SCORE,
+  DEFAULT_RAG_MIN_SCORE,
+  DEFAULT_RAG_TOKEN_BUDGET,
+  DEFAULT_RAG_TOP_K,
   DEFAULT_SKIP_PATTERNS,
   DEFAULT_TOKEN_BUDGET,
   DEFAULT_TOP_K,
+  readAgentsCore,
   readOldTurns,
   withRetry,
 } from "./shared.js";
+import { estimateTokens } from "./token-estimator.js";
 import type { PineconeContextEngineParams } from "./types.js";
 
 // Re-export for backward compatibility
@@ -49,6 +56,11 @@ export class PineconeContextEngine implements ContextEngine {
   private readonly defaultCategory: string;
   private readonly memoryHint?: string;
   private readonly minQueryTokens: number;
+  private readonly ragEnabled: boolean;
+  private readonly agentsCorePath?: string;
+  private readonly ragTokenBudget: number;
+  private readonly ragMinScore: number;
+  private readonly ragTopK: number;
 
   constructor(params: PineconeContextEngineParams) {
     this.client = params.pineconeClient;
@@ -64,6 +76,11 @@ export class PineconeContextEngine implements ContextEngine {
     this.defaultCategory = params.defaultCategory ?? "conversation";
     this.memoryHint = params.memoryHint;
     this.minQueryTokens = params.minQueryTokens ?? DEFAULT_MIN_QUERY_TOKENS;
+    this.ragEnabled = params.ragEnabled ?? false;
+    this.agentsCorePath = params.agentsCorePath;
+    this.ragTokenBudget = params.ragTokenBudget ?? DEFAULT_RAG_TOKEN_BUDGET;
+    this.ragMinScore = params.ragMinScore ?? DEFAULT_RAG_MIN_SCORE;
+    this.ragTopK = params.ragTopK ?? DEFAULT_RAG_TOP_K;
   }
 
   async bootstrap(_params: { sessionId: string; sessionFile: string }): Promise<BootstrapResult> {
@@ -140,6 +157,17 @@ export class PineconeContextEngine implements ContextEngine {
     messages: AgentMessage[];
     tokenBudget?: number;
   }): Promise<AssembleResult> {
+    if (this.ragEnabled) {
+      return this.assembleRag(params);
+    }
+    return this.assembleClassic(params);
+  }
+
+  private async assembleClassic(params: {
+    sessionId: string;
+    messages: AgentMessage[];
+    tokenBudget?: number;
+  }): Promise<AssembleResult> {
     try {
       const baseQuery = buildQueryFromRecentTurns(params.messages);
 
@@ -185,6 +213,143 @@ export class PineconeContextEngine implements ContextEngine {
       console.error("[PineconeContextEngine] assemble failed, using fallback:", err);
       return this.fallback.assemble(params);
     }
+  }
+
+  private async assembleRag(params: {
+    sessionId: string;
+    messages: AgentMessage[];
+    tokenBudget?: number;
+  }): Promise<AssembleResult> {
+    const startTime = Date.now();
+
+    // 1. AGENTS-CORE.md を読み込み
+    let agentsCoreText = "";
+    if (this.agentsCorePath) {
+      agentsCoreText = await readAgentsCore(this.agentsCorePath);
+      if (!agentsCoreText) {
+        console.warn(`[pinecone-context-engine] AGENTS-CORE.md not found: ${this.agentsCorePath}`);
+      }
+    }
+
+    // 2. 検索クエリを生成
+    const baseQuery = buildQueryFromRecentTurns(params.messages);
+    const queryTokens = baseQuery ? estimateTokens(baseQuery) : 0;
+
+    if (!baseQuery) {
+      // クエリなし → AGENTS-CORE.md のみ返却
+      if (agentsCoreText) {
+        const coreTokens = estimateTokens(agentsCoreText);
+        console.info(
+          `[pinecone-context-engine] mode=rag query_tokens=0 ns=agent:${this.agentId} topK=0 results=0 latency=${Date.now() - startTime}ms`,
+        );
+        console.info(
+          `[pinecone-context-engine] merged: core_tokens=${coreTokens} dynamic_tokens=0 total=${coreTokens} budget=${this.ragTokenBudget}`,
+        );
+        return {
+          messages: params.messages,
+          estimatedTokens: coreTokens,
+          systemPromptAddition: agentsCoreText,
+        };
+      }
+      return { messages: params.messages, estimatedTokens: 0 };
+    }
+
+    const queryText = this.enrichQuery(baseQuery);
+
+    // 3. Pinecone セマンティック検索
+    let results: Awaited<ReturnType<IPineconeClient["query"]>> = [];
+    try {
+      results = await Promise.race([
+        withRetry(() =>
+          this.client.query({
+            text: queryText,
+            agentId: this.agentId,
+            topK: this.ragTopK,
+            minScore: this.ragMinScore,
+          }),
+        ),
+        new Promise<never>((_, reject) =>
+          setTimeout(() => reject(new Error("assemble timeout")), ASSEMBLE_TIMEOUT_MS),
+        ),
+      ]);
+    } catch (err) {
+      // Pinecone 接続不可 → AGENTS-CORE.md のみで動作
+      console.warn("[pinecone-context-engine] Pinecone query failed in RAG mode:", err);
+      if (agentsCoreText) {
+        const coreTokens = estimateTokens(agentsCoreText);
+        return {
+          messages: params.messages,
+          estimatedTokens: coreTokens,
+          systemPromptAddition: agentsCoreText,
+        };
+      }
+      return this.fallback.assemble(params);
+    }
+
+    const latency = Date.now() - startTime;
+
+    if (results.length === 0) {
+      console.info(
+        `[pinecone-context-engine] mode=rag query_tokens=${queryTokens} ns=agent:${this.agentId} topK=${this.ragTopK} results=0 latency=${latency}ms`,
+      );
+      // 検索結果 0 件 → AGENTS-CORE.md のみ
+      if (agentsCoreText) {
+        const coreTokens = estimateTokens(agentsCoreText);
+        console.info(
+          `[pinecone-context-engine] merged: core_tokens=${coreTokens} dynamic_tokens=0 total=${coreTokens} budget=${this.ragTokenBudget}`,
+        );
+        return {
+          messages: params.messages,
+          estimatedTokens: coreTokens,
+          systemPromptAddition: agentsCoreText,
+        };
+      }
+      return { messages: params.messages, estimatedTokens: 0 };
+    }
+
+    // 4. re-ranking
+    const chunksForRerank = results.map((r) => ({
+      id: r.chunk.id,
+      text: r.chunk.text,
+      score: r.score,
+      metadata: r.chunk.metadata,
+    }));
+    const ranked = rerankChunks(chunksForRerank);
+    const dropped = chunksForRerank.length - ranked.length;
+
+    // rerank ログ: sourceType 別カウント
+    const typeCounts: Record<string, number> = {};
+    for (const chunk of ranked) {
+      const st = chunk.metadata.sourceType;
+      typeCounts[st] = (typeCounts[st] ?? 0) + 1;
+    }
+    console.info(
+      `[pinecone-context-engine] mode=rag query_tokens=${queryTokens} ns=agent:${this.agentId} topK=${this.ragTopK} results=${results.length} latency=${latency}ms`,
+    );
+    console.info(
+      `[pinecone-context-engine] rerank: ${Object.entries(typeCounts)
+        .map(([k, v]) => `${k}=${v}`)
+        .join(" ")} dropped=${dropped}`,
+    );
+
+    // 5. トークン予算内でマージ
+    const dynamicBudget = params.tokenBudget ?? this.ragTokenBudget;
+    const { markdown, coreTokens, dynamicTokens } = buildRagSystemPromptAddition(
+      agentsCoreText,
+      ranked,
+      dynamicBudget,
+    );
+    const totalTokens = coreTokens + dynamicTokens;
+
+    console.info(
+      `[pinecone-context-engine] merged: core_tokens=${coreTokens} dynamic_tokens=${dynamicTokens} total=${totalTokens} budget=${dynamicBudget}`,
+    );
+
+    return {
+      messages: params.messages,
+      estimatedTokens: totalTokens,
+      systemPromptAddition: markdown || undefined,
+    };
   }
 
   async compact(params: {

--- a/packages/pinecone-context-engine/src/pinecone-context-engine.ts
+++ b/packages/pinecone-context-engine/src/pinecone-context-engine.ts
@@ -342,6 +342,7 @@ export class PineconeContextEngine implements ContextEngine {
         agentsCoreText,
         ranked,
         dynamicBudget,
+        coreTokensEstimate,
       );
       const totalTokens = coreTokens + dynamicTokens;
 

--- a/packages/pinecone-context-engine/src/pinecone-context-engine.ts
+++ b/packages/pinecone-context-engine/src/pinecone-context-engine.ts
@@ -333,7 +333,10 @@ export class PineconeContextEngine implements ContextEngine {
     );
 
     // 5. トークン予算内でマージ
-    const dynamicBudget = params.tokenBudget ?? this.ragTokenBudget;
+    // params.tokenBudget は総トークン上限。AGENTS-CORE.md 分を差し引いて動的チャンク予算を算出
+    const totalBudget = params.tokenBudget ?? this.ragTokenBudget;
+    const coreTokensEstimate = agentsCoreText ? estimateTokens(agentsCoreText) : 0;
+    const dynamicBudget = Math.max(0, totalBudget - coreTokensEstimate);
     const { markdown, coreTokens, dynamicTokens } = buildRagSystemPromptAddition(
       agentsCoreText,
       ranked,
@@ -342,7 +345,7 @@ export class PineconeContextEngine implements ContextEngine {
     const totalTokens = coreTokens + dynamicTokens;
 
     console.info(
-      `[pinecone-context-engine] merged: core_tokens=${coreTokens} dynamic_tokens=${dynamicTokens} total=${totalTokens} budget=${dynamicBudget}`,
+      `[pinecone-context-engine] merged: core_tokens=${coreTokens} dynamic_tokens=${dynamicTokens} total=${totalTokens} budget=${totalBudget}`,
     );
 
     return {

--- a/packages/pinecone-context-engine/src/pinecone-context-engine.ts
+++ b/packages/pinecone-context-engine/src/pinecone-context-engine.ts
@@ -237,6 +237,7 @@ export class PineconeContextEngine implements ContextEngine {
       // 2. 検索クエリを生成
       const baseQuery = buildQueryFromRecentTurns(params.messages);
       const queryTokens = baseQuery ? estimateTokens(baseQuery) : 0;
+      const totalBudget = params.tokenBudget ?? this.ragTokenBudget;
 
       if (!baseQuery) {
         // クエリなし → AGENTS-CORE.md のみ返却
@@ -246,7 +247,7 @@ export class PineconeContextEngine implements ContextEngine {
             `[pinecone-context-engine] mode=rag query_tokens=0 ns=agent:${this.agentId} topK=0 results=0 latency=${Date.now() - startTime}ms`,
           );
           console.info(
-            `[pinecone-context-engine] merged: core_tokens=${coreTokens} dynamic_tokens=0 total=${coreTokens} budget=${this.ragTokenBudget}`,
+            `[pinecone-context-engine] merged: core_tokens=${coreTokens} dynamic_tokens=0 total=${coreTokens} budget=${totalBudget}`,
           );
           return {
             messages: params.messages,
@@ -299,7 +300,7 @@ export class PineconeContextEngine implements ContextEngine {
         if (agentsCoreText) {
           const coreTokens = estimateTokens(agentsCoreText);
           console.info(
-            `[pinecone-context-engine] merged: core_tokens=${coreTokens} dynamic_tokens=0 total=${coreTokens} budget=${this.ragTokenBudget}`,
+            `[pinecone-context-engine] merged: core_tokens=${coreTokens} dynamic_tokens=0 total=${coreTokens} budget=${totalBudget}`,
           );
           return {
             messages: params.messages,
@@ -336,8 +337,7 @@ export class PineconeContextEngine implements ContextEngine {
       );
 
       // 5. トークン予算内でマージ
-      // params.tokenBudget は総トークン上限。AGENTS-CORE.md 分を差し引いて動的チャンク予算を算出
-      const totalBudget = params.tokenBudget ?? this.ragTokenBudget;
+      // totalBudget は総トークン上限。AGENTS-CORE.md 分を差し引いて動的チャンク予算を算出
       const coreTokensEstimate = agentsCoreText ? estimateTokens(agentsCoreText) : 0;
       const dynamicBudget = Math.max(0, totalBudget - coreTokensEstimate);
       const { markdown, coreTokens, dynamicTokens } = buildRagSystemPromptAddition(

--- a/packages/pinecone-context-engine/src/pinecone-context-engine.ts
+++ b/packages/pinecone-context-engine/src/pinecone-context-engine.ts
@@ -317,7 +317,7 @@ export class PineconeContextEngine implements ContextEngine {
         metadata: r.chunk.metadata,
       }));
       const ranked = rerankChunks(chunksForRerank);
-      const dropped = chunksForRerank.length - ranked.length;
+      const deduplicated = chunksForRerank.length - ranked.length;
 
       // rerank ログ: sourceType 別カウント
       const typeCounts: Record<string, number> = {};
@@ -331,7 +331,7 @@ export class PineconeContextEngine implements ContextEngine {
       console.info(
         `[PineconeContextEngine] rerank: ${Object.entries(typeCounts)
           .map(([k, v]) => `${k}=${v}`)
-          .join(" ")} dropped=${dropped}`,
+          .join(" ")} deduplicated=${deduplicated}`,
       );
 
       // 5. トークン予算内でマージ

--- a/packages/pinecone-context-engine/src/pinecone-context-engine.ts
+++ b/packages/pinecone-context-engine/src/pinecone-context-engine.ts
@@ -220,139 +220,146 @@ export class PineconeContextEngine implements ContextEngine {
     messages: AgentMessage[];
     tokenBudget?: number;
   }): Promise<AssembleResult> {
-    const startTime = Date.now();
-
-    // 1. AGENTS-CORE.md を読み込み
-    let agentsCoreText = "";
-    if (this.agentsCorePath) {
-      agentsCoreText = await readAgentsCore(this.agentsCorePath);
-      if (!agentsCoreText) {
-        console.warn(`[pinecone-context-engine] AGENTS-CORE.md not found: ${this.agentsCorePath}`);
-      }
-    }
-
-    // 2. 検索クエリを生成
-    const baseQuery = buildQueryFromRecentTurns(params.messages);
-    const queryTokens = baseQuery ? estimateTokens(baseQuery) : 0;
-
-    if (!baseQuery) {
-      // クエリなし → AGENTS-CORE.md のみ返却
-      if (agentsCoreText) {
-        const coreTokens = estimateTokens(agentsCoreText);
-        console.info(
-          `[pinecone-context-engine] mode=rag query_tokens=0 ns=agent:${this.agentId} topK=0 results=0 latency=${Date.now() - startTime}ms`,
-        );
-        console.info(
-          `[pinecone-context-engine] merged: core_tokens=${coreTokens} dynamic_tokens=0 total=${coreTokens} budget=${this.ragTokenBudget}`,
-        );
-        return {
-          messages: params.messages,
-          estimatedTokens: coreTokens,
-          systemPromptAddition: agentsCoreText,
-        };
-      }
-      return { messages: params.messages, estimatedTokens: 0 };
-    }
-
-    const queryText = this.enrichQuery(baseQuery);
-
-    // 3. Pinecone セマンティック検索
-    let results: Awaited<ReturnType<IPineconeClient["query"]>> = [];
     try {
-      results = await Promise.race([
-        withRetry(() =>
-          this.client.query({
-            text: queryText,
-            agentId: this.agentId,
-            topK: this.ragTopK,
-            minScore: this.ragMinScore,
-          }),
-        ),
-        new Promise<never>((_, reject) =>
-          setTimeout(() => reject(new Error("assemble timeout")), ASSEMBLE_TIMEOUT_MS),
-        ),
-      ]);
-    } catch (err) {
-      // Pinecone 接続不可 → AGENTS-CORE.md のみで動作
-      console.warn("[pinecone-context-engine] Pinecone query failed in RAG mode:", err);
-      if (agentsCoreText) {
-        const coreTokens = estimateTokens(agentsCoreText);
-        return {
-          messages: params.messages,
-          estimatedTokens: coreTokens,
-          systemPromptAddition: agentsCoreText,
-        };
+      const startTime = Date.now();
+
+      // 1. AGENTS-CORE.md を読み込み
+      let agentsCoreText = "";
+      if (this.agentsCorePath) {
+        agentsCoreText = await readAgentsCore(this.agentsCorePath);
+        if (!agentsCoreText) {
+          console.warn(
+            `[pinecone-context-engine] AGENTS-CORE.md not found: ${this.agentsCorePath}`,
+          );
+        }
       }
+
+      // 2. 検索クエリを生成
+      const baseQuery = buildQueryFromRecentTurns(params.messages);
+      const queryTokens = baseQuery ? estimateTokens(baseQuery) : 0;
+
+      if (!baseQuery) {
+        // クエリなし → AGENTS-CORE.md のみ返却
+        if (agentsCoreText) {
+          const coreTokens = estimateTokens(agentsCoreText);
+          console.info(
+            `[pinecone-context-engine] mode=rag query_tokens=0 ns=agent:${this.agentId} topK=0 results=0 latency=${Date.now() - startTime}ms`,
+          );
+          console.info(
+            `[pinecone-context-engine] merged: core_tokens=${coreTokens} dynamic_tokens=0 total=${coreTokens} budget=${this.ragTokenBudget}`,
+          );
+          return {
+            messages: params.messages,
+            estimatedTokens: coreTokens,
+            systemPromptAddition: agentsCoreText,
+          };
+        }
+        return { messages: params.messages, estimatedTokens: 0 };
+      }
+
+      const queryText = this.enrichQuery(baseQuery);
+
+      // 3. Pinecone セマンティック検索
+      let results: Awaited<ReturnType<IPineconeClient["query"]>> = [];
+      try {
+        results = await Promise.race([
+          withRetry(() =>
+            this.client.query({
+              text: queryText,
+              agentId: this.agentId,
+              topK: this.ragTopK,
+              minScore: this.ragMinScore,
+            }),
+          ),
+          new Promise<never>((_, reject) =>
+            setTimeout(() => reject(new Error("assemble timeout")), ASSEMBLE_TIMEOUT_MS),
+          ),
+        ]);
+      } catch (err) {
+        // Pinecone 接続不可 → AGENTS-CORE.md のみで動作
+        console.warn("[pinecone-context-engine] Pinecone query failed in RAG mode:", err);
+        if (agentsCoreText) {
+          const coreTokens = estimateTokens(agentsCoreText);
+          return {
+            messages: params.messages,
+            estimatedTokens: coreTokens,
+            systemPromptAddition: agentsCoreText,
+          };
+        }
+        return this.fallback.assemble(params);
+      }
+
+      const latency = Date.now() - startTime;
+
+      if (results.length === 0) {
+        console.info(
+          `[pinecone-context-engine] mode=rag query_tokens=${queryTokens} ns=agent:${this.agentId} topK=${this.ragTopK} results=0 latency=${latency}ms`,
+        );
+        // 検索結果 0 件 → AGENTS-CORE.md のみ
+        if (agentsCoreText) {
+          const coreTokens = estimateTokens(agentsCoreText);
+          console.info(
+            `[pinecone-context-engine] merged: core_tokens=${coreTokens} dynamic_tokens=0 total=${coreTokens} budget=${this.ragTokenBudget}`,
+          );
+          return {
+            messages: params.messages,
+            estimatedTokens: coreTokens,
+            systemPromptAddition: agentsCoreText,
+          };
+        }
+        return { messages: params.messages, estimatedTokens: 0 };
+      }
+
+      // 4. re-ranking
+      const chunksForRerank = results.map((r) => ({
+        id: r.chunk.id,
+        text: r.chunk.text,
+        score: r.score,
+        metadata: r.chunk.metadata,
+      }));
+      const ranked = rerankChunks(chunksForRerank);
+      const dropped = chunksForRerank.length - ranked.length;
+
+      // rerank ログ: sourceType 別カウント
+      const typeCounts: Record<string, number> = {};
+      for (const chunk of ranked) {
+        const st = chunk.metadata.sourceType;
+        typeCounts[st] = (typeCounts[st] ?? 0) + 1;
+      }
+      console.info(
+        `[pinecone-context-engine] mode=rag query_tokens=${queryTokens} ns=agent:${this.agentId} topK=${this.ragTopK} results=${results.length} latency=${latency}ms`,
+      );
+      console.info(
+        `[pinecone-context-engine] rerank: ${Object.entries(typeCounts)
+          .map(([k, v]) => `${k}=${v}`)
+          .join(" ")} dropped=${dropped}`,
+      );
+
+      // 5. トークン予算内でマージ
+      // params.tokenBudget は総トークン上限。AGENTS-CORE.md 分を差し引いて動的チャンク予算を算出
+      const totalBudget = params.tokenBudget ?? this.ragTokenBudget;
+      const coreTokensEstimate = agentsCoreText ? estimateTokens(agentsCoreText) : 0;
+      const dynamicBudget = Math.max(0, totalBudget - coreTokensEstimate);
+      const { markdown, coreTokens, dynamicTokens } = buildRagSystemPromptAddition(
+        agentsCoreText,
+        ranked,
+        dynamicBudget,
+      );
+      const totalTokens = coreTokens + dynamicTokens;
+
+      console.info(
+        `[pinecone-context-engine] merged: core_tokens=${coreTokens} dynamic_tokens=${dynamicTokens} total=${totalTokens} budget=${totalBudget}`,
+      );
+
+      return {
+        messages: params.messages,
+        estimatedTokens: totalTokens,
+        systemPromptAddition: markdown || undefined,
+      };
+    } catch (err) {
+      console.error("[PineconeContextEngine] assembleRag failed, using fallback:", err);
       return this.fallback.assemble(params);
     }
-
-    const latency = Date.now() - startTime;
-
-    if (results.length === 0) {
-      console.info(
-        `[pinecone-context-engine] mode=rag query_tokens=${queryTokens} ns=agent:${this.agentId} topK=${this.ragTopK} results=0 latency=${latency}ms`,
-      );
-      // 検索結果 0 件 → AGENTS-CORE.md のみ
-      if (agentsCoreText) {
-        const coreTokens = estimateTokens(agentsCoreText);
-        console.info(
-          `[pinecone-context-engine] merged: core_tokens=${coreTokens} dynamic_tokens=0 total=${coreTokens} budget=${this.ragTokenBudget}`,
-        );
-        return {
-          messages: params.messages,
-          estimatedTokens: coreTokens,
-          systemPromptAddition: agentsCoreText,
-        };
-      }
-      return { messages: params.messages, estimatedTokens: 0 };
-    }
-
-    // 4. re-ranking
-    const chunksForRerank = results.map((r) => ({
-      id: r.chunk.id,
-      text: r.chunk.text,
-      score: r.score,
-      metadata: r.chunk.metadata,
-    }));
-    const ranked = rerankChunks(chunksForRerank);
-    const dropped = chunksForRerank.length - ranked.length;
-
-    // rerank ログ: sourceType 別カウント
-    const typeCounts: Record<string, number> = {};
-    for (const chunk of ranked) {
-      const st = chunk.metadata.sourceType;
-      typeCounts[st] = (typeCounts[st] ?? 0) + 1;
-    }
-    console.info(
-      `[pinecone-context-engine] mode=rag query_tokens=${queryTokens} ns=agent:${this.agentId} topK=${this.ragTopK} results=${results.length} latency=${latency}ms`,
-    );
-    console.info(
-      `[pinecone-context-engine] rerank: ${Object.entries(typeCounts)
-        .map(([k, v]) => `${k}=${v}`)
-        .join(" ")} dropped=${dropped}`,
-    );
-
-    // 5. トークン予算内でマージ
-    // params.tokenBudget は総トークン上限。AGENTS-CORE.md 分を差し引いて動的チャンク予算を算出
-    const totalBudget = params.tokenBudget ?? this.ragTokenBudget;
-    const coreTokensEstimate = agentsCoreText ? estimateTokens(agentsCoreText) : 0;
-    const dynamicBudget = Math.max(0, totalBudget - coreTokensEstimate);
-    const { markdown, coreTokens, dynamicTokens } = buildRagSystemPromptAddition(
-      agentsCoreText,
-      ranked,
-      dynamicBudget,
-    );
-    const totalTokens = coreTokens + dynamicTokens;
-
-    console.info(
-      `[pinecone-context-engine] merged: core_tokens=${coreTokens} dynamic_tokens=${dynamicTokens} total=${totalTokens} budget=${totalBudget}`,
-    );
-
-    return {
-      messages: params.messages,
-      estimatedTokens: totalTokens,
-      systemPromptAddition: markdown || undefined,
-    };
   }
 
   async compact(params: {

--- a/packages/pinecone-context-engine/src/pinecone-context-engine.ts
+++ b/packages/pinecone-context-engine/src/pinecone-context-engine.ts
@@ -228,9 +228,7 @@ export class PineconeContextEngine implements ContextEngine {
       if (this.agentsCorePath) {
         agentsCoreText = await readAgentsCore(this.agentsCorePath);
         if (!agentsCoreText) {
-          console.warn(
-            `[pinecone-context-engine] AGENTS-CORE.md not found: ${this.agentsCorePath}`,
-          );
+          console.warn(`[PineconeContextEngine] AGENTS-CORE.md not found: ${this.agentsCorePath}`);
         }
       }
 
@@ -244,10 +242,10 @@ export class PineconeContextEngine implements ContextEngine {
         if (agentsCoreText) {
           const coreTokens = estimateTokens(agentsCoreText);
           console.info(
-            `[pinecone-context-engine] mode=rag query_tokens=0 ns=agent:${this.agentId} topK=0 results=0 latency=${Date.now() - startTime}ms`,
+            `[PineconeContextEngine] mode=rag query_tokens=0 ns=agent:${this.agentId} topK=0 results=0 latency=${Date.now() - startTime}ms`,
           );
           console.info(
-            `[pinecone-context-engine] merged: core_tokens=${coreTokens} dynamic_tokens=0 total=${coreTokens} budget=${totalBudget}`,
+            `[PineconeContextEngine] merged: core_tokens=${coreTokens} dynamic_tokens=0 total=${coreTokens} budget=${totalBudget}`,
           );
           return {
             messages: params.messages,
@@ -278,7 +276,7 @@ export class PineconeContextEngine implements ContextEngine {
         ]);
       } catch (err) {
         // Pinecone 接続不可 → AGENTS-CORE.md のみで動作
-        console.warn("[pinecone-context-engine] Pinecone query failed in RAG mode:", err);
+        console.warn("[PineconeContextEngine] Pinecone query failed in RAG mode:", err);
         if (agentsCoreText) {
           const coreTokens = estimateTokens(agentsCoreText);
           return {
@@ -294,13 +292,13 @@ export class PineconeContextEngine implements ContextEngine {
 
       if (results.length === 0) {
         console.info(
-          `[pinecone-context-engine] mode=rag query_tokens=${queryTokens} ns=agent:${this.agentId} topK=${this.ragTopK} results=0 latency=${latency}ms`,
+          `[PineconeContextEngine] mode=rag query_tokens=${queryTokens} ns=agent:${this.agentId} topK=${this.ragTopK} results=0 latency=${latency}ms`,
         );
         // 検索結果 0 件 → AGENTS-CORE.md のみ
         if (agentsCoreText) {
           const coreTokens = estimateTokens(agentsCoreText);
           console.info(
-            `[pinecone-context-engine] merged: core_tokens=${coreTokens} dynamic_tokens=0 total=${coreTokens} budget=${totalBudget}`,
+            `[PineconeContextEngine] merged: core_tokens=${coreTokens} dynamic_tokens=0 total=${coreTokens} budget=${totalBudget}`,
           );
           return {
             messages: params.messages,
@@ -328,10 +326,10 @@ export class PineconeContextEngine implements ContextEngine {
         typeCounts[st] = (typeCounts[st] ?? 0) + 1;
       }
       console.info(
-        `[pinecone-context-engine] mode=rag query_tokens=${queryTokens} ns=agent:${this.agentId} topK=${this.ragTopK} results=${results.length} latency=${latency}ms`,
+        `[PineconeContextEngine] mode=rag query_tokens=${queryTokens} ns=agent:${this.agentId} topK=${this.ragTopK} results=${results.length} latency=${latency}ms`,
       );
       console.info(
-        `[pinecone-context-engine] rerank: ${Object.entries(typeCounts)
+        `[PineconeContextEngine] rerank: ${Object.entries(typeCounts)
           .map(([k, v]) => `${k}=${v}`)
           .join(" ")} dropped=${dropped}`,
       );
@@ -348,7 +346,7 @@ export class PineconeContextEngine implements ContextEngine {
       const totalTokens = coreTokens + dynamicTokens;
 
       console.info(
-        `[pinecone-context-engine] merged: core_tokens=${coreTokens} dynamic_tokens=${dynamicTokens} total=${totalTokens} budget=${totalBudget}`,
+        `[PineconeContextEngine] merged: core_tokens=${coreTokens} dynamic_tokens=${dynamicTokens} total=${totalTokens} budget=${totalBudget}`,
       );
 
       return {

--- a/packages/pinecone-context-engine/src/rag-assemble.test.ts
+++ b/packages/pinecone-context-engine/src/rag-assemble.test.ts
@@ -1,0 +1,402 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { QueryResult } from "@easy-flow/pinecone-client";
+import { afterEach, beforeEach, describe, expect, it, type Mock, vi } from "vitest";
+import { PineconeContextEngine } from "./pinecone-context-engine.js";
+import type { IPineconeClient } from "./types.js";
+
+function createMockClient(
+  overrides?: Partial<IPineconeClient>,
+): IPineconeClient & { [K in keyof IPineconeClient]: Mock } {
+  return {
+    upsert: vi.fn().mockResolvedValue(undefined),
+    query: vi.fn().mockResolvedValue([]),
+    delete: vi.fn().mockResolvedValue(undefined),
+    deleteBySource: vi.fn().mockResolvedValue(undefined),
+    deleteNamespace: vi.fn().mockResolvedValue(undefined),
+    ensureIndex: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  } as IPineconeClient & { [K in keyof IPineconeClient]: Mock };
+}
+
+function makeQueryResult(
+  text: string,
+  score: number,
+  sourceType: "agents_rule" | "memory_file" | "session_turn" | "workflow_state" = "session_turn",
+  createdAt: number = Date.now(),
+): QueryResult {
+  return {
+    chunk: {
+      id: `chunk-${Math.random().toString(36).slice(2, 8)}`,
+      text,
+      metadata: {
+        agentId: "test-agent",
+        sourceFile: "test.md",
+        sourceType,
+        chunkIndex: 0,
+        createdAt,
+      },
+    },
+    score,
+  };
+}
+
+const AGENTS_CORE_CONTENT = "# AGENTS-CORE\n\nCore rules for the agent.";
+
+describe("PineconeContextEngine - RAG mode", () => {
+  let tmpDir: string;
+  let agentsCorePath: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "rag-test-"));
+    agentsCorePath = path.join(tmpDir, "AGENTS-CORE.md");
+    fs.writeFileSync(agentsCorePath, AGENTS_CORE_CONTENT);
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  describe("RAG_ENABLED=false (デフォルト)", () => {
+    it("従来の動作が変わらない — assembleClassic が使われる", async () => {
+      const client = createMockClient();
+      const results: QueryResult[] = [makeQueryResult("Previous conversation about testing", 0.85)];
+      client.query.mockResolvedValue(results);
+
+      const engine = new PineconeContextEngine({
+        pineconeClient: client,
+        agentId: "test-agent",
+        // ragEnabled は未設定（デフォルト false）
+      });
+
+      const result = await engine.assemble({
+        sessionId: "s1",
+        messages: [{ role: "user", content: "How do I write tests?" }],
+      });
+
+      expect(result.systemPromptAddition).toContain("Relevant Memory");
+      expect(result.systemPromptAddition).not.toContain("AGENTS-CORE");
+      expect(result.systemPromptAddition).not.toContain("Relevant Knowledge");
+    });
+
+    it("ragEnabled=false を明示しても従来の動作", async () => {
+      const client = createMockClient();
+      client.query.mockResolvedValue([]);
+
+      const engine = new PineconeContextEngine({
+        pineconeClient: client,
+        agentId: "test-agent",
+        ragEnabled: false,
+        agentsCorePath,
+      });
+
+      const result = await engine.assemble({
+        sessionId: "s1",
+        messages: [{ role: "user", content: "Hello" }],
+      });
+
+      expect(result.systemPromptAddition).toBeUndefined();
+      expect(result.estimatedTokens).toBe(0);
+    });
+  });
+
+  describe("RAG_ENABLED=true", () => {
+    it("AGENTS-CORE.md + 動的チャンクが systemPromptAddition に含まれる", async () => {
+      const client = createMockClient();
+      const results: QueryResult[] = [
+        makeQueryResult("Dynamic rule from Pinecone", 0.9, "agents_rule"),
+        makeQueryResult("Memory about user preferences", 0.85, "memory_file"),
+      ];
+      client.query.mockResolvedValue(results);
+
+      const engine = new PineconeContextEngine({
+        pineconeClient: client,
+        agentId: "test-agent",
+        ragEnabled: true,
+        agentsCorePath,
+      });
+
+      const result = await engine.assemble({
+        sessionId: "s1",
+        messages: [{ role: "user", content: "What are my preferences?" }],
+      });
+
+      expect(result.systemPromptAddition).toContain("AGENTS-CORE");
+      expect(result.systemPromptAddition).toContain("Core rules for the agent");
+      expect(result.systemPromptAddition).toContain("Relevant Knowledge");
+      expect(result.systemPromptAddition).toContain("Dynamic rule from Pinecone");
+      expect(result.systemPromptAddition).toContain("Memory about user preferences");
+      expect(result.estimatedTokens).toBeGreaterThan(0);
+    });
+
+    it("ragTopK と ragMinScore がクエリに使用される", async () => {
+      const client = createMockClient();
+      client.query.mockResolvedValue([]);
+
+      const engine = new PineconeContextEngine({
+        pineconeClient: client,
+        agentId: "test-agent",
+        ragEnabled: true,
+        agentsCorePath,
+        ragTopK: 5,
+        ragMinScore: 0.8,
+      });
+
+      await engine.assemble({
+        sessionId: "s1",
+        messages: [{ role: "user", content: "Test query" }],
+      });
+
+      const queryParams = client.query.mock.calls[0][0];
+      expect(queryParams.topK).toBe(5);
+      expect(queryParams.minScore).toBe(0.8);
+    });
+
+    it("re-ranking が適用される — agents_rule が優先される", async () => {
+      const client = createMockClient();
+      const now = Date.now();
+      const results: QueryResult[] = [
+        makeQueryResult("Session turn text", 0.9, "session_turn", now),
+        makeQueryResult("Agents rule text", 0.88, "agents_rule", now),
+      ];
+      client.query.mockResolvedValue(results);
+
+      const engine = new PineconeContextEngine({
+        pineconeClient: client,
+        agentId: "test-agent",
+        ragEnabled: true,
+        agentsCorePath,
+      });
+
+      const result = await engine.assemble({
+        sessionId: "s1",
+        messages: [{ role: "user", content: "Apply rules" }],
+      });
+
+      const addition = result.systemPromptAddition ?? "";
+      // agents_rule が re-ranking で上位に来る（sourceType weight が高い）
+      const agentsRuleIndex = addition.indexOf("Agents rule text");
+      const sessionTurnIndex = addition.indexOf("Session turn text");
+      expect(agentsRuleIndex).toBeLessThan(sessionTurnIndex);
+    });
+  });
+
+  describe("トークン予算", () => {
+    it("トークン予算超過時に低スコアチャンクが除外される", async () => {
+      const client = createMockClient();
+      const longText = "A".repeat(8000); // ~2000 ASCII tokens → 予算いっぱい
+      const results: QueryResult[] = [
+        makeQueryResult(longText, 0.95, "agents_rule"),
+        makeQueryResult("Should be excluded due to budget", 0.8, "memory_file"),
+      ];
+      client.query.mockResolvedValue(results);
+
+      const engine = new PineconeContextEngine({
+        pineconeClient: client,
+        agentId: "test-agent",
+        ragEnabled: true,
+        agentsCorePath,
+        ragTokenBudget: 2000,
+      });
+
+      const result = await engine.assemble({
+        sessionId: "s1",
+        messages: [{ role: "user", content: "Test budget" }],
+      });
+
+      expect(result.systemPromptAddition).toContain("AGENTS-CORE");
+      expect(result.systemPromptAddition).not.toContain("Should be excluded due to budget");
+    });
+
+    it("ragTokenBudget パラメータで予算を制御可能", async () => {
+      const client = createMockClient();
+      const results: QueryResult[] = [makeQueryResult("Short chunk", 0.9, "agents_rule")];
+      client.query.mockResolvedValue(results);
+
+      const engine = new PineconeContextEngine({
+        pineconeClient: client,
+        agentId: "test-agent",
+        ragEnabled: true,
+        agentsCorePath,
+        ragTokenBudget: 500,
+      });
+
+      const consoleSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+
+      await engine.assemble({
+        sessionId: "s1",
+        messages: [{ role: "user", content: "Budget test" }],
+      });
+
+      // ログに budget=500 が出力される
+      const budgetLog = consoleSpy.mock.calls.find(
+        (call) => typeof call[0] === "string" && call[0].includes("budget=500"),
+      );
+      expect(budgetLog).toBeDefined();
+    });
+  });
+
+  describe("フォールバック", () => {
+    it("Pinecone 接続不可時 — AGENTS-CORE.md のみで動作する（warn ログ出力）", async () => {
+      const client = createMockClient();
+      client.query.mockRejectedValue(new Error("connection refused"));
+
+      const engine = new PineconeContextEngine({
+        pineconeClient: client,
+        agentId: "test-agent",
+        ragEnabled: true,
+        agentsCorePath,
+      });
+
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      const result = await engine.assemble({
+        sessionId: "s1",
+        messages: [{ role: "user", content: "Pinecone is down" }],
+      });
+
+      expect(result.systemPromptAddition).toContain("AGENTS-CORE");
+      expect(result.systemPromptAddition).toContain("Core rules for the agent");
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("[pinecone-context-engine] Pinecone query failed in RAG mode:"),
+        expect.any(Error),
+      );
+    });
+
+    it("AGENTS-CORE.md 不在 — 動的チャンクのみで動作する（warn ログ出力）", async () => {
+      const client = createMockClient();
+      const results: QueryResult[] = [makeQueryResult("Dynamic chunk only", 0.9, "agents_rule")];
+      client.query.mockResolvedValue(results);
+
+      const nonExistentPath = path.join(tmpDir, "NON_EXISTENT.md");
+
+      const engine = new PineconeContextEngine({
+        pineconeClient: client,
+        agentId: "test-agent",
+        ragEnabled: true,
+        agentsCorePath: nonExistentPath,
+      });
+
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      const result = await engine.assemble({
+        sessionId: "s1",
+        messages: [{ role: "user", content: "No core file" }],
+      });
+
+      expect(result.systemPromptAddition).toContain("Dynamic chunk only");
+      expect(result.systemPromptAddition).not.toContain("AGENTS-CORE");
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("[pinecone-context-engine] AGENTS-CORE.md not found:"),
+      );
+    });
+
+    it("検索結果 0 件 — AGENTS-CORE.md のみで応答する", async () => {
+      const client = createMockClient();
+      client.query.mockResolvedValue([]);
+
+      const engine = new PineconeContextEngine({
+        pineconeClient: client,
+        agentId: "test-agent",
+        ragEnabled: true,
+        agentsCorePath,
+      });
+
+      vi.spyOn(console, "info").mockImplementation(() => {});
+
+      const result = await engine.assemble({
+        sessionId: "s1",
+        messages: [{ role: "user", content: "No results query" }],
+      });
+
+      expect(result.systemPromptAddition).toContain("AGENTS-CORE");
+      expect(result.systemPromptAddition).toContain("Core rules for the agent");
+      expect(result.systemPromptAddition).not.toContain("Relevant Knowledge");
+    });
+
+    it("Pinecone 接続不可 + AGENTS-CORE.md 不在 — fallback adapter が使われる", async () => {
+      const client = createMockClient();
+      client.query.mockRejectedValue(new Error("connection refused"));
+
+      const fallbackAdapter = {
+        info: { id: "mock-fallback", name: "Mock Fallback", version: "0.0.1" },
+        ingest: vi.fn().mockResolvedValue({ ingested: false }),
+        assemble: vi.fn().mockResolvedValue({
+          messages: [],
+          estimatedTokens: 0,
+          systemPromptAddition: "fallback content",
+        }),
+        compact: vi.fn().mockResolvedValue({ ok: true, compacted: false }),
+      };
+
+      const engine = new PineconeContextEngine({
+        pineconeClient: client,
+        agentId: "test-agent",
+        ragEnabled: true,
+        agentsCorePath: path.join(tmpDir, "NON_EXISTENT.md"),
+        fallbackAdapter,
+      });
+
+      vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      const result = await engine.assemble({
+        sessionId: "s1",
+        messages: [{ role: "user", content: "Everything fails" }],
+      });
+
+      expect(result.systemPromptAddition).toBe("fallback content");
+    });
+  });
+
+  describe("構造化ログ", () => {
+    it("assemble 実行時に mode, results, latency, tokens を含むログが出力される", async () => {
+      const client = createMockClient();
+      const results: QueryResult[] = [
+        makeQueryResult("Rule chunk", 0.9, "agents_rule"),
+        makeQueryResult("Memory chunk", 0.85, "memory_file"),
+      ];
+      client.query.mockResolvedValue(results);
+
+      const engine = new PineconeContextEngine({
+        pineconeClient: client,
+        agentId: "test-agent",
+        ragEnabled: true,
+        agentsCorePath,
+        ragTopK: 10,
+      });
+
+      const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+
+      await engine.assemble({
+        sessionId: "s1",
+        messages: [{ role: "user", content: "Log test" }],
+      });
+
+      const logMessages = infoSpy.mock.calls.map((c) => c[0] as string);
+
+      // mode=rag ログ
+      const modeLog = logMessages.find((m) => m.includes("mode=rag"));
+      expect(modeLog).toBeDefined();
+      expect(modeLog).toContain("ns=agent:test-agent");
+      expect(modeLog).toContain("topK=10");
+      expect(modeLog).toContain("results=2");
+      expect(modeLog).toMatch(/latency=\d+ms/);
+
+      // rerank ログ
+      const rerankLog = logMessages.find((m) => m.includes("rerank:"));
+      expect(rerankLog).toBeDefined();
+      expect(rerankLog).toContain("agents_rule=1");
+      expect(rerankLog).toContain("memory_file=1");
+
+      // merged ログ
+      const mergedLog = logMessages.find((m) => m.includes("merged:"));
+      expect(mergedLog).toBeDefined();
+      expect(mergedLog).toMatch(/core_tokens=\d+/);
+      expect(mergedLog).toMatch(/dynamic_tokens=\d+/);
+      expect(mergedLog).toMatch(/total=\d+/);
+      expect(mergedLog).toMatch(/budget=\d+/);
+    });
+  });
+});

--- a/packages/pinecone-context-engine/src/rag-assemble.test.ts
+++ b/packages/pinecone-context-engine/src/rag-assemble.test.ts
@@ -186,19 +186,22 @@ describe("PineconeContextEngine - RAG mode", () => {
   describe("トークン予算", () => {
     it("トークン予算超過時に低スコアチャンクが除外される", async () => {
       const client = createMockClient();
-      const longText = "A".repeat(8000); // ~2000 ASCII tokens → 予算いっぱい
+      const longText = "A".repeat(8000); // ~2000 ASCII tokens
+      const overflowText = "B".repeat(400); // ~100 tokens → 残り予算を超過
       const results: QueryResult[] = [
         makeQueryResult(longText, 0.95, "agents_rule"),
-        makeQueryResult("Should be excluded due to budget", 0.8, "memory_file"),
+        makeQueryResult(overflowText, 0.8, "memory_file"),
       ];
       client.query.mockResolvedValue(results);
 
+      // ragTokenBudget は総予算（core + dynamic）
+      // AGENTS-CORE.md ~10 tokens → 動的予算 ~2040 → longText (2000) は入る → overflowText (100) は超過
       const engine = new PineconeContextEngine({
         pineconeClient: client,
         agentId: "test-agent",
         ragEnabled: true,
         agentsCorePath,
-        ragTokenBudget: 2000,
+        ragTokenBudget: 2050,
       });
 
       const result = await engine.assemble({
@@ -207,7 +210,8 @@ describe("PineconeContextEngine - RAG mode", () => {
       });
 
       expect(result.systemPromptAddition).toContain("AGENTS-CORE");
-      expect(result.systemPromptAddition).not.toContain("Should be excluded due to budget");
+      expect(result.systemPromptAddition).toContain(longText);
+      expect(result.systemPromptAddition).not.toContain(overflowText);
     });
 
     it("ragTokenBudget パラメータで予算を制御可能", async () => {

--- a/packages/pinecone-context-engine/src/rag-assemble.test.ts
+++ b/packages/pinecone-context-engine/src/rag-assemble.test.ts
@@ -264,7 +264,7 @@ describe("PineconeContextEngine - RAG mode", () => {
       expect(result.systemPromptAddition).toContain("AGENTS-CORE");
       expect(result.systemPromptAddition).toContain("Core rules for the agent");
       expect(warnSpy).toHaveBeenCalledWith(
-        expect.stringContaining("[pinecone-context-engine] Pinecone query failed in RAG mode:"),
+        expect.stringContaining("[PineconeContextEngine] Pinecone query failed in RAG mode:"),
         expect.any(Error),
       );
     });
@@ -293,7 +293,7 @@ describe("PineconeContextEngine - RAG mode", () => {
       expect(result.systemPromptAddition).toContain("Dynamic chunk only");
       expect(result.systemPromptAddition).not.toContain("AGENTS-CORE");
       expect(warnSpy).toHaveBeenCalledWith(
-        expect.stringContaining("[pinecone-context-engine] AGENTS-CORE.md not found:"),
+        expect.stringContaining("[PineconeContextEngine] AGENTS-CORE.md not found:"),
       );
     });
 
@@ -318,6 +318,29 @@ describe("PineconeContextEngine - RAG mode", () => {
       expect(result.systemPromptAddition).toContain("AGENTS-CORE");
       expect(result.systemPromptAddition).toContain("Core rules for the agent");
       expect(result.systemPromptAddition).not.toContain("Relevant Knowledge");
+    });
+
+    it("agentsCorePath 未設定でも動的チャンクのみで動作する", async () => {
+      const client = createMockClient();
+      const results: QueryResult[] = [makeQueryResult("Dynamic only", 0.9, "agents_rule")];
+      client.query.mockResolvedValue(results);
+
+      const engine = new PineconeContextEngine({
+        pineconeClient: client,
+        agentId: "test-agent",
+        ragEnabled: true,
+        // agentsCorePath は未設定
+      });
+
+      vi.spyOn(console, "info").mockImplementation(() => {});
+
+      const result = await engine.assemble({
+        sessionId: "s1",
+        messages: [{ role: "user", content: "No core path" }],
+      });
+
+      expect(result.systemPromptAddition).toContain("Dynamic only");
+      expect(result.systemPromptAddition).not.toContain("AGENTS-CORE");
     });
 
     it("Pinecone 接続不可 + AGENTS-CORE.md 不在 — fallback adapter が使われる", async () => {

--- a/packages/pinecone-context-engine/src/reranker.test.ts
+++ b/packages/pinecone-context-engine/src/reranker.test.ts
@@ -1,0 +1,149 @@
+import type { ChunkMetadata } from "@easy-flow/pinecone-client";
+import { describe, expect, it } from "vitest";
+import { rerankChunks } from "./reranker.js";
+
+function makeChunk(
+  overrides: Partial<{
+    id: string;
+    text: string;
+    score: number;
+    sourceType: ChunkMetadata["sourceType"];
+    createdAt: number;
+  }> = {},
+) {
+  return {
+    id: overrides.id ?? "chunk-1",
+    text: overrides.text ?? "some text",
+    score: overrides.score ?? 0.9,
+    metadata: {
+      agentId: "test-agent",
+      sourceFile: "test.md",
+      sourceType: overrides.sourceType ?? "memory_file",
+      chunkIndex: 0,
+      createdAt: overrides.createdAt ?? Date.now(),
+    } satisfies ChunkMetadata,
+  };
+}
+
+describe("rerankChunks", () => {
+  describe("空配列", () => {
+    it("空の入力で空の出力を返す", () => {
+      expect(rerankChunks([])).toEqual([]);
+    });
+  });
+
+  describe("sourceType 重み付け", () => {
+    it("agents_rule > memory_file > session_turn > workflow_state の順にスコアが高い", () => {
+      const now = Date.now();
+      const chunks = [
+        makeChunk({ id: "wf", sourceType: "workflow_state", score: 0.9, createdAt: now }),
+        makeChunk({ id: "st", sourceType: "session_turn", score: 0.9, createdAt: now }),
+        makeChunk({ id: "mf", sourceType: "memory_file", score: 0.9, createdAt: now }),
+        makeChunk({ id: "ar", sourceType: "agents_rule", score: 0.9, createdAt: now }),
+      ];
+
+      // テキストが同一だと重複排除されるので、テキストを変える
+      for (const c of chunks) c.text = `text-${c.id}`;
+
+      const ranked = rerankChunks(chunks, now);
+
+      expect(ranked[0].id).toBe("ar");
+      expect(ranked[1].id).toBe("mf");
+      expect(ranked[2].id).toBe("st");
+      expect(ranked[3].id).toBe("wf");
+    });
+  });
+
+  describe("鮮度スコア", () => {
+    it("新しいチャンクが古いチャンクよりスコアが高い", () => {
+      const now = Date.now();
+      const recent = makeChunk({
+        id: "recent",
+        text: "recent text",
+        score: 0.9,
+        createdAt: now - 1 * 60 * 60 * 1000, // 1 hour ago
+      });
+      const old = makeChunk({
+        id: "old",
+        text: "old text",
+        score: 0.9,
+        createdAt: now - 6 * 24 * 60 * 60 * 1000, // 6 days ago
+      });
+
+      const ranked = rerankChunks([old, recent], now);
+
+      expect(ranked[0].id).toBe("recent");
+      expect(ranked[1].id).toBe("old");
+      expect(ranked[0].score).toBeGreaterThan(ranked[1].score);
+    });
+
+    it("7 日以上前のチャンクは鮮度 0.0", () => {
+      const now = Date.now();
+      const chunk = makeChunk({
+        id: "very-old",
+        text: "very old",
+        score: 0.9,
+        createdAt: now - 8 * 24 * 60 * 60 * 1000, // 8 days ago
+      });
+
+      const ranked = rerankChunks([chunk], now);
+
+      // 最終スコア = 0.9 * 0.7 + 0.8 * 0.2 + 0.0 * 0.1 = 0.63 + 0.16 = 0.79
+      expect(ranked[0].score).toBeCloseTo(0.79, 2);
+    });
+  });
+
+  describe("重複排除", () => {
+    it("同一テキストのチャンクが 1 つに絞られる", () => {
+      const now = Date.now();
+      const chunks = [
+        makeChunk({ id: "dup-1", text: "duplicate text", score: 0.8, createdAt: now }),
+        makeChunk({ id: "dup-2", text: "duplicate text", score: 0.95, createdAt: now }),
+        makeChunk({ id: "unique", text: "unique text", score: 0.85, createdAt: now }),
+      ];
+
+      const ranked = rerankChunks(chunks, now);
+
+      expect(ranked).toHaveLength(2);
+      // 高スコアの方が残る
+      const dupChunk = ranked.find((c) => c.text === "duplicate text");
+      expect(dupChunk?.id).toBe("dup-2");
+    });
+  });
+
+  describe("スコア計算", () => {
+    it("最終スコア = ベクトル類似度 × 0.7 + sourceType 重み × 0.2 + 鮮度スコア × 0.1", () => {
+      const now = Date.now();
+      const chunk = makeChunk({
+        id: "calc",
+        text: "calc text",
+        score: 0.9, // vector similarity
+        sourceType: "agents_rule", // weight = 1.0
+        createdAt: now, // freshness = 1.0
+      });
+
+      const ranked = rerankChunks([chunk], now);
+
+      // 0.9 * 0.7 + 1.0 * 0.2 + 1.0 * 0.1 = 0.63 + 0.2 + 0.1 = 0.93
+      expect(ranked[0].score).toBeCloseTo(0.93, 2);
+      expect(ranked[0].originalScore).toBe(0.9);
+    });
+  });
+
+  describe("ソート順", () => {
+    it("最終スコア降順でソートされる", () => {
+      const now = Date.now();
+      const chunks = [
+        makeChunk({ id: "low", text: "low", score: 0.7, createdAt: now }),
+        makeChunk({ id: "high", text: "high", score: 0.99, createdAt: now }),
+        makeChunk({ id: "mid", text: "mid", score: 0.85, createdAt: now }),
+      ];
+
+      const ranked = rerankChunks(chunks, now);
+
+      expect(ranked[0].id).toBe("high");
+      expect(ranked[1].id).toBe("mid");
+      expect(ranked[2].id).toBe("low");
+    });
+  });
+});

--- a/packages/pinecone-context-engine/src/reranker.ts
+++ b/packages/pinecone-context-engine/src/reranker.ts
@@ -21,7 +21,7 @@ const VECTOR_WEIGHT = 0.7;
 const SOURCE_WEIGHT = 0.2;
 const FRESHNESS_WEIGHT = 0.1;
 
-/** 線形減衰で鮮度スコアを計算（直近 24h = 1.0、7 日以上前 = 0.0） */
+/** 線形減衰で鮮度スコアを計算（作成直後 = 1.0、7 日以上前 = 0.0） */
 const FRESHNESS_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
 
 function computeFreshnessScore(createdAt: number, now: number): number {

--- a/packages/pinecone-context-engine/src/reranker.ts
+++ b/packages/pinecone-context-engine/src/reranker.ts
@@ -1,0 +1,76 @@
+import type { ChunkMetadata } from "@easy-flow/pinecone-client";
+
+export interface RankedChunk {
+  id: string;
+  text: string;
+  /** re-ranking 後の最終スコア */
+  score: number;
+  /** Pinecone のベクトル類似度 */
+  originalScore: number;
+  metadata: ChunkMetadata;
+}
+
+const SOURCE_TYPE_WEIGHTS: Record<ChunkMetadata["sourceType"], number> = {
+  agents_rule: 1.0,
+  memory_file: 0.8,
+  session_turn: 0.6,
+  workflow_state: 0.5,
+};
+
+const VECTOR_WEIGHT = 0.7;
+const SOURCE_WEIGHT = 0.2;
+const FRESHNESS_WEIGHT = 0.1;
+
+/** 線形減衰で鮮度スコアを計算（直近 24h = 1.0、7 日以上前 = 0.0） */
+const FRESHNESS_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+
+function computeFreshnessScore(createdAt: number, now: number): number {
+  const age = now - createdAt;
+  if (age <= 0) return 1.0;
+  if (age >= FRESHNESS_MAX_AGE_MS) return 0.0;
+  return 1.0 - age / FRESHNESS_MAX_AGE_MS;
+}
+
+/**
+ * Pinecone 検索結果に re-ranking を適用する。
+ *
+ * 最終スコア = ベクトル類似度 × 0.7 + sourceType 重み × 0.2 + 鮮度スコア × 0.1
+ *
+ * 同一テキストの重複はスコアが高い方を残す。
+ */
+export function rerankChunks(
+  chunks: Array<{ id: string; text: string; score: number; metadata: ChunkMetadata }>,
+  now: number = Date.now(),
+): RankedChunk[] {
+  if (chunks.length === 0) return [];
+
+  const scored: RankedChunk[] = chunks.map((chunk) => {
+    const sourceWeight = SOURCE_TYPE_WEIGHTS[chunk.metadata.sourceType] ?? 0.5;
+    const freshnessScore = computeFreshnessScore(chunk.metadata.createdAt, now);
+
+    const finalScore =
+      chunk.score * VECTOR_WEIGHT +
+      sourceWeight * SOURCE_WEIGHT +
+      freshnessScore * FRESHNESS_WEIGHT;
+
+    return {
+      id: chunk.id,
+      text: chunk.text,
+      score: finalScore,
+      originalScore: chunk.score,
+      metadata: chunk.metadata,
+    };
+  });
+
+  // 重複排除: 同一テキストのチャンクはスコアが高い方を残す
+  const deduped = new Map<string, RankedChunk>();
+  for (const chunk of scored) {
+    const existing = deduped.get(chunk.text);
+    if (!existing || chunk.score > existing.score) {
+      deduped.set(chunk.text, chunk);
+    }
+  }
+
+  // スコア降順でソート
+  return [...deduped.values()].sort((a, b) => b.score - a.score);
+}

--- a/packages/pinecone-context-engine/src/shared.ts
+++ b/packages/pinecone-context-engine/src/shared.ts
@@ -31,6 +31,11 @@ export const RETRY_BASE_MS = 100;
 export const MAX_RETRIES = 3;
 export const ASSEMBLE_TIMEOUT_MS = 3000;
 
+// --- RAG mode defaults ---
+export const DEFAULT_RAG_TOKEN_BUDGET = 2000;
+export const DEFAULT_RAG_MIN_SCORE = 0.75;
+export const DEFAULT_RAG_TOP_K = 10;
+
 /**
  * Determine if a query is "thin" — too short or lacking proper nouns to
  * produce good Pinecone vector-search results.
@@ -131,6 +136,55 @@ export async function readOldTurns(
   } catch {
     return [];
   }
+}
+
+/**
+ * AGENTS-CORE.md をファイルシステムから読み込む。
+ * ファイルが存在しない場合は空文字を返す。
+ */
+export async function readAgentsCore(filePath: string): Promise<string> {
+  try {
+    const { readFile } = await import("node:fs/promises");
+    return await readFile(filePath, "utf-8");
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * RAG モードの systemPromptAddition を組み立てる。
+ *
+ * AGENTS-CORE.md 固定テキスト + re-ranking 済み動的チャンクをトークン予算内でマージ。
+ */
+export function buildRagSystemPromptAddition(
+  agentsCoreText: string,
+  dynamicChunks: Array<{ text: string; score: number }>,
+  dynamicBudget: number,
+): { markdown: string; coreTokens: number; dynamicTokens: number } {
+  const parts: string[] = [];
+  let coreTokens = 0;
+
+  if (agentsCoreText) {
+    parts.push(agentsCoreText);
+    coreTokens = estimateTokens(agentsCoreText);
+  }
+
+  const selectedTexts: string[] = [];
+  let dynamicTokens = 0;
+
+  for (const chunk of dynamicChunks) {
+    const tokens = estimateTokens(chunk.text);
+    if (dynamicTokens + tokens > dynamicBudget) break;
+    selectedTexts.push(chunk.text);
+    dynamicTokens += tokens;
+  }
+
+  if (selectedTexts.length > 0) {
+    parts.push(`## Relevant Knowledge\n\n${selectedTexts.map((t) => `- ${t}`).join("\n")}`);
+  }
+
+  const markdown = parts.join("\n\n");
+  return { markdown, coreTokens, dynamicTokens };
 }
 
 export function buildSystemPromptAddition(

--- a/packages/pinecone-context-engine/src/shared.ts
+++ b/packages/pinecone-context-engine/src/shared.ts
@@ -160,13 +160,14 @@ export function buildRagSystemPromptAddition(
   agentsCoreText: string,
   dynamicChunks: Array<{ text: string; score: number }>,
   dynamicBudget: number,
+  precomputedCoreTokens?: number,
 ): { markdown: string; coreTokens: number; dynamicTokens: number } {
   const parts: string[] = [];
   let coreTokens = 0;
 
   if (agentsCoreText) {
     parts.push(agentsCoreText);
-    coreTokens = estimateTokens(agentsCoreText);
+    coreTokens = precomputedCoreTokens ?? estimateTokens(agentsCoreText);
   }
 
   const selectedTexts: string[] = [];

--- a/packages/pinecone-context-engine/src/types.ts
+++ b/packages/pinecone-context-engine/src/types.ts
@@ -27,7 +27,7 @@ export interface PineconeContextEngineParams {
   ragEnabled?: boolean;
   /** AGENTS-CORE.md の絶対パス (env: RAG_AGENTS_CORE_PATH) */
   agentsCorePath?: string;
-  /** 動的チャンクのトークン予算。Default: 2000 (env: RAG_TOKEN_BUDGET) */
+  /** AGENTS-CORE.md と動的チャンクを合わせた総トークン予算。Default: 2000 (env: RAG_TOKEN_BUDGET) */
   ragTokenBudget?: number;
   /** 最低類似度スコア。Default: 0.75 (env: RAG_MIN_SCORE) */
   ragMinScore?: number;

--- a/packages/pinecone-context-engine/src/types.ts
+++ b/packages/pinecone-context-engine/src/types.ts
@@ -21,4 +21,16 @@ export interface PineconeContextEngineParams {
   memoryHint?: string;
   /** Token threshold below which a query is considered "thin". Default: 20 */
   minQueryTokens?: number;
+
+  // --- RAG mode params ---
+  /** RAG モード有効化。Default: false (env: RAG_ENABLED) */
+  ragEnabled?: boolean;
+  /** AGENTS-CORE.md の絶対パス (env: RAG_AGENTS_CORE_PATH) */
+  agentsCorePath?: string;
+  /** 動的チャンクのトークン予算。Default: 2000 (env: RAG_TOKEN_BUDGET) */
+  ragTokenBudget?: number;
+  /** 最低類似度スコア。Default: 0.75 (env: RAG_MIN_SCORE) */
+  ragMinScore?: number;
+  /** 検索結果数。Default: 10 (env: RAG_TOP_K) */
+  ragTopK?: number;
 }


### PR DESCRIPTION
## Summary

Task 1.3: `RAG_ENABLED=true` 時に AGENTS-CORE.md を固定注入 + Pinecone から関連チャンクを動的検索・re-ranking して注入する仕組みを実装。

- **reranker.ts 新規作成**: ベクトル類似度 × 0.7 + sourceType 重み × 0.2 + 鮮度スコア × 0.1 による re-ranking。同一テキストの重複排除
- **assemble() RAG モード拡張**: `RAG_ENABLED=true` 時に assembleRag() を実行。AGENTS-CORE.md 固定 + 動的チャンクをトークン予算内でマージ
- **環境変数によるパラメータ制御**: `RAG_TOKEN_BUDGET` (default: 2000), `RAG_MIN_SCORE` (default: 0.75), `RAG_TOP_K` (default: 10)
- **フォールバック設計**: Pinecone 接続不可時は AGENTS-CORE.md のみ、AGENTS-CORE.md 不在時は動的チャンクのみで動作
- **構造化ログ**: mode, query_tokens, results, latency, rerank sourceType 別カウント, merged tokens
- **openclaw-pinecone-plugin**: RAG 設定（環境変数 + pluginConfig）の受け渡しを追加

### 後方互換性

`RAG_ENABLED` が未設定（デフォルト `false`）の場合、既存の assemble() ロジックがそのまま実行される。既存テスト 54 件 + parallel 7 件すべてパス済み。

### 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `pinecone-context-engine/src/reranker.ts` | **新規** — re-ranking モジュール |
| `pinecone-context-engine/src/reranker.test.ts` | **新規** — reranker テスト (7 件) |
| `pinecone-context-engine/src/rag-assemble.test.ts` | **新規** — RAG assemble テスト (12 件) |
| `pinecone-context-engine/src/pinecone-context-engine.ts` | assemble() RAG モード追加 |
| `pinecone-context-engine/src/shared.ts` | RAG 定数・readAgentsCore・buildRagSystemPromptAddition 追加 |
| `pinecone-context-engine/src/types.ts` | RAG パラメータ追加 |
| `pinecone-context-engine/src/index.ts` | reranker エクスポート追加 |
| `openclaw-pinecone-plugin/src/index.ts` | RAG 設定受け渡し |
| `openclaw-pinecone-plugin/src/index.test.ts` | ログ形式・パラメータ変更への追従 |

### 既知の制限事項

- AGENTS.md / MEMORY.md の静的全量注入スキップは OpenClaw コア側の対応が必要（本 PR のスコープ外）

Closes estack-inc/easy-flow#134

## Test plan

- [x] reranker テスト 7 件パス（sourceType 重み、鮮度スコア、重複排除、空配列、スコア計算）
- [x] RAG assemble テスト 12 件パス（RAG ON/OFF、トークン予算、フォールバック 4 パターン、構造化ログ）
- [x] 既存 pinecone-context-engine テスト 54 件パス（回帰なし）
- [x] 既存 parallel テスト 7 件パス
- [x] openclaw-pinecone-plugin テスト 7 件パス
- [x] `npm run lint` クリーン## AIレビュースキップ理由

### `Number()` 変換に NaN ガードがない
**スキップ理由:** 実装済み。環境変数は直接 `Number()` を呼ばず、`parseFiniteNumber()` (NaN→undefined), `parsePositiveInt()` (0・負値→undefined), `parseScoreFloat()` (0≤n≤1 範囲外→undefined) を経由する。テスト「ignores NaN from invalid env var values」「rejects zero and negative RAG_TOP_K env var values」「rejects negative and out-of-range RAG_MIN_SCORE env var values」「rejects zero and negative RAG_TOKEN_BUDGET env var values」で検証済み。

### `params.tokenBudget` の意味が RAG モードで変わる
**スキップ理由:** 実装済み。`assembleRag()` で `totalBudget = params.tokenBudget ?? this.ragTokenBudget` を総上限とし、`dynamicBudget = Math.max(0, totalBudget - coreTokensEstimate)` で core 分を差し引く。合計は totalBudget を超えない。テスト「トークン予算超過時に低スコアチャンクが除外される」で検証済み。