### PR TITLE
perf(pinecone): assemble レイテンシ改善

### DIFF
--- a/packages/pinecone-client/src/embedding.test.ts
+++ b/packages/pinecone-client/src/embedding.test.ts
@@ -108,4 +108,102 @@ describe("EmbeddingService", () => {
   it("has BATCH_SIZE of 96", () => {
     expect(EmbeddingService.BATCH_SIZE).toBe(96);
   });
+
+  describe("query embedding cache", () => {
+    it("returns cached embedding on second call with same query text", async () => {
+      const fakeEmbedding = createFakeEmbedding();
+      const embedFn = vi
+        .fn()
+        .mockResolvedValue({ data: [{ vectorType: "dense", values: fakeEmbedding }] });
+      const mockPinecone = createMockPinecone(embedFn);
+      const service = new EmbeddingService(mockPinecone);
+
+      const result1 = await service.embed(["same query"], "query");
+      const result2 = await service.embed(["same query"], "query");
+
+      expect(embedFn).toHaveBeenCalledTimes(1);
+      expect(result1).toEqual(result2);
+      expect(service.cacheSize).toBe(1);
+    });
+
+    it("does not cache passage embeddings", async () => {
+      const fakeEmbedding = createFakeEmbedding();
+      const embedFn = vi
+        .fn()
+        .mockResolvedValue({ data: [{ vectorType: "dense", values: fakeEmbedding }] });
+      const mockPinecone = createMockPinecone(embedFn);
+      const service = new EmbeddingService(mockPinecone);
+
+      await service.embed(["some text"], "passage");
+      await service.embed(["some text"], "passage");
+
+      expect(embedFn).toHaveBeenCalledTimes(2);
+      expect(service.cacheSize).toBe(0);
+    });
+
+    it("does not cache multi-text query batches", async () => {
+      const fakeEmbedding = createFakeEmbedding();
+      const embedFn = vi.fn().mockResolvedValue({
+        data: [
+          { vectorType: "dense", values: fakeEmbedding },
+          { vectorType: "dense", values: fakeEmbedding },
+        ],
+      });
+      const mockPinecone = createMockPinecone(embedFn);
+      const service = new EmbeddingService(mockPinecone);
+
+      await service.embed(["text1", "text2"], "query");
+      await service.embed(["text1", "text2"], "query");
+
+      expect(embedFn).toHaveBeenCalledTimes(2);
+      expect(service.cacheSize).toBe(0);
+    });
+
+    it("evicts oldest entry when cache exceeds max size", async () => {
+      const embedFn = vi.fn().mockImplementation((params: { inputs: string[] }) =>
+        Promise.resolve({
+          data: params.inputs.map((_, i) => ({
+            vectorType: "dense",
+            values: createFakeEmbedding().map((v) => v + i),
+          })),
+        }),
+      );
+      const mockPinecone = createMockPinecone(embedFn);
+      const service = new EmbeddingService(mockPinecone);
+
+      // Fill cache to max size
+      for (let i = 0; i < EmbeddingService.QUERY_CACHE_SIZE; i++) {
+        await service.embed([`query-${i}`], "query");
+      }
+      expect(service.cacheSize).toBe(EmbeddingService.QUERY_CACHE_SIZE);
+
+      // Add one more — should evict "query-0"
+      await service.embed(["query-new"], "query");
+      expect(service.cacheSize).toBe(EmbeddingService.QUERY_CACHE_SIZE);
+
+      // "query-0" should now miss (re-embed)
+      const callsBefore = embedFn.mock.calls.length;
+      await service.embed(["query-0"], "query");
+      expect(embedFn).toHaveBeenCalledTimes(callsBefore + 1);
+    });
+
+    it("clearCache resets the cache", async () => {
+      const fakeEmbedding = createFakeEmbedding();
+      const embedFn = vi
+        .fn()
+        .mockResolvedValue({ data: [{ vectorType: "dense", values: fakeEmbedding }] });
+      const mockPinecone = createMockPinecone(embedFn);
+      const service = new EmbeddingService(mockPinecone);
+
+      await service.embed(["cached query"], "query");
+      expect(service.cacheSize).toBe(1);
+
+      service.clearCache();
+      expect(service.cacheSize).toBe(0);
+
+      // Should re-embed after clearing
+      await service.embed(["cached query"], "query");
+      expect(embedFn).toHaveBeenCalledTimes(2);
+    });
+  });
 });

--- a/packages/pinecone-client/src/embedding.test.ts
+++ b/packages/pinecone-client/src/embedding.test.ts
@@ -187,6 +187,42 @@ describe("EmbeddingService", () => {
       expect(embedFn).toHaveBeenCalledTimes(callsBefore + 1);
     });
 
+    it("promotes accessed entry so it is not evicted", async () => {
+      const embedFn = vi.fn().mockImplementation((params: { inputs: string[] }) =>
+        Promise.resolve({
+          data: params.inputs.map((_, i) => ({
+            vectorType: "dense",
+            values: createFakeEmbedding().map((v) => v + i),
+          })),
+        }),
+      );
+      const mockPinecone = createMockPinecone(embedFn);
+      const service = new EmbeddingService(mockPinecone);
+
+      // Fill cache completely: query-0 through query-63
+      for (let i = 0; i < EmbeddingService.QUERY_CACHE_SIZE; i++) {
+        await service.embed([`query-${i}`], "query");
+      }
+      expect(service.cacheSize).toBe(EmbeddingService.QUERY_CACHE_SIZE);
+
+      // Access query-0 to promote it (cache hit, moves to end)
+      const callsAfterFill = embedFn.mock.calls.length;
+      await service.embed(["query-0"], "query");
+      expect(embedFn).toHaveBeenCalledTimes(callsAfterFill); // cache hit
+
+      // Insert query-new — should evict query-1 (oldest non-promoted), NOT query-0
+      await service.embed(["query-new"], "query");
+
+      // query-0 should still be cached (was promoted by get)
+      const callsBefore0 = embedFn.mock.calls.length;
+      await service.embed(["query-0"], "query");
+      expect(embedFn).toHaveBeenCalledTimes(callsBefore0); // still cached
+
+      // query-1 should have been evicted (was the oldest after query-0 was promoted)
+      await service.embed(["query-1"], "query");
+      expect(embedFn).toHaveBeenCalledTimes(callsBefore0 + 1); // re-embedded
+    });
+
     it("clearCache resets the cache", async () => {
       const fakeEmbedding = createFakeEmbedding();
       const embedFn = vi

--- a/packages/pinecone-client/src/embedding.ts
+++ b/packages/pinecone-client/src/embedding.ts
@@ -94,12 +94,12 @@ export class EmbeddingService {
     return results;
   }
 
-  /** Clear the query embedding cache. Useful for testing. */
+  /** @internal Clear the query embedding cache. */
   clearCache(): void {
     this.queryCache.clear();
   }
 
-  /** Current number of cached query embeddings. */
+  /** @internal Current number of cached query embeddings. */
   get cacheSize(): number {
     return this.queryCache.size;
   }

--- a/packages/pinecone-client/src/embedding.ts
+++ b/packages/pinecone-client/src/embedding.ts
@@ -88,7 +88,7 @@ export class EmbeddingService {
 
     // Cache single-text query embeddings
     if (inputType === "query" && texts.length === 1 && results.length === 1) {
-      this.queryCache.set(texts[0], results[0]);
+      this.queryCache.set(texts[0], results[0].slice());
     }
 
     return results;

--- a/packages/pinecone-client/src/embedding.ts
+++ b/packages/pinecone-client/src/embedding.ts
@@ -2,18 +2,71 @@ import type { Pinecone } from "@pinecone-database/pinecone";
 
 const MODEL = "multilingual-e5-large";
 
+/**
+ * Simple LRU cache for query embeddings.
+ * Avoids redundant Pinecone Inference API calls for identical query texts.
+ */
+class EmbeddingCache {
+  private readonly maxSize: number;
+  private readonly cache = new Map<string, number[]>();
+
+  constructor(maxSize: number) {
+    this.maxSize = maxSize;
+  }
+
+  get(key: string): number[] | undefined {
+    const value = this.cache.get(key);
+    if (value !== undefined) {
+      // Move to end (most recently used)
+      this.cache.delete(key);
+      this.cache.set(key, value);
+    }
+    return value;
+  }
+
+  set(key: string, value: number[]): void {
+    if (this.cache.has(key)) {
+      this.cache.delete(key);
+    } else if (this.cache.size >= this.maxSize) {
+      // Evict oldest (first) entry
+      const firstKey = this.cache.keys().next().value!;
+      this.cache.delete(firstKey);
+    }
+    this.cache.set(key, value);
+  }
+
+  get size(): number {
+    return this.cache.size;
+  }
+
+  clear(): void {
+    this.cache.clear();
+  }
+}
+
 export class EmbeddingService {
   static readonly BATCH_SIZE = 96;
+  static readonly QUERY_CACHE_SIZE = 64;
 
   private readonly pinecone: Pinecone;
+  private readonly queryCache: EmbeddingCache;
 
   constructor(pinecone: Pinecone) {
     this.pinecone = pinecone;
+    this.queryCache = new EmbeddingCache(EmbeddingService.QUERY_CACHE_SIZE);
   }
 
   async embed(texts: string[], inputType: "passage" | "query"): Promise<number[][]> {
     if (texts.length === 0) {
       return [];
+    }
+
+    // For single-text query embeddings, check cache first
+    if (inputType === "query" && texts.length === 1) {
+      const cached = this.queryCache.get(texts[0]);
+      if (cached) {
+        return [cached];
+      }
     }
 
     const results: number[][] = [];
@@ -33,6 +86,21 @@ export class EmbeddingService {
       }
     }
 
+    // Cache single-text query embeddings
+    if (inputType === "query" && texts.length === 1 && results.length === 1) {
+      this.queryCache.set(texts[0], results[0]);
+    }
+
     return results;
+  }
+
+  /** Clear the query embedding cache. Useful for testing. */
+  clearCache(): void {
+    this.queryCache.clear();
+  }
+
+  /** Current number of cached query embeddings. */
+  get cacheSize(): number {
+    return this.queryCache.size;
   }
 }

--- a/packages/pinecone-client/src/embedding.ts
+++ b/packages/pinecone-client/src/embedding.ts
@@ -65,7 +65,7 @@ export class EmbeddingService {
     if (inputType === "query" && texts.length === 1) {
       const cached = this.queryCache.get(texts[0]);
       if (cached) {
-        return [cached];
+        return [cached.slice()];
       }
     }
 

--- a/packages/pinecone-context-engine/src/pinecone-context-engine.ts
+++ b/packages/pinecone-context-engine/src/pinecone-context-engine.ts
@@ -223,22 +223,19 @@ export class PineconeContextEngine implements ContextEngine {
     try {
       const startTime = Date.now();
 
-      // 1. AGENTS-CORE.md を読み込み
-      let agentsCoreText = "";
-      if (this.agentsCorePath) {
-        agentsCoreText = await readAgentsCore(this.agentsCorePath);
-        if (!agentsCoreText) {
-          console.warn(`[PineconeContextEngine] AGENTS-CORE.md not found: ${this.agentsCorePath}`);
-        }
-      }
+      // 1. AGENTS-CORE.md 読み込みを即座に開始（await せず並列化）
+      const agentsCorePromise = this.agentsCorePath
+        ? readAgentsCore(this.agentsCorePath)
+        : Promise.resolve("");
 
-      // 2. 検索クエリを生成
+      // 2. 検索クエリを生成（同期処理）
       const baseQuery = buildQueryFromRecentTurns(params.messages);
       const queryTokens = baseQuery ? estimateTokens(baseQuery) : 0;
       const totalBudget = params.tokenBudget ?? this.ragTokenBudget;
 
       if (!baseQuery) {
         // クエリなし → AGENTS-CORE.md のみ返却
+        const agentsCoreText = await agentsCorePromise;
         if (agentsCoreText) {
           const coreTokens = estimateTokens(agentsCoreText);
           console.info(
@@ -258,25 +255,29 @@ export class PineconeContextEngine implements ContextEngine {
 
       const queryText = this.enrichQuery(baseQuery);
 
-      // 3. Pinecone セマンティック検索
-      let results: Awaited<ReturnType<IPineconeClient["query"]>> = [];
+      // 3. AGENTS-CORE.md と Pinecone セマンティック検索を並列実行
+      const pineconePromise = Promise.race([
+        withRetry(() =>
+          this.client.query({
+            text: queryText,
+            agentId: this.agentId,
+            topK: this.ragTopK,
+            minScore: this.ragMinScore,
+          }),
+        ),
+        new Promise<never>((_, reject) =>
+          setTimeout(() => reject(new Error("assemble timeout")), ASSEMBLE_TIMEOUT_MS),
+        ),
+      ]);
+
+      let agentsCoreText: string;
+      let results: Awaited<ReturnType<IPineconeClient["query"]>>;
       try {
-        results = await Promise.race([
-          withRetry(() =>
-            this.client.query({
-              text: queryText,
-              agentId: this.agentId,
-              topK: this.ragTopK,
-              minScore: this.ragMinScore,
-            }),
-          ),
-          new Promise<never>((_, reject) =>
-            setTimeout(() => reject(new Error("assemble timeout")), ASSEMBLE_TIMEOUT_MS),
-          ),
-        ]);
+        [agentsCoreText, results] = await Promise.all([agentsCorePromise, pineconePromise]);
       } catch (err) {
         // Pinecone 接続不可 → AGENTS-CORE.md のみで動作
         console.warn("[PineconeContextEngine] Pinecone query failed in RAG mode:", err);
+        agentsCoreText = await agentsCorePromise.catch(() => "");
         if (agentsCoreText) {
           const coreTokens = estimateTokens(agentsCoreText);
           return {
@@ -286,6 +287,10 @@ export class PineconeContextEngine implements ContextEngine {
           };
         }
         return this.fallback.assemble(params);
+      }
+
+      if (this.agentsCorePath && !agentsCoreText) {
+        console.warn(`[PineconeContextEngine] AGENTS-CORE.md not found: ${this.agentsCorePath}`);
       }
 
       const latency = Date.now() - startTime;

--- a/packages/pinecone-context-engine/src/shared.ts
+++ b/packages/pinecone-context-engine/src/shared.ts
@@ -29,7 +29,7 @@ export const DEFAULT_COMPACT_AFTER_DAYS = 7;
 
 export const RETRY_BASE_MS = 100;
 export const MAX_RETRIES = 3;
-export const ASSEMBLE_TIMEOUT_MS = 3000;
+export const ASSEMBLE_TIMEOUT_MS = 5000;
 
 // --- RAG mode defaults ---
 export const DEFAULT_RAG_TOKEN_BUDGET = 2000;


### PR DESCRIPTION
## Summary

- EmbeddingService に query embedding 用 LRU キャッシュ（64 エントリ）を追加。同一クエリの embedding API 呼び出しをスキップし、レイテンシの ~78% を占める embedding 生成を削減
- assembleRag で `readAgentsCore()` と Pinecone query を `Promise.all` で並列実行
- `ASSEMBLE_TIMEOUT_MS` を 3000 → 5000 に引き上げ（コールドスタート時のタイムアウト防止）

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `packages/pinecone-client/src/embedding.ts` | LRU キャッシュ追加（query 用、64 エントリ上限） |
| `packages/pinecone-client/src/embedding.test.ts` | キャッシュテスト 5 件追加 |
| `packages/pinecone-context-engine/src/shared.ts` | `ASSEMBLE_TIMEOUT_MS` 3000 → 5000 |
| `packages/pinecone-context-engine/src/pinecone-context-engine.ts` | assembleRag 並列化 |

## Test plan

- [x] pinecone-client: 42 passed（キャッシュテスト 5 件含む）
- [x] pinecone-context-engine: 83 passed（既存テスト全パス）
- [x] biome lint: No fixes applied
- [ ] 社内インスタンスで assemble latency ログ確認
- [ ] キャッシュヒット時のレイテンシ短縮を実測

Refs: estack-inc/easy-flow#185