### PR TITLE
feat: イメージリビルドトリガー追加

### DIFF
--- a/.github/workflows/trigger-image-rebuild.yml
+++ b/.github/workflows/trigger-image-rebuild.yml
@@ -1,0 +1,24 @@
+name: Trigger Image Rebuild
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  notify:
+    name: Notify openclaw-templates
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Trigger repository_dispatch
+        env:
+          DISPATCH_TOKEN: ${{ secrets.OPENCLAW_DISPATCH_TOKEN }}
+          REPO_NAME: ${{ github.repository }}
+          SHA: ${{ github.sha }}
+          REF: ${{ github.ref }}
+        run: |
+          curl -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${DISPATCH_TOKEN}" \
+            https://api.github.com/repos/estack-inc/openclaw-templates/dispatches \
+            -d "{\"event_type\":\"dependency-updated\",\"client_payload\":{\"source\":\"${REPO_NAME}\",\"sha\":\"${SHA}\",\"ref\":\"${REF}\"}}"

--- a/.github/workflows/trigger-image-rebuild.yml
+++ b/.github/workflows/trigger-image-rebuild.yml
@@ -22,5 +22,6 @@ jobs:
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${DISPATCH_TOKEN}" \
             -H "Content-Type: application/json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/estack-inc/openclaw-templates/dispatches \
             -d "{\"event_type\":\"dependency-updated\",\"client_payload\":{\"source\":\"${REPO_NAME}\",\"sha\":\"${SHA}\",\"ref\":\"${REF}\"}}"

--- a/.github/workflows/trigger-image-rebuild.yml
+++ b/.github/workflows/trigger-image-rebuild.yml
@@ -9,6 +9,7 @@ jobs:
     name: Notify openclaw-templates
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions: {}
     steps:
       - name: Trigger repository_dispatch
         env:
@@ -17,8 +18,9 @@ jobs:
           SHA: ${{ github.sha }}
           REF: ${{ github.ref }}
         run: |
-          curl -X POST \
+          curl --fail-with-body -X POST \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${DISPATCH_TOKEN}" \
+            -H "Content-Type: application/json" \
             https://api.github.com/repos/estack-inc/openclaw-templates/dispatches \
             -d "{\"event_type\":\"dependency-updated\",\"client_payload\":{\"source\":\"${REPO_NAME}\",\"sha\":\"${SHA}\",\"ref\":\"${REF}\"}}"


### PR DESCRIPTION
## Summary
- main ブランチへの push 時に openclaw-templates へ `repository_dispatch` を送信
- openclaw-templates の `build-image.yml` が自動でイメージリビルドを実行

## セットアップ
`OPENCLAW_DISPATCH_TOKEN` secret の登録が必要（fine-grained PAT, contents:write on openclaw-templates）

## Test plan
- [ ] OPENCLAW_DISPATCH_TOKEN 設定後、main push で openclaw-templates の Build & Push Image が起動すること