### PR TITLE
fix(file-serve): LINE ファイル送信のブロックリスト修正

### DIFF
--- a/packages/file-serve/openclaw.plugin.json
+++ b/packages/file-serve/openclaw.plugin.json
@@ -26,6 +26,7 @@
       },
       "allowedSourceDir": {
         "type": "string",
+        "default": "/data/workspace",
         "description": "ソースファイルの許可ディレクトリ（デフォルト: /data/workspace。このディレクトリ外のファイルは拒否される）"
       }
     },

--- a/packages/file-serve/openclaw.plugin.json
+++ b/packages/file-serve/openclaw.plugin.json
@@ -26,7 +26,7 @@
       },
       "allowedSourceDir": {
         "type": "string",
-        "description": "ソースファイルの許可ディレクトリ（省略時はシステムパスのみブロック）"
+        "description": "ソースファイルの許可ディレクトリ（デフォルト: /data/workspace。このディレクトリ外のファイルは拒否される）"
       }
     },
     "additionalProperties": false

--- a/packages/file-serve/src/config.ts
+++ b/packages/file-serve/src/config.ts
@@ -58,7 +58,7 @@ export function loadConfig(
   const allowedSourceDir =
     typeof rawAllowedSourceDir === "string" && rawAllowedSourceDir
       ? rawAllowedSourceDir
-      : undefined;
+      : "/data/workspace";
 
   const rawStorageDir = pluginConfig?.storageDir;
   const storageDir =

--- a/packages/file-serve/src/config.ts
+++ b/packages/file-serve/src/config.ts
@@ -6,8 +6,8 @@ export type FileServeConfig = {
     windowMs: number;
     maxRequests: number;
   };
-  /** ソースファイルの許可ディレクトリ。設定時はこのディレクトリ外のファイルを拒否する。 */
-  allowedSourceDir?: string;
+  /** ソースファイルの許可ディレクトリ（デフォルト: /data/workspace）。このディレクトリ外のファイルは拒否される。 */
+  allowedSourceDir: string;
 };
 
 /**

--- a/packages/file-serve/src/hook-before-tool-call.ts
+++ b/packages/file-serve/src/hook-before-tool-call.ts
@@ -47,12 +47,6 @@ export type PluginHookBeforeToolCallResult = {
 };
 
 export function createBeforeToolCallHook(config: FileServeConfig, logger: PluginLogger) {
-  if (!config.allowedSourceDir) {
-    logger.warn(
-      "allowedSourceDir が未設定です。本番環境では allowedSourceDir を設定してソースパスを制限することを推奨します。",
-    );
-  }
-
   return async (
     event: PluginHookBeforeToolCallEvent,
     ctx: PluginHookToolContext,

--- a/packages/file-serve/src/storage.ts
+++ b/packages/file-serve/src/storage.ts
@@ -28,7 +28,11 @@ const BLOCKED_SOURCE_PREFIXES = [
   "/boot/",
   "/dev/",
   "/app/", // アプリソースコード・.env 等の漏洩防止
-  "/data/", // アプリデータ（ストレージ自体も /data/file-serve/ 配下）
+  "/data/openclaw.json", // OpenClaw 設定ファイル
+  "/data/lcm.db", // LCM データベース
+  "/data/file-serve/", // file-serve ストレージ自体の再配信防止
+  "/data/extensions/", // プラグインソースコード
+  "/data/easy-flow-agent/", // エージェントソースコード
   "/var/", // ログ・データベース等
   "/opt/", // オプションパッケージ
   "/usr/", // システムユーティリティ

--- a/packages/file-serve/test/cleanup-service.test.ts
+++ b/packages/file-serve/test/cleanup-service.test.ts
@@ -20,6 +20,7 @@ const baseConfig: FileServeConfig = {
   baseUrl: "https://example.fly.dev",
   ttlDays: 7,
   rateLimit: { windowMs: 60000, maxRequests: 30 },
+  allowedSourceDir: "/data/workspace",
 };
 
 const mockLogger = {

--- a/packages/file-serve/test/config.test.ts
+++ b/packages/file-serve/test/config.test.ts
@@ -196,17 +196,17 @@ describe("loadConfig", () => {
       expect(config.allowedSourceDir).toBe("/tmp/uploads");
     });
 
-    it("allowedSourceDir 未設定 → undefined", () => {
+    it("allowedSourceDir 未設定 → デフォルト /data/workspace", () => {
       const config = loadConfig({ baseUrl: "https://example.com" }, undefined);
-      expect(config.allowedSourceDir).toBeUndefined();
+      expect(config.allowedSourceDir).toBe("/data/workspace");
     });
 
-    it("allowedSourceDir が空文字列 → undefined にフォールバック", () => {
+    it("allowedSourceDir が空文字列 → デフォルト /data/workspace にフォールバック", () => {
       const config = loadConfig(
         { baseUrl: "https://example.com", allowedSourceDir: "" },
         undefined,
       );
-      expect(config.allowedSourceDir).toBeUndefined();
+      expect(config.allowedSourceDir).toBe("/data/workspace");
     });
   });
 });

--- a/packages/file-serve/test/hook-before-tool-call.test.ts
+++ b/packages/file-serve/test/hook-before-tool-call.test.ts
@@ -18,6 +18,7 @@ const baseConfig: FileServeConfig = {
   baseUrl: "https://example.fly.dev",
   ttlDays: 7,
   rateLimit: { windowMs: 60000, maxRequests: 30 },
+  allowedSourceDir: "/data/workspace",
 };
 
 const mockLogger = {

--- a/packages/file-serve/test/http-handler.test.ts
+++ b/packages/file-serve/test/http-handler.test.ts
@@ -30,6 +30,7 @@ const baseConfig: FileServeConfig = {
   baseUrl: "https://example.fly.dev",
   ttlDays: 7,
   rateLimit: { windowMs: 60000, maxRequests: 30 },
+  allowedSourceDir: "/data/workspace",
 };
 
 const mockLogger = {

--- a/packages/file-serve/test/storage.test.ts
+++ b/packages/file-serve/test/storage.test.ts
@@ -176,6 +176,32 @@ describe("saveFile / validateSourceFilePath", () => {
       ).rejects.toThrow("許可されていないソースパス");
     });
 
+    it("/data/lcm.db をブロックする（LCM データベース漏洩防止）", async () => {
+      (fs.promises.realpath as ReturnType<typeof vi.fn>).mockResolvedValue("/data/lcm.db");
+
+      await expect(
+        saveFile({
+          sourceFilePath: "/data/lcm.db",
+          filename: "lcm.db",
+          mimeType: "application/octet-stream",
+          storageDir: STORAGE_DIR,
+          baseUrl: BASE_URL,
+        }),
+      ).rejects.toThrow("許可されていないソースパス");
+    });
+
+    it("/data/easy-flow-agent/ のパスをブロックする（エージェントソースコード漏洩防止）", async () => {
+      await expect(
+        saveFile({
+          sourceFilePath: "/data/easy-flow-agent/src/index.ts",
+          filename: "index.ts",
+          mimeType: "text/plain",
+          storageDir: STORAGE_DIR,
+          baseUrl: BASE_URL,
+        }),
+      ).rejects.toThrow("許可されていないソースパス");
+    });
+
     it("/data/workspace/ のパスは通過する（エージェント作業ディレクトリ）", async () => {
       await expect(
         saveFile({

--- a/packages/file-serve/test/storage.test.ts
+++ b/packages/file-serve/test/storage.test.ts
@@ -137,16 +137,55 @@ describe("saveFile / validateSourceFilePath", () => {
       ).rejects.toThrow("許可されていないソースパス");
     });
 
-    it("/data/ のパスをブロックする（アプリデータ漏洩防止）", async () => {
+    it("/data/openclaw.json をブロックする（設定ファイル漏洩防止）", async () => {
+      // realpath で正確なパスに解決されるケースをシミュレート
+      (fs.promises.realpath as ReturnType<typeof vi.fn>).mockResolvedValue("/data/openclaw.json");
+
       await expect(
         saveFile({
-          sourceFilePath: "/data/secrets/key.pem",
-          filename: "key.pem",
+          sourceFilePath: "/data/openclaw.json",
+          filename: "openclaw.json",
+          mimeType: "application/json",
+          storageDir: STORAGE_DIR,
+          baseUrl: BASE_URL,
+        }),
+      ).rejects.toThrow("許可されていないソースパス");
+    });
+
+    it("/data/extensions/ のパスをブロックする（プラグインソースコード漏洩防止）", async () => {
+      await expect(
+        saveFile({
+          sourceFilePath: "/data/extensions/file-serve/index.ts",
+          filename: "index.ts",
           mimeType: "text/plain",
           storageDir: STORAGE_DIR,
           baseUrl: BASE_URL,
         }),
       ).rejects.toThrow("許可されていないソースパス");
+    });
+
+    it("/data/file-serve/ のパスをブロックする（ストレージ自体の再配信防止）", async () => {
+      await expect(
+        saveFile({
+          sourceFilePath: "/data/file-serve/some-uuid/secret.pdf",
+          filename: "secret.pdf",
+          mimeType: "application/pdf",
+          storageDir: STORAGE_DIR,
+          baseUrl: BASE_URL,
+        }),
+      ).rejects.toThrow("許可されていないソースパス");
+    });
+
+    it("/data/workspace/ のパスは通過する（エージェント作業ディレクトリ）", async () => {
+      await expect(
+        saveFile({
+          sourceFilePath: "/data/workspace/reports/output.csv",
+          filename: "output.csv",
+          mimeType: "text/csv",
+          storageDir: STORAGE_DIR,
+          baseUrl: BASE_URL,
+        }),
+      ).resolves.toMatchObject({ uuid: VALID_UUID });
     });
 
     it("/var/ のパスをブロックする", async () => {


### PR DESCRIPTION
## Summary

- LINE チャネルでエージェントがファイルを送信しようとすると、file-serve プラグインのブロックリストによりサイレントにブロックされる問題を修正
- `allowedSourceDir` が `pluginConfig` 経由で渡されない場合でも安全に動作するようデフォルト値を設定

## 根本原因

1. **ブロックリスト `/data/` が広すぎる**: `BLOCKED_SOURCE_PREFIXES` に `/data/` が含まれており、エージェントの作業ディレクトリ `/data/workspace/` のファイルもブロックされていた
2. **`allowedSourceDir` がプラグインに渡されない**: OpenClaw の自動検出（`/data/extensions/` スキャン）でロードされたプラグインには `plugins.entries.file-serve.config` が渡されず、`allowedSourceDir` が `undefined` → ブロックリスト方式にフォールバック → `/data/` で全ブロック

## 変更内容

### `storage.ts`
- `/data/` を削除し、具体的なパス（`/data/openclaw.json`, `/data/lcm.db`, `/data/file-serve/`, `/data/extensions/`, `/data/easy-flow-agent/`）に分割
- `/data/workspace/` のファイルはブロックされなくなる

### `config.ts`
- `allowedSourceDir` のデフォルト値を `undefined` → `/data/workspace` に変更
- `pluginConfig` が渡されないケースでも安全に動作

## Test plan

- [x] `storage.test.ts`: `/data/workspace/` パスの通過テスト追加、個別ブロック対象のテスト追加（24 テスト PASS）
- [x] `config.test.ts`: `allowedSourceDir` デフォルト値のテスト更新（28 テスト PASS）
- [x] `hook-before-tool-call.test.ts`: 既存テスト全 PASS（10 テスト）
- [ ] LINE 実機でのファイル送信動作確認

Closes estack-inc/easy-flow#199