### PR TITLE
fix(file-serve): LINE メッセージ内の Flex JSON を plain text に自動変換

### DIFF
--- a/.github/workflows/trigger-image-rebuild.yml
+++ b/.github/workflows/trigger-image-rebuild.yml
@@ -2,7 +2,9 @@ name: Trigger Image Rebuild
 
 on:
   push:
-    branches: [main]
+    tags:
+      - 'v*'
+  workflow_dispatch: {}
 
 jobs:
   notify:

--- a/packages/file-serve/src/hook-before-tool-call.ts
+++ b/packages/file-serve/src/hook-before-tool-call.ts
@@ -29,15 +29,15 @@ function buildDownloadText(
 function findJsonEnd(s: string): number {
   let depth = 0;
   let inString = false;
-  let escape = false;
+  let escaped = false;
   for (let i = 0; i < s.length; i++) {
     const ch = s[i];
-    if (escape) {
-      escape = false;
+    if (escaped) {
+      escaped = false;
       continue;
     }
     if (ch === "\\" && inString) {
-      escape = true;
+      escaped = true;
       continue;
     }
     if (ch === '"') {
@@ -71,7 +71,7 @@ function sanitizeFlexJson(message: string, logger: PluginLogger): string | null 
   const trailingText = jsonEnd > 0 ? message.slice(jsonEnd).trim() : "";
 
   logger.info(`Flex JSON を検出、plain text に変換: ${downloadUrl}`);
-  return `📄 ${filename}\n${downloadUrl}${trailingText ? "\n" + trailingText : ""}`;
+  return `📄 ${filename}\n${downloadUrl}${trailingText ? `\n${trailingText}` : ""}`;
 }
 
 export type PluginHookBeforeToolCallEvent = {

--- a/packages/file-serve/src/hook-before-tool-call.ts
+++ b/packages/file-serve/src/hook-before-tool-call.ts
@@ -25,6 +25,39 @@ function buildDownloadText(
   return `📄 ${filename}（${formatFileSize(sizeBytes)}）\n${downloadUrl}\n有効期限: ${ttlDays}日間`;
 }
 
+/**
+ * AI が Flex Message JSON を message パラメータに直接埋め込んだ場合に検出し、
+ * file-serve ダウンロード URL を含む plain text に変換する。
+ * Flex JSON でない場合や file-serve URL が含まれない場合は null を返す。
+ */
+function sanitizeFlexJson(message: string, logger: PluginLogger): string | null {
+  if (!message.startsWith('{"type":"flex"')) return null;
+
+  const urlMatch = message.match(/https?:\/\/[^"\s]+\/files\/[a-f0-9-]+\/[^"\s]+/);
+  if (!urlMatch) return null;
+
+  const downloadUrl = urlMatch[0];
+  const filename = decodeURIComponent(downloadUrl.split("/").pop() || "file");
+
+  // Flex JSON の終端を検出し、後続テキストを保持
+  let depth = 0;
+  let jsonEnd = 0;
+  for (let i = 0; i < message.length; i++) {
+    if (message[i] === "{") depth++;
+    else if (message[i] === "}") {
+      depth--;
+      if (depth === 0) {
+        jsonEnd = i + 1;
+        break;
+      }
+    }
+  }
+  const trailingText = jsonEnd > 0 ? message.slice(jsonEnd).trim() : "";
+
+  logger.info(`Flex JSON を検出、plain text に変換: ${downloadUrl}`);
+  return `📄 ${filename}\n${downloadUrl}${trailingText ? "\n" + trailingText : ""}`;
+}
+
 export type PluginHookBeforeToolCallEvent = {
   toolName: string;
   params: Record<string, unknown>;
@@ -57,11 +90,21 @@ export function createBeforeToolCallHook(config: FileServeConfig, logger: Plugin
     // filePath または media が存在するかチェック
     const sourceFilePath =
       (event.params.filePath as string | undefined) || (event.params.media as string | undefined);
-    if (!sourceFilePath) return undefined;
 
     // LINE チャネルのみ処理
     if (!ctx.sessionKey?.startsWith("line:")) {
       logger.debug?.(`LINE 以外のチャネルはスキップ: ${ctx.sessionKey}`);
+      return undefined;
+    }
+
+    // Flex JSON がメッセージに直接含まれている場合の検出・変換
+    // AI がセッションコンテキストから旧ワークアラウンドを使用するケースに対応
+    if (!sourceFilePath) {
+      const message = event.params.message as string | undefined;
+      if (message) {
+        const sanitized = sanitizeFlexJson(message, logger);
+        if (sanitized) return { params: { ...event.params, message: sanitized } };
+      }
       return undefined;
     }
 

--- a/packages/file-serve/src/hook-before-tool-call.ts
+++ b/packages/file-serve/src/hook-before-tool-call.ts
@@ -25,6 +25,32 @@ function buildDownloadText(
   return `📄 ${filename}（${formatFileSize(sizeBytes)}）\n${downloadUrl}\n有効期限: ${ttlDays}日間`;
 }
 
+/** JSON 文字列の終端位置を返す。文字列値・エスケープを考慮し } の誤検出を防ぐ。 */
+function findJsonEnd(s: string): number {
+  let depth = 0;
+  let inString = false;
+  let escape = false;
+  for (let i = 0; i < s.length; i++) {
+    const ch = s[i];
+    if (escape) {
+      escape = false;
+      continue;
+    }
+    if (ch === "\\" && inString) {
+      escape = true;
+      continue;
+    }
+    if (ch === '"') {
+      inString = !inString;
+      continue;
+    }
+    if (inString) continue;
+    if (ch === "{") depth++;
+    else if (ch === "}" && --depth === 0) return i + 1;
+  }
+  return 0;
+}
+
 /**
  * AI が Flex Message JSON を message パラメータに直接埋め込んだ場合に検出し、
  * file-serve ダウンロード URL を含む plain text に変換する。
@@ -40,18 +66,8 @@ function sanitizeFlexJson(message: string, logger: PluginLogger): string | null 
   const filename = decodeURIComponent(downloadUrl.split("/").pop() || "file");
 
   // Flex JSON の終端を検出し、後続テキストを保持
-  let depth = 0;
-  let jsonEnd = 0;
-  for (let i = 0; i < message.length; i++) {
-    if (message[i] === "{") depth++;
-    else if (message[i] === "}") {
-      depth--;
-      if (depth === 0) {
-        jsonEnd = i + 1;
-        break;
-      }
-    }
-  }
+  // JSON 文字列値内の } で誤動作しないよう、文字列・エスケープを考慮
+  const jsonEnd = findJsonEnd(message);
   const trailingText = jsonEnd > 0 ? message.slice(jsonEnd).trim() : "";
 
   logger.info(`Flex JSON を検出、plain text に変換: ${downloadUrl}`);

--- a/packages/file-serve/test/hook-before-tool-call.test.ts
+++ b/packages/file-serve/test/hook-before-tool-call.test.ts
@@ -174,6 +174,50 @@ describe("createBeforeToolCallHook", () => {
     expect(saveFile).not.toHaveBeenCalled();
   });
 
+  it("LINE + Flex JSON が message に直接含まれている → plain text に変換", async () => {
+    const flexJson =
+      '{"type":"flex","altText":"📄 sample.pdf","contents":{"type":"bubble","body":{"type":"box","layout":"vertical","contents":[]},"footer":{"type":"box","layout":"vertical","contents":[{"type":"button","action":{"type":"uri","label":"ダウンロード","uri":"https://example.fly.dev/files/abcd1234-5678-9abc-def0-123456789abc/sample.pdf"},"style":"primary"}]}}}送りました！';
+    const hook = createBeforeToolCallHook(baseConfig, mockLogger);
+    const result = await hook(
+      makeEvent({ params: { message: flexJson } }),
+      makeCtx({ sessionKey: "line:user123" }),
+    );
+
+    expect(result).toBeDefined();
+    expect(result?.params?.message).not.toContain('{"type":"flex"');
+    expect(result?.params?.message).toContain("sample.pdf");
+    expect(result?.params?.message).toContain(
+      "https://example.fly.dev/files/abcd1234-5678-9abc-def0-123456789abc/sample.pdf",
+    );
+    expect(result?.params?.message).toContain("送りました！");
+    expect(saveFile).not.toHaveBeenCalled();
+  });
+
+  it("LINE + Flex JSON（file-serve URL なし）→ 変換しない", async () => {
+    const flexJson = '{"type":"flex","altText":"test","contents":{"type":"bubble"}}';
+    const hook = createBeforeToolCallHook(baseConfig, mockLogger);
+    const result = await hook(
+      makeEvent({ params: { message: flexJson } }),
+      makeCtx({ sessionKey: "line:user123" }),
+    );
+
+    expect(result).toBeUndefined();
+    expect(saveFile).not.toHaveBeenCalled();
+  });
+
+  it("Slack + Flex JSON → 変換しない（LINE 以外はスキップ）", async () => {
+    const flexJson =
+      '{"type":"flex","altText":"test","contents":{"type":"bubble","footer":{"type":"box","layout":"vertical","contents":[{"type":"button","action":{"type":"uri","uri":"https://example.fly.dev/files/abcd1234-5678-9abc-def0-123456789abc/test.pdf"}}]}}}';
+    const hook = createBeforeToolCallHook(baseConfig, mockLogger);
+    const result = await hook(
+      makeEvent({ params: { message: flexJson } }),
+      makeCtx({ sessionKey: "slack:C0123456" }),
+    );
+
+    expect(result).toBeUndefined();
+    expect(saveFile).not.toHaveBeenCalled();
+  });
+
   it("toolName が message 以外 → 戻り値が undefined", async () => {
     const hook = createBeforeToolCallHook(baseConfig, mockLogger);
     const result = await hook(

--- a/packages/file-serve/test/hook-before-tool-call.test.ts
+++ b/packages/file-serve/test/hook-before-tool-call.test.ts
@@ -205,6 +205,23 @@ describe("createBeforeToolCallHook", () => {
     expect(saveFile).not.toHaveBeenCalled();
   });
 
+  it("LINE + Flex JSON（文字列値内に } を含む）→ 正しく終端検出して変換", async () => {
+    const flexJson =
+      '{"type":"flex","altText":"完了}テスト","contents":{"type":"bubble","footer":{"type":"box","layout":"vertical","contents":[{"type":"button","action":{"type":"uri","uri":"https://example.fly.dev/files/abcd1234-5678-9abc-def0-123456789abc/report.pdf"}}]}}}後続テキスト';
+    const hook = createBeforeToolCallHook(baseConfig, mockLogger);
+    const result = await hook(
+      makeEvent({ params: { message: flexJson } }),
+      makeCtx({ sessionKey: "line:user123" }),
+    );
+
+    expect(result).toBeDefined();
+    expect(result?.params?.message).toContain("report.pdf");
+    expect(result?.params?.message).toContain("後続テキスト");
+    expect(result?.params?.message).not.toContain('{"type":"flex"');
+    // JSON フラグメントが混入していないことを確認
+    expect(result?.params?.message).not.toContain("完了}テスト");
+  });
+
   it("Slack + Flex JSON → 変換しない（LINE 以外はスキップ）", async () => {
     const flexJson =
       '{"type":"flex","altText":"test","contents":{"type":"bubble","footer":{"type":"box","layout":"vertical","contents":[{"type":"button","action":{"type":"uri","uri":"https://example.fly.dev/files/abcd1234-5678-9abc-def0-123456789abc/test.pdf"}}]}}}';


### PR DESCRIPTION
## Summary
- AI がセッションコンテキストから旧ワークアラウンド（Flex Message JSON を `message` パラメータに直接構築）を使用した場合、`before_tool_call` フックが検出して plain text に自動変換
- セッションリセット不要で既存の全クライアントセッションに即座に効くため、顧客体験への影響なし
- file-serve ダウンロード URL を含む Flex JSON のみ対象。URL なしの Flex JSON や LINE 以外のチャネルは変換しない

## 背景
旧バグ（blocklist が `/data/workspace/` をブロック）の回避策として、AI が `filePath` パラメータを使わず Flex JSON を直接構築するワークアラウンドをセッション/メモリに学習していた。コード修正後もセッションコンテキストに残るため、フック側で検出・変換する防御層を追加。

## Test plan
- [x] Flex JSON → plain text 変換テスト
- [x] file-serve URL なしの Flex JSON は変換しないテスト
- [x] LINE 以外のチャネルは変換しないテスト
- [x] 全 128 テスト pass