### PR TITLE
fix(pinecone-memory): configSchema に memoryHint/minQueryTokens 等を追加

### DIFF
--- a/packages/openclaw-pinecone-plugin/openclaw.plugin.json
+++ b/packages/openclaw-pinecone-plugin/openclaw.plugin.json
@@ -25,6 +25,18 @@
       "placeholder": "7",
       "help": "Days after which old turns are compacted into Pinecone",
       "advanced": true
+    },
+    "memoryHint": {
+      "label": "Memory Hint",
+      "placeholder": "AI agent for ○○. 業種: ○○",
+      "help": "Thin query enrichment 用のヒントテキスト（最大200文字）",
+      "advanced": true
+    },
+    "minQueryTokens": {
+      "label": "Min Query Tokens",
+      "placeholder": "20",
+      "help": "クエリがこのトークン数未満の場合 'thin' と判定（デフォルト: 20）",
+      "advanced": true
     }
   },
   "configSchema": {
@@ -34,7 +46,37 @@
       "apiKey": { "type": "string" },
       "agentId": { "type": "string" },
       "indexName": { "type": "string" },
-      "compactAfterDays": { "type": "number", "minimum": 1, "maximum": 90 }
+      "compactAfterDays": { "type": "number", "minimum": 1, "maximum": 90 },
+      "memoryHint": {
+        "type": "string",
+        "maxLength": 200
+      },
+      "minQueryTokens": {
+        "type": "number",
+        "minimum": 1,
+        "maximum": 100
+      },
+      "ragEnabled": {
+        "type": "boolean"
+      },
+      "agentsCorePath": {
+        "type": "string"
+      },
+      "ragTokenBudget": {
+        "type": "number",
+        "minimum": 100,
+        "maximum": 100000
+      },
+      "ragMinScore": {
+        "type": "number",
+        "minimum": 0,
+        "maximum": 1
+      },
+      "ragTopK": {
+        "type": "number",
+        "minimum": 1,
+        "maximum": 100
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

- `openclaw.plugin.json` の `configSchema.properties` に、TypeScript の `PluginConfig` 型に定義済みだが未登録の 7 プロパティを追加
  - `memoryHint`, `minQueryTokens`, `ragEnabled`, `agentsCorePath`, `ragTokenBudget`, `ragMinScore`, `ragTopK`
- `uiHints` に `memoryHint` と `minQueryTokens` のエントリを追加
- `additionalProperties: false` により `openclaw.json` に設定すると gateway が起動しない問題を解消

Closes estack-inc/easy-flow#185

## Test plan

- [x] `npm test --workspace=packages/openclaw-pinecone-plugin` — 全 13 テストパス
- [x] `npm run lint` — エラーゼロ
- [x] 変更ファイルは `packages/openclaw-pinecone-plugin/openclaw.plugin.json` のみ
- [x] `required` 配列にはプロパティを追加していない（すべてオプショナル）
- [x] スキーマの型・制約が TypeScript `PluginConfig` 型と整合していることを確認