### PR TITLE
fix(file-serve): ネイティブプラグイン認識と publicUrl 対応

### DIFF
--- a/packages/file-serve/openclaw.plugin.json
+++ b/packages/file-serve/openclaw.plugin.json
@@ -28,6 +28,10 @@
         "type": "string",
         "default": "/data/workspace",
         "description": "ソースファイルの許可ディレクトリ（デフォルト: /data/workspace。このディレクトリ外のファイルは拒否される）"
+      },
+      "publicUrl": {
+        "type": "string",
+        "description": "baseUrl の別名。entrypoint.sh との互換性用"
       }
     },
     "additionalProperties": false

--- a/packages/file-serve/src/config.ts
+++ b/packages/file-serve/src/config.ts
@@ -25,6 +25,8 @@ export function loadConfig(
   let baseUrl: string;
   if (typeof pluginConfig?.baseUrl === "string" && pluginConfig.baseUrl) {
     baseUrl = pluginConfig.baseUrl;
+  } else if (typeof pluginConfig?.publicUrl === "string" && pluginConfig.publicUrl) {
+    baseUrl = pluginConfig.publicUrl;
   } else if (typeof apiConfig?.publicUrl === "string" && apiConfig.publicUrl) {
     baseUrl = apiConfig.publicUrl;
   } else if (process.env.FLY_APP_NAME) {

--- a/packages/file-serve/src/config.ts
+++ b/packages/file-serve/src/config.ts
@@ -14,9 +14,10 @@ export type FileServeConfig = {
  * プラグイン設定をロードする。
  * baseUrl 優先順位:
  *   1. pluginConfig.baseUrl（明示指定）
- *   2. apiConfig から取得できる publicUrl
- *   3. 環境変数 FLY_APP_NAME から構成
- *   4. フォールバック: "http://localhost:8080"
+ *   2. pluginConfig.publicUrl（entrypoint.sh 互換エイリアス）
+ *   3. apiConfig から取得できる publicUrl
+ *   4. 環境変数 FLY_APP_NAME から構成
+ *   5. フォールバック: "http://localhost:8080"
  */
 export function loadConfig(
   pluginConfig: Record<string, unknown> | undefined,

--- a/packages/file-serve/test/config.test.ts
+++ b/packages/file-serve/test/config.test.ts
@@ -13,6 +13,27 @@ describe("loadConfig", () => {
       expect(config.baseUrl).toBe("https://custom.example.com");
     });
 
+    it("pluginConfig.publicUrl が baseUrl の代替として使用される", () => {
+      const config = loadConfig({ publicUrl: "https://entrypoint.example.com" }, undefined);
+      expect(config.baseUrl).toBe("https://entrypoint.example.com");
+    });
+
+    it("pluginConfig.baseUrl が pluginConfig.publicUrl より優先される", () => {
+      const config = loadConfig(
+        { baseUrl: "https://explicit.example.com", publicUrl: "https://entrypoint.example.com" },
+        undefined,
+      );
+      expect(config.baseUrl).toBe("https://explicit.example.com");
+    });
+
+    it("pluginConfig.publicUrl が apiConfig.publicUrl より優先される", () => {
+      const config = loadConfig(
+        { publicUrl: "https://entrypoint.example.com" },
+        { publicUrl: "https://api.example.com" },
+      );
+      expect(config.baseUrl).toBe("https://entrypoint.example.com");
+    });
+
     it("apiConfig.publicUrl が次の優先順位", () => {
       const config = loadConfig(undefined, { publicUrl: "https://api-public.example.com" });
       expect(config.baseUrl).toBe("https://api-public.example.com");


### PR DESCRIPTION
## Summary
- `openclaw.plugin.json` の `configSchema` に `publicUrl` プロパティを追加（`additionalProperties: false` による validation エラーを解消）
- `config.ts` で `pluginConfig.publicUrl` を `baseUrl` のフォールバックとして読み取るように修正

## Background
entrypoint.sh が一部インスタンスで `publicUrl` を `plugins.entries.file-serve.config` に設定しており、OpenClaw が `openclaw.extensions` フィールド付きのプラグインとして正しく認識した際に config validation が失敗していた。

## Test plan
- [ ] hub-spoke-agent で before_tool_call フックが発火することを確認済み
- [ ] baniyan-tsuri-agent で config validation エラーが解消されることを確認