### PR TITLE
feat: タグベースリリースに変更

### DIFF
--- a/.github/workflows/trigger-image-rebuild.yml
+++ b/.github/workflows/trigger-image-rebuild.yml
@@ -2,7 +2,9 @@ name: Trigger Image Rebuild
 
 on:
   push:
-    branches: [main]
+    tags:
+      - 'v*'
+  workflow_dispatch: {}
 
 jobs:
   notify:


### PR DESCRIPTION
## Summary
- デプロイトリガーを `push: branches: [main]` → `push: tags: ['v*']` に変更
- main へのマージだけではデプロイチェーンが起動しなくなる
- `workflow_dispatch` を追加し、緊急時の手動トリガーを維持

## 背景
main への ANY マージが即座にフリート全台デプロイを発動するリスクがあった。
タグ push 時のみデプロイを起動することで、意図的なリリースタイミング制御を実現。

## Test plan
- [ ] main push でワークフローが起動しないことを確認
- [ ] `v*` タグ push でワークフローが起動すること
- [ ] workflow_dispatch で手動トリガーが機能すること