### PR TITLE
feat: pgvector + Upstash Vector クライアント・プラグインを追加

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -185,6 +185,10 @@
       "resolved": "packages/migrate-memory",
       "link": true
     },
+    "node_modules/@easy-flow/pgvector-client": {
+      "resolved": "packages/pgvector-client",
+      "link": true
+    },
     "node_modules/@easy-flow/pinecone-client": {
       "resolved": "packages/pinecone-client",
       "link": true
@@ -643,6 +647,15 @@
       "resolved": "packages/file-serve",
       "link": true
     },
+    "node_modules/@google/generative-ai": {
+      "version": "0.24.1",
+      "resolved": "https://registry.npmjs.org/@google/generative-ai/-/generative-ai-0.24.1.tgz",
+      "integrity": "sha512-MqO+MLfM6kjxcKoy0p1wRzG3b4ZZXtPI+z2IE26UogS2Cm/XHO+7gGRBh6gcJsOiIVoH93UwKvW4HdgiOZCy9Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
@@ -1048,6 +1061,18 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@types/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
+      }
+    },
     "node_modules/@types/picomatch": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/picomatch/-/picomatch-4.0.2.tgz",
@@ -1437,6 +1462,108 @@
         "node": ">= 14.16"
       }
     },
+    "node_modules/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.12.0",
+        "pg-pool": "^3.13.0",
+        "pg-protocol": "^1.13.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.3.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.3.0.tgz",
+      "integrity": "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.12.0.tgz",
+      "integrity": "sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.13.0.tgz",
+      "integrity": "sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.13.0.tgz",
+      "integrity": "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
+    "node_modules/pgvector": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/pgvector/-/pgvector-0.2.1.tgz",
+      "integrity": "sha512-nKaQY9wtuiidwLMdVIce1O3kL0d+FxrigCVzsShnoqzOSaWWWOvuctb/sYwlai5cTwwzRSNa+a/NtN2kVZGNJw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/pgvector-memory": {
+      "resolved": "packages/openclaw-pgvector-plugin",
+      "link": true
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -1487,6 +1614,45 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve-pkg-maps": {
@@ -1559,6 +1725,15 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
       }
     },
     "node_modules/stackback": {
@@ -1882,6 +2057,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
     "packages/file-serve": {
       "name": "@estack/openclaw-file-serve",
       "version": "1.0.0",
@@ -1964,6 +2148,27 @@
         }
       }
     },
+    "packages/openclaw-pgvector-plugin": {
+      "name": "pgvector-memory",
+      "version": "0.1.0",
+      "dependencies": {
+        "@easy-flow/pgvector-client": "*",
+        "@easy-flow/pinecone-context-engine": "*"
+      },
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      },
+      "peerDependencies": {
+        "openclaw": ">=2026.3.7"
+      },
+      "peerDependenciesMeta": {
+        "openclaw": {
+          "optional": true
+        }
+      }
+    },
     "packages/openclaw-pinecone-plugin": {
       "name": "pinecone-memory",
       "version": "0.1.0",
@@ -2004,6 +2209,21 @@
         "openclaw": {
           "optional": true
         }
+      }
+    },
+    "packages/pgvector-client": {
+      "name": "@easy-flow/pgvector-client",
+      "version": "1.0.0",
+      "dependencies": {
+        "@easy-flow/pinecone-client": "1.0.0",
+        "@google/generative-ai": "^0.24.0",
+        "pg": "^8.13.0",
+        "pgvector": "^0.2.0"
+      },
+      "devDependencies": {
+        "@types/pg": "^8.11.0",
+        "typescript": "^5.7.0",
+        "vitest": "^3.0.0"
       }
     },
     "packages/pinecone-client": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -193,6 +193,10 @@
       "resolved": "packages/pinecone-context-engine",
       "link": true
     },
+    "node_modules/@easy-flow/upstash-vector-client": {
+      "resolved": "packages/upstash-vector-client",
+      "link": true
+    },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.27.4",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.4.tgz",
@@ -1051,6 +1055,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@upstash/vector": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@upstash/vector/-/vector-1.2.3.tgz",
+      "integrity": "sha512-yXsWKeuHNYyH72BcSZd3bV5ZD5MybAoTvKxkMaeV2UzuGfNzbHBVh5eO+ysTWTFAf8I9XcOueF4tZfAGjCa4Iw==",
+      "license": "MIT"
+    },
     "node_modules/@vitest/expect": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
@@ -1680,6 +1690,10 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/upstash-memory": {
+      "resolved": "packages/openclaw-upstash-plugin",
+      "link": true
+    },
     "node_modules/vite": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
@@ -1971,6 +1985,27 @@
         }
       }
     },
+    "packages/openclaw-upstash-plugin": {
+      "name": "upstash-memory",
+      "version": "0.1.0",
+      "dependencies": {
+        "@easy-flow/pinecone-context-engine": "*",
+        "@easy-flow/upstash-vector-client": "*"
+      },
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      },
+      "peerDependencies": {
+        "openclaw": ">=2026.3.7"
+      },
+      "peerDependenciesMeta": {
+        "openclaw": {
+          "optional": true
+        }
+      }
+    },
     "packages/pinecone-client": {
       "name": "@easy-flow/pinecone-client",
       "version": "1.0.0",
@@ -1999,6 +2034,18 @@
         "openclaw": {
           "optional": true
         }
+      }
+    },
+    "packages/upstash-vector-client": {
+      "name": "@easy-flow/upstash-vector-client",
+      "version": "1.0.0",
+      "dependencies": {
+        "@easy-flow/pinecone-client": "1.0.0",
+        "@upstash/vector": "^1.2.0"
+      },
+      "devDependencies": {
+        "typescript": "^5.7.0",
+        "vitest": "^3.0.0"
       }
     },
     "packages/workflow-controller": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2215,7 +2215,7 @@
       "name": "@easy-flow/pgvector-client",
       "version": "1.0.0",
       "dependencies": {
-        "@easy-flow/pinecone-client": "1.0.0",
+        "@easy-flow/pinecone-client": "*",
         "@google/generative-ai": "^0.24.0",
         "pg": "^8.13.0",
         "pgvector": "^0.2.0"
@@ -2260,7 +2260,7 @@
       "name": "@easy-flow/upstash-vector-client",
       "version": "1.0.0",
       "dependencies": {
-        "@easy-flow/pinecone-client": "1.0.0",
+        "@easy-flow/pinecone-client": "*",
         "@upstash/vector": "^1.2.0"
       },
       "devDependencies": {

--- a/packages/openclaw-pgvector-plugin/openclaw.plugin.json
+++ b/packages/openclaw-pgvector-plugin/openclaw.plugin.json
@@ -1,0 +1,43 @@
+{
+  "id": "pgvector-memory",
+  "kind": "context-engine",
+  "name": "pgvector Memory",
+  "description": "Long-term vector memory for OpenClaw agents using PostgreSQL pgvector (co-located in Tokyo)",
+  "uiHints": {
+    "databaseUrl": {
+      "label": "Database URL",
+      "sensitive": true,
+      "placeholder": "postgres://user:pass@host:5432/db",
+      "help": "PostgreSQL connection string (or use ${PGVECTOR_DATABASE_URL} env var)"
+    },
+    "geminiApiKey": {
+      "label": "Gemini API Key",
+      "sensitive": true,
+      "placeholder": "AIza...",
+      "help": "Google Gemini API key for embeddings (or use ${GEMINI_API_KEY} env var)"
+    },
+    "agentId": {
+      "label": "Agent ID",
+      "placeholder": "mell",
+      "help": "Unique identifier for this agent (used as namespace prefix)"
+    },
+    "compactAfterDays": {
+      "label": "Compact After Days",
+      "placeholder": "7",
+      "help": "Days after which old turns are compacted into pgvector",
+      "advanced": true
+    }
+  },
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "databaseUrl": { "type": "string" },
+      "geminiApiKey": { "type": "string" },
+      "agentId": { "type": "string" },
+      "compactAfterDays": { "type": "number", "minimum": 1, "maximum": 90 },
+      "memoryHint": { "type": "string" },
+      "minQueryTokens": { "type": "number", "minimum": 1 }
+    }
+  }
+}

--- a/packages/openclaw-pgvector-plugin/package.json
+++ b/packages/openclaw-pgvector-plugin/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "pgvector-memory",
+  "version": "0.1.0",
+  "type": "module",
+  "exports": {
+    ".": {
+      "import": "./pgvector-memory/index.js",
+      "types": "./pgvector-memory/index.d.ts",
+      "default": "./pgvector-memory/index.js"
+    }
+  },
+  "main": "./pgvector-memory/index.js",
+  "types": "./pgvector-memory/index.d.ts",
+  "openclaw": {
+    "extensions": ["./src/index.ts"]
+  },
+  "files": [
+    "pgvector-memory"
+  ],
+  "scripts": {
+    "build": "tsc && cp openclaw.plugin.json pgvector-memory/openclaw.plugin.json",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@easy-flow/pgvector-client": "*",
+    "@easy-flow/pinecone-context-engine": "*"
+  },
+  "peerDependencies": {
+    "openclaw": ">=2026.3.7"
+  },
+  "peerDependenciesMeta": {
+    "openclaw": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.0.0",
+    "vitest": "^3.0.0"
+  }
+}

--- a/packages/openclaw-pgvector-plugin/src/index.test.ts
+++ b/packages/openclaw-pgvector-plugin/src/index.test.ts
@@ -1,0 +1,127 @@
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@easy-flow/pgvector-client", () => ({
+  PgVectorClient: vi.fn().mockImplementation(() => ({})),
+}));
+
+vi.mock("@easy-flow/pinecone-context-engine", () => ({
+  PineconeContextEngine: vi.fn().mockImplementation(() => ({
+    info: { id: "pgvector", name: "test", version: "1.0.0" },
+  })),
+}));
+
+import { PgVectorClient } from "@easy-flow/pgvector-client";
+import { PineconeContextEngine } from "@easy-flow/pinecone-context-engine";
+import register from "./index.js";
+
+function createMockApi(config: Record<string, unknown> = {}) {
+  let registeredFactory: (() => unknown) | null = null;
+
+  return {
+    pluginConfig: config,
+    logger: {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    },
+    registerContextEngine: vi.fn((_name: string, factory: () => unknown) => {
+      registeredFactory = factory;
+    }),
+    getRegisteredFactory: () => registeredFactory,
+  };
+}
+
+describe("openclaw-pgvector-plugin", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env = { ...originalEnv };
+    delete process.env.PGVECTOR_DATABASE_URL;
+    delete process.env.GEMINI_API_KEY;
+    delete process.env.OPENCLAW_AGENT_ID;
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  it("should disable plugin when credentials are missing", () => {
+    const api = createMockApi();
+
+    register(api as never);
+
+    expect(api.logger.warn).toHaveBeenCalledWith(expect.stringContaining("plugin disabled"));
+    expect(api.registerContextEngine).not.toHaveBeenCalled();
+  });
+
+  it("should register context engine with env vars", () => {
+    process.env.PGVECTOR_DATABASE_URL = "postgres://test:test@localhost:5432/test";
+    process.env.GEMINI_API_KEY = "test-key";
+    process.env.OPENCLAW_AGENT_ID = "mell";
+
+    const api = createMockApi();
+
+    register(api as never);
+
+    expect(api.registerContextEngine).toHaveBeenCalledWith("pgvector-memory", expect.any(Function));
+    expect(api.logger.info).toHaveBeenCalledWith(expect.stringContaining("agentId: mell"));
+  });
+
+  it("should register context engine with plugin config", () => {
+    const api = createMockApi({
+      databaseUrl: "postgres://config@localhost/db",
+      geminiApiKey: "config-key",
+      agentId: "tom",
+      compactAfterDays: 14,
+    });
+
+    register(api as never);
+
+    const factory = api.getRegisteredFactory();
+    factory?.();
+
+    expect(PgVectorClient).toHaveBeenCalledWith({
+      databaseUrl: "postgres://config@localhost/db",
+      geminiApiKey: "config-key",
+    });
+    expect(PineconeContextEngine).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentId: "tom",
+        compactAfterDays: 14,
+      }),
+    );
+  });
+
+  it("should use default agentId when not specified", () => {
+    process.env.PGVECTOR_DATABASE_URL = "postgres://test@localhost/db";
+    process.env.GEMINI_API_KEY = "test-key";
+
+    const api = createMockApi();
+
+    register(api as never);
+
+    expect(api.logger.info).toHaveBeenCalledWith(expect.stringContaining("agentId: default"));
+  });
+
+  it("should prefer plugin config over env vars", () => {
+    process.env.PGVECTOR_DATABASE_URL = "postgres://env@localhost/db";
+    process.env.GEMINI_API_KEY = "env-key";
+
+    const api = createMockApi({
+      databaseUrl: "postgres://config@localhost/db",
+      geminiApiKey: "config-key",
+    });
+
+    register(api as never);
+
+    const factory = api.getRegisteredFactory();
+    factory?.();
+
+    expect(PgVectorClient).toHaveBeenCalledWith({
+      databaseUrl: "postgres://config@localhost/db",
+      geminiApiKey: "config-key",
+    });
+  });
+});

--- a/packages/openclaw-pgvector-plugin/src/index.ts
+++ b/packages/openclaw-pgvector-plugin/src/index.ts
@@ -1,0 +1,44 @@
+import { PgVectorClient } from "@easy-flow/pgvector-client";
+import { PineconeContextEngine } from "@easy-flow/pinecone-context-engine";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+
+type PluginConfig = {
+  databaseUrl?: string;
+  geminiApiKey?: string;
+  agentId?: string;
+  compactAfterDays?: number;
+  memoryHint?: string;
+  minQueryTokens?: number;
+};
+
+export default function register(api: OpenClawPluginApi): void {
+  const cfg = (api.pluginConfig ?? {}) as PluginConfig;
+
+  const databaseUrl = cfg.databaseUrl ?? process.env.PGVECTOR_DATABASE_URL;
+  const geminiApiKey = cfg.geminiApiKey ?? process.env.GEMINI_API_KEY;
+
+  if (!databaseUrl || !geminiApiKey) {
+    api.logger.warn(
+      "pgvector-memory: PGVECTOR_DATABASE_URL / GEMINI_API_KEY not set — plugin disabled",
+    );
+    return;
+  }
+
+  const agentId = cfg.agentId ?? process.env.OPENCLAW_AGENT_ID ?? "default";
+  const compactAfterDays = cfg.compactAfterDays ?? 7;
+
+  api.registerContextEngine("pgvector-memory", () => {
+    const client = new PgVectorClient({ databaseUrl, geminiApiKey });
+    return new PineconeContextEngine({
+      pineconeClient: client,
+      agentId,
+      compactAfterDays,
+      memoryHint: cfg.memoryHint,
+      minQueryTokens: cfg.minQueryTokens,
+    });
+  });
+
+  api.logger.info(
+    `pgvector-memory: registered (agentId: ${agentId}, compactAfterDays: ${compactAfterDays})`,
+  );
+}

--- a/packages/openclaw-pgvector-plugin/tsconfig.json
+++ b/packages/openclaw-pgvector-plugin/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./pgvector-memory",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/packages/openclaw-upstash-plugin/openclaw.plugin.json
+++ b/packages/openclaw-upstash-plugin/openclaw.plugin.json
@@ -1,0 +1,43 @@
+{
+  "id": "upstash-memory",
+  "kind": "context-engine",
+  "name": "Upstash Memory",
+  "description": "Long-term vector memory for OpenClaw agents using Upstash Vector (Tokyo region)",
+  "uiHints": {
+    "url": {
+      "label": "Upstash Vector REST URL",
+      "sensitive": false,
+      "placeholder": "https://xxx.upstash.io",
+      "help": "Upstash Vector REST URL (or use ${UPSTASH_VECTOR_REST_URL} env var)"
+    },
+    "token": {
+      "label": "Upstash Vector REST Token",
+      "sensitive": true,
+      "placeholder": "AXxxExx...",
+      "help": "Upstash Vector REST token (or use ${UPSTASH_VECTOR_REST_TOKEN} env var)"
+    },
+    "agentId": {
+      "label": "Agent ID",
+      "placeholder": "mell",
+      "help": "Unique identifier for this agent (used as namespace prefix)"
+    },
+    "compactAfterDays": {
+      "label": "Compact After Days",
+      "placeholder": "7",
+      "help": "Days after which old turns are compacted into Upstash Vector",
+      "advanced": true
+    }
+  },
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "url": { "type": "string" },
+      "token": { "type": "string" },
+      "agentId": { "type": "string" },
+      "compactAfterDays": { "type": "number", "minimum": 1, "maximum": 90 },
+      "memoryHint": { "type": "string" },
+      "minQueryTokens": { "type": "number", "minimum": 1 }
+    }
+  }
+}

--- a/packages/openclaw-upstash-plugin/package.json
+++ b/packages/openclaw-upstash-plugin/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "upstash-memory",
+  "version": "0.1.0",
+  "type": "module",
+  "exports": {
+    ".": {
+      "import": "./upstash-memory/index.js",
+      "types": "./upstash-memory/index.d.ts",
+      "default": "./upstash-memory/index.js"
+    }
+  },
+  "main": "./upstash-memory/index.js",
+  "types": "./upstash-memory/index.d.ts",
+  "openclaw": {
+    "extensions": ["./src/index.ts"]
+  },
+  "files": [
+    "upstash-memory"
+  ],
+  "scripts": {
+    "build": "tsc && cp openclaw.plugin.json upstash-memory/openclaw.plugin.json",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@easy-flow/upstash-vector-client": "*",
+    "@easy-flow/pinecone-context-engine": "*"
+  },
+  "peerDependencies": {
+    "openclaw": ">=2026.3.7"
+  },
+  "peerDependenciesMeta": {
+    "openclaw": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.0.0",
+    "vitest": "^3.0.0"
+  }
+}

--- a/packages/openclaw-upstash-plugin/src/index.test.ts
+++ b/packages/openclaw-upstash-plugin/src/index.test.ts
@@ -1,0 +1,131 @@
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock dependencies before importing the module under test
+vi.mock("@easy-flow/upstash-vector-client", () => ({
+  UpstashVectorClient: vi.fn().mockImplementation(() => ({})),
+}));
+
+vi.mock("@easy-flow/pinecone-context-engine", () => ({
+  PineconeContextEngine: vi.fn().mockImplementation(() => ({
+    info: { id: "pinecone", name: "test", version: "1.0.0" },
+  })),
+}));
+
+import { PineconeContextEngine } from "@easy-flow/pinecone-context-engine";
+import { UpstashVectorClient } from "@easy-flow/upstash-vector-client";
+import register from "./index.js";
+
+function createMockApi(config: Record<string, unknown> = {}) {
+  let registeredFactory: (() => unknown) | null = null;
+
+  return {
+    pluginConfig: config,
+    logger: {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    },
+    registerContextEngine: vi.fn((_name: string, factory: () => unknown) => {
+      registeredFactory = factory;
+    }),
+    getRegisteredFactory: () => registeredFactory,
+  };
+}
+
+describe("openclaw-upstash-plugin", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env = { ...originalEnv };
+    delete process.env.UPSTASH_VECTOR_REST_URL;
+    delete process.env.UPSTASH_VECTOR_REST_TOKEN;
+    delete process.env.OPENCLAW_AGENT_ID;
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  it("should disable plugin when credentials are missing", () => {
+    const api = createMockApi();
+
+    register(api as never);
+
+    expect(api.logger.warn).toHaveBeenCalledWith(expect.stringContaining("plugin disabled"));
+    expect(api.registerContextEngine).not.toHaveBeenCalled();
+  });
+
+  it("should register context engine with env vars", () => {
+    process.env.UPSTASH_VECTOR_REST_URL = "https://test.upstash.io";
+    process.env.UPSTASH_VECTOR_REST_TOKEN = "test-token";
+    process.env.OPENCLAW_AGENT_ID = "mell";
+
+    const api = createMockApi();
+
+    register(api as never);
+
+    expect(api.registerContextEngine).toHaveBeenCalledWith("upstash-memory", expect.any(Function));
+    expect(api.logger.info).toHaveBeenCalledWith(expect.stringContaining("agentId: mell"));
+  });
+
+  it("should register context engine with plugin config", () => {
+    const api = createMockApi({
+      url: "https://config.upstash.io",
+      token: "config-token",
+      agentId: "tom",
+      compactAfterDays: 14,
+    });
+
+    register(api as never);
+
+    expect(api.registerContextEngine).toHaveBeenCalledWith("upstash-memory", expect.any(Function));
+
+    // Invoke the factory
+    const factory = api.getRegisteredFactory();
+    factory?.();
+
+    expect(UpstashVectorClient).toHaveBeenCalledWith({
+      url: "https://config.upstash.io",
+      token: "config-token",
+    });
+    expect(PineconeContextEngine).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentId: "tom",
+        compactAfterDays: 14,
+      }),
+    );
+  });
+
+  it("should use default agentId when not specified", () => {
+    process.env.UPSTASH_VECTOR_REST_URL = "https://test.upstash.io";
+    process.env.UPSTASH_VECTOR_REST_TOKEN = "test-token";
+
+    const api = createMockApi();
+
+    register(api as never);
+
+    expect(api.logger.info).toHaveBeenCalledWith(expect.stringContaining("agentId: default"));
+  });
+
+  it("should prefer plugin config over env vars", () => {
+    process.env.UPSTASH_VECTOR_REST_URL = "https://env.upstash.io";
+    process.env.UPSTASH_VECTOR_REST_TOKEN = "env-token";
+
+    const api = createMockApi({
+      url: "https://config.upstash.io",
+      token: "config-token",
+    });
+
+    register(api as never);
+
+    const factory = api.getRegisteredFactory();
+    factory?.();
+
+    expect(UpstashVectorClient).toHaveBeenCalledWith({
+      url: "https://config.upstash.io",
+      token: "config-token",
+    });
+  });
+});

--- a/packages/openclaw-upstash-plugin/src/index.ts
+++ b/packages/openclaw-upstash-plugin/src/index.ts
@@ -1,0 +1,44 @@
+import { PineconeContextEngine } from "@easy-flow/pinecone-context-engine";
+import { UpstashVectorClient } from "@easy-flow/upstash-vector-client";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+
+type PluginConfig = {
+  url?: string;
+  token?: string;
+  agentId?: string;
+  compactAfterDays?: number;
+  memoryHint?: string;
+  minQueryTokens?: number;
+};
+
+export default function register(api: OpenClawPluginApi): void {
+  const cfg = (api.pluginConfig ?? {}) as PluginConfig;
+
+  const url = cfg.url ?? process.env.UPSTASH_VECTOR_REST_URL;
+  const token = cfg.token ?? process.env.UPSTASH_VECTOR_REST_TOKEN;
+
+  if (!url || !token) {
+    api.logger.warn(
+      "upstash-memory: UPSTASH_VECTOR_REST_URL / UPSTASH_VECTOR_REST_TOKEN not set — plugin disabled",
+    );
+    return;
+  }
+
+  const agentId = cfg.agentId ?? process.env.OPENCLAW_AGENT_ID ?? "default";
+  const compactAfterDays = cfg.compactAfterDays ?? 7;
+
+  api.registerContextEngine("upstash-memory", () => {
+    const client = new UpstashVectorClient({ url, token });
+    return new PineconeContextEngine({
+      pineconeClient: client,
+      agentId,
+      compactAfterDays,
+      memoryHint: cfg.memoryHint,
+      minQueryTokens: cfg.minQueryTokens,
+    });
+  });
+
+  api.logger.info(
+    `upstash-memory: registered (agentId: ${agentId}, compactAfterDays: ${compactAfterDays})`,
+  );
+}

--- a/packages/openclaw-upstash-plugin/tsconfig.json
+++ b/packages/openclaw-upstash-plugin/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./upstash-memory",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/packages/pgvector-client/package.json
+++ b/packages/pgvector-client/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@easy-flow/pgvector-client",
+  "version": "1.0.0",
+  "private": true,
+  "description": "PostgreSQL pgvector client implementing IPineconeClient for Easy Flow Agent memory",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./src/index.ts"
+    }
+  },
+  "scripts": {
+    "test": "vitest run",
+    "build": "tsc"
+  },
+  "dependencies": {
+    "@easy-flow/pinecone-client": "1.0.0",
+    "@google/generative-ai": "^0.24.0",
+    "pg": "^8.13.0",
+    "pgvector": "^0.2.0"
+  },
+  "devDependencies": {
+    "@types/pg": "^8.11.0",
+    "typescript": "^5.7.0",
+    "vitest": "^3.0.0"
+  }
+}

--- a/packages/pgvector-client/package.json
+++ b/packages/pgvector-client/package.json
@@ -15,7 +15,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@easy-flow/pinecone-client": "1.0.0",
+    "@easy-flow/pinecone-client": "*",
     "@google/generative-ai": "^0.24.0",
     "pg": "^8.13.0",
     "pgvector": "^0.2.0"

--- a/packages/pgvector-client/src/client.test.ts
+++ b/packages/pgvector-client/src/client.test.ts
@@ -1,0 +1,222 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { PgVectorClient } from "./client.js";
+
+// Mock pg
+const mockQuery = vi.fn().mockResolvedValue({ rows: [] });
+const mockRelease = vi.fn();
+const mockConnect = vi.fn().mockResolvedValue({
+  query: mockQuery,
+  release: mockRelease,
+});
+const mockEnd = vi.fn().mockResolvedValue(undefined);
+
+vi.mock("pg", () => ({
+  Pool: vi.fn().mockImplementation(() => ({
+    connect: mockConnect,
+    end: mockEnd,
+  })),
+}));
+
+// Mock pgvector
+vi.mock("pgvector/pg", () => ({
+  default: {
+    registerTypes: vi.fn().mockResolvedValue(undefined),
+    toSql: vi.fn((v: number[]) => `[${v.join(",")}]`),
+  },
+}));
+
+// Mock embedding service
+const mockEmbed = vi.fn().mockResolvedValue([[0.1, 0.2, 0.3]]);
+vi.mock("./embedding.js", () => ({
+  GeminiEmbeddingService: vi.fn().mockImplementation(() => ({
+    embed: mockEmbed,
+  })),
+}));
+
+// Mock schema
+vi.mock("./schema.js", () => ({
+  ensureSchema: vi.fn().mockResolvedValue(undefined),
+}));
+
+function makeChunk(agentId: string, sourceFile: string, chunkIndex: number, text: string) {
+  return {
+    id: `${agentId}:${sourceFile}:${chunkIndex}`,
+    text,
+    metadata: {
+      agentId,
+      sourceFile,
+      sourceType: "session_turn" as const,
+      chunkIndex,
+      createdAt: Date.now(),
+    },
+  };
+}
+
+describe("PgVectorClient", () => {
+  let client: PgVectorClient;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockQuery.mockResolvedValue({ rows: [] });
+    mockEmbed.mockResolvedValue([[0.1, 0.2, 0.3]]);
+    client = new PgVectorClient({
+      databaseUrl: "postgres://test:test@localhost:5432/test",
+      geminiApiKey: "test-key",
+    });
+  });
+
+  describe("ensureIndex", () => {
+    it("should call ensureSchema", async () => {
+      const { ensureSchema } = await import("./schema.js");
+      await client.ensureIndex();
+      expect(ensureSchema).toHaveBeenCalled();
+    });
+  });
+
+  describe("upsert", () => {
+    it("should embed texts and insert with ON CONFLICT upsert", async () => {
+      mockEmbed.mockResolvedValueOnce([[0.1, 0.2, 0.3]]);
+      const chunks = [makeChunk("mell", "session:abc:hash", 0, "hello world")];
+
+      await client.upsert(chunks);
+
+      expect(mockEmbed).toHaveBeenCalledWith(["hello world"], "RETRIEVAL_DOCUMENT");
+      expect(mockQuery).toHaveBeenCalledWith(
+        expect.stringContaining("INSERT INTO memory_vectors"),
+        expect.arrayContaining(["mell:session:abc:hash:0", "agent:mell"]),
+      );
+    });
+
+    it("should reject mixed agentId chunks", async () => {
+      const chunks = [makeChunk("mell", "file1", 0, "a"), makeChunk("tom", "file1", 0, "b")];
+      await expect(client.upsert(chunks)).rejects.toThrow("same agentId");
+    });
+
+    it("should skip empty chunks", async () => {
+      await client.upsert([]);
+      expect(mockEmbed).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("query", () => {
+    it("should embed query text and search by cosine distance", async () => {
+      mockEmbed.mockResolvedValueOnce([[0.1, 0.2, 0.3]]);
+      mockQuery.mockResolvedValueOnce({
+        rows: [
+          {
+            id: "mell:session:abc:0",
+            score: 0.9,
+            text: "hello",
+            metadata: {
+              agentId: "mell",
+              sourceFile: "session:abc",
+              sourceType: "session_turn",
+              chunkIndex: 0,
+              createdAt: 1000,
+              text: "hello",
+            },
+          },
+        ],
+      });
+
+      const results = await client.query({
+        text: "hello",
+        agentId: "mell",
+        topK: 10,
+        minScore: 0.5,
+      });
+
+      expect(mockEmbed).toHaveBeenCalledWith(["hello"], "RETRIEVAL_QUERY");
+      expect(mockQuery).toHaveBeenCalledWith(
+        expect.stringContaining("1 - (embedding <=>"),
+        expect.arrayContaining(["agent:mell"]),
+      );
+      expect(results).toHaveLength(1);
+      expect(results[0].score).toBe(0.9);
+    });
+
+    it("should filter by minScore", async () => {
+      mockEmbed.mockResolvedValueOnce([[0.1, 0.2, 0.3]]);
+      mockQuery.mockResolvedValueOnce({
+        rows: [
+          { id: "mell:a:0", score: 0.9, text: "high", metadata: { text: "high" } },
+          { id: "mell:b:0", score: 0.3, text: "low", metadata: { text: "low" } },
+        ],
+      });
+
+      const results = await client.query({
+        text: "test",
+        agentId: "mell",
+        minScore: 0.5,
+      });
+
+      expect(results).toHaveLength(1);
+      expect(results[0].chunk.text).toBe("high");
+    });
+
+    it("should apply category filter", async () => {
+      mockEmbed.mockResolvedValueOnce([[0.1, 0.2, 0.3]]);
+      mockQuery.mockResolvedValueOnce({ rows: [] });
+
+      await client.query({
+        text: "test",
+        agentId: "mell",
+        filterCategory: "conversation",
+      });
+
+      expect(mockQuery).toHaveBeenCalledWith(
+        expect.stringContaining("metadata->>'category'"),
+        expect.arrayContaining(["conversation"]),
+      );
+    });
+  });
+
+  describe("delete", () => {
+    it("should delete by IDs within namespace", async () => {
+      await client.delete(["mell:file:0", "mell:file:1"]);
+
+      expect(mockQuery).toHaveBeenCalledWith(
+        expect.stringContaining("DELETE FROM memory_vectors"),
+        ["agent:mell", ["mell:file:0", "mell:file:1"]],
+      );
+    });
+
+    it("should reject mixed agentId IDs", async () => {
+      await expect(client.delete(["mell:f:0", "tom:f:0"])).rejects.toThrow("same agentId");
+    });
+
+    it("should skip empty IDs", async () => {
+      await client.delete([]);
+      expect(mockQuery).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("deleteBySource", () => {
+    it("should delete by ID prefix using LIKE", async () => {
+      await client.deleteBySource("mell", "session:abc");
+
+      expect(mockQuery).toHaveBeenCalledWith(
+        expect.stringContaining("DELETE FROM memory_vectors WHERE namespace = $1 AND id LIKE $2"),
+        ["agent:mell", "mell:session:abc:%"],
+      );
+    });
+  });
+
+  describe("deleteNamespace", () => {
+    it("should delete all vectors in namespace", async () => {
+      await client.deleteNamespace("mell");
+
+      expect(mockQuery).toHaveBeenCalledWith(
+        expect.stringContaining("DELETE FROM memory_vectors WHERE namespace = $1"),
+        ["agent:mell"],
+      );
+    });
+  });
+
+  describe("dispose", () => {
+    it("should end the pool", async () => {
+      await client.dispose();
+      expect(mockEnd).toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/pgvector-client/src/client.test.ts
+++ b/packages/pgvector-client/src/client.test.ts
@@ -202,6 +202,15 @@ describe("PgVectorClient", () => {
         ["agent:mell", "mell:session:abc:%"],
       );
     });
+
+    it("should escape LIKE special chars in agentId and sourceFile", async () => {
+      await client.deleteBySource("agent%1", "file_name\\path");
+
+      expect(mockQuery).toHaveBeenCalledWith(expect.stringContaining("id LIKE $2 ESCAPE"), [
+        "agent:agent%1",
+        "agent\\%1:file\\_name\\\\path:%",
+      ]);
+    });
   });
 
   describe("deleteNamespace", () => {

--- a/packages/pgvector-client/src/client.test.ts
+++ b/packages/pgvector-client/src/client.test.ts
@@ -196,7 +196,9 @@ describe("PgVectorClient", () => {
       await client.deleteBySource("mell", "session:abc");
 
       expect(mockQuery).toHaveBeenCalledWith(
-        expect.stringContaining("DELETE FROM memory_vectors WHERE namespace = $1 AND id LIKE $2"),
+        expect.stringContaining(
+          "DELETE FROM memory_vectors WHERE namespace = $1 AND id LIKE $2 ESCAPE",
+        ),
         ["agent:mell", "mell:session:abc:%"],
       );
     });

--- a/packages/pgvector-client/src/client.test.ts
+++ b/packages/pgvector-client/src/client.test.ts
@@ -87,6 +87,19 @@ describe("PgVectorClient", () => {
       );
     });
 
+    it("should batch upserts when exceeding UPSERT_BATCH_SIZE (100)", async () => {
+      const chunks = Array.from({ length: 101 }, (_, i) =>
+        makeChunk("mell", "file", i, `text-${i}`),
+      );
+      const embeddings = Array.from({ length: 101 }, () => [0.1, 0.2, 0.3]);
+      mockEmbed.mockResolvedValueOnce(embeddings);
+
+      await client.upsert(chunks);
+
+      // Should call query twice: batch of 100, then batch of 1
+      expect(mockQuery).toHaveBeenCalledTimes(2);
+    });
+
     it("should reject mixed agentId chunks", async () => {
       const chunks = [makeChunk("mell", "file1", 0, "a"), makeChunk("tom", "file1", 0, "b")];
       await expect(client.upsert(chunks)).rejects.toThrow("same agentId");

--- a/packages/pgvector-client/src/client.ts
+++ b/packages/pgvector-client/src/client.ts
@@ -1,0 +1,202 @@
+import type {
+  IPineconeClient,
+  MemoryChunk,
+  QueryParams,
+  QueryResult,
+} from "@easy-flow/pinecone-client";
+import { Pool } from "pg";
+import pgvector from "pgvector/pg";
+import { GeminiEmbeddingService } from "./embedding.js";
+import { ensureSchema } from "./schema.js";
+
+const UPSERT_BATCH_SIZE = 100;
+
+export class PgVectorClient implements IPineconeClient {
+  private readonly pool: Pool;
+  private readonly embeddingService: GeminiEmbeddingService;
+  private typesRegistered = false;
+
+  constructor(config: { databaseUrl: string; geminiApiKey: string }) {
+    this.pool = new Pool({ connectionString: config.databaseUrl, max: 5 });
+    this.embeddingService = new GeminiEmbeddingService(config.geminiApiKey);
+  }
+
+  private async getClient() {
+    const client = await this.pool.connect();
+    if (!this.typesRegistered) {
+      await pgvector.registerTypes(client);
+      this.typesRegistered = true;
+    }
+    return client;
+  }
+
+  async ensureIndex(): Promise<void> {
+    await ensureSchema(this.pool);
+  }
+
+  async upsert(chunks: MemoryChunk[]): Promise<void> {
+    if (chunks.length === 0) return;
+
+    const agentId = chunks[0].metadata.agentId;
+    const mixed = chunks.some((c) => c.metadata.agentId !== agentId);
+    if (mixed) {
+      throw new Error("All chunks must have the same agentId");
+    }
+
+    const namespace = `agent:${agentId}`;
+    const texts = chunks.map((c) => c.text);
+    const embeddings = await this.embeddingService.embed(texts, "RETRIEVAL_DOCUMENT");
+
+    const client = await this.getClient();
+    try {
+      for (let i = 0; i < chunks.length; i += UPSERT_BATCH_SIZE) {
+        const batch = chunks.slice(i, i + UPSERT_BATCH_SIZE);
+        const batchEmbeddings = embeddings.slice(i, i + UPSERT_BATCH_SIZE);
+
+        const values: string[] = [];
+        const params: unknown[] = [];
+        let paramIdx = 1;
+
+        for (let j = 0; j < batch.length; j++) {
+          const chunk = batch[j];
+          values.push(
+            `($${paramIdx}, $${paramIdx + 1}, $${paramIdx + 2}, $${paramIdx + 3}, $${paramIdx + 4}, $${paramIdx + 5})`,
+          );
+          params.push(
+            chunk.id,
+            namespace,
+            pgvector.toSql(batchEmbeddings[j]),
+            JSON.stringify({ ...chunk.metadata, text: chunk.text }),
+            chunk.text,
+            chunk.metadata.createdAt,
+          );
+          paramIdx += 6;
+        }
+
+        await client.query(
+          `INSERT INTO memory_vectors (id, namespace, embedding, metadata, text, created_at)
+           VALUES ${values.join(", ")}
+           ON CONFLICT (namespace, id) DO UPDATE SET
+             embedding = EXCLUDED.embedding,
+             metadata = EXCLUDED.metadata,
+             text = EXCLUDED.text,
+             created_at = EXCLUDED.created_at`,
+          params,
+        );
+      }
+    } finally {
+      client.release();
+    }
+  }
+
+  async query(params: QueryParams): Promise<QueryResult[]> {
+    const { text, agentId, topK = 20, minScore = 0.7, filterCategory } = params;
+    const namespace = `agent:${agentId}`;
+
+    const [queryEmbedding] = await this.embeddingService.embed([text], "RETRIEVAL_QUERY");
+
+    const client = await this.getClient();
+    try {
+      let sql = `
+        SELECT id, metadata, text,
+               1 - (embedding <=> $1) AS score
+        FROM memory_vectors
+        WHERE namespace = $2
+      `;
+      const sqlParams: unknown[] = [pgvector.toSql(queryEmbedding), namespace];
+      let paramIdx = 3;
+
+      if (filterCategory) {
+        sql += ` AND metadata->>'category' = $${paramIdx}`;
+        sqlParams.push(filterCategory);
+        paramIdx++;
+      }
+
+      sql += ` ORDER BY embedding <=> $1 LIMIT $${paramIdx}`;
+      sqlParams.push(topK);
+
+      const result = await client.query(sql, sqlParams);
+
+      return result.rows
+        .filter((row: { score: number }) => row.score >= minScore)
+        .map(
+          (row: {
+            id: string;
+            metadata: Record<string, unknown>;
+            text: string;
+            score: number;
+          }) => ({
+            chunk: {
+              id: row.id,
+              text: (row.metadata?.text as string) ?? row.text,
+              metadata: {
+                agentId: (row.metadata?.agentId as string) ?? agentId,
+                sourceFile: (row.metadata?.sourceFile as string) ?? "",
+                sourceType:
+                  (row.metadata?.sourceType as MemoryChunk["metadata"]["sourceType"]) ??
+                  "memory_file",
+                chunkIndex: (row.metadata?.chunkIndex as number) ?? 0,
+                createdAt: (row.metadata?.createdAt as number) ?? 0,
+                turnId: row.metadata?.turnId as string | undefined,
+                role: row.metadata?.role as "user" | "assistant" | undefined,
+                category: row.metadata?.category as string | undefined,
+              },
+            },
+            score: row.score,
+          }),
+        );
+    } finally {
+      client.release();
+    }
+  }
+
+  async delete(ids: string[]): Promise<void> {
+    if (ids.length === 0) return;
+
+    const agentId = ids[0].split(":")[0];
+    const mixed = ids.some((id) => id.split(":")[0] !== agentId);
+    if (mixed) {
+      throw new Error("All ids must belong to the same agentId");
+    }
+
+    const namespace = `agent:${agentId}`;
+    const client = await this.getClient();
+    try {
+      await client.query("DELETE FROM memory_vectors WHERE namespace = $1 AND id = ANY($2)", [
+        namespace,
+        ids,
+      ]);
+    } finally {
+      client.release();
+    }
+  }
+
+  async deleteBySource(agentId: string, sourceFile: string): Promise<void> {
+    const namespace = `agent:${agentId}`;
+    const prefix = `${agentId}:${sourceFile}:%`;
+
+    const client = await this.getClient();
+    try {
+      await client.query("DELETE FROM memory_vectors WHERE namespace = $1 AND id LIKE $2", [
+        namespace,
+        prefix,
+      ]);
+    } finally {
+      client.release();
+    }
+  }
+
+  async deleteNamespace(agentId: string): Promise<void> {
+    const namespace = `agent:${agentId}`;
+    const client = await this.getClient();
+    try {
+      await client.query("DELETE FROM memory_vectors WHERE namespace = $1", [namespace]);
+    } finally {
+      client.release();
+    }
+  }
+
+  async dispose(): Promise<void> {
+    await this.pool.end();
+  }
+}

--- a/packages/pgvector-client/src/client.ts
+++ b/packages/pgvector-client/src/client.ts
@@ -4,6 +4,7 @@ import type {
   QueryParams,
   QueryResult,
 } from "@easy-flow/pinecone-client";
+import { TaskType } from "@google/generative-ai";
 import { Pool } from "pg";
 import pgvector from "pgvector/pg";
 import { GeminiEmbeddingService } from "./embedding.js";
@@ -45,7 +46,7 @@ export class PgVectorClient implements IPineconeClient {
 
     const namespace = `agent:${agentId}`;
     const texts = chunks.map((c) => c.text);
-    const embeddings = await this.embeddingService.embed(texts, "RETRIEVAL_DOCUMENT");
+    const embeddings = await this.embeddingService.embed(texts, TaskType.RETRIEVAL_DOCUMENT);
 
     const client = await this.getClient();
     try {
@@ -93,7 +94,7 @@ export class PgVectorClient implements IPineconeClient {
     const { text, agentId, topK = 20, minScore = 0.7, filterCategory } = params;
     const namespace = `agent:${agentId}`;
 
-    const [queryEmbedding] = await this.embeddingService.embed([text], "RETRIEVAL_QUERY");
+    const [queryEmbedding] = await this.embeddingService.embed([text], TaskType.RETRIEVAL_QUERY);
 
     const client = await this.getClient();
     try {
@@ -173,14 +174,15 @@ export class PgVectorClient implements IPineconeClient {
 
   async deleteBySource(agentId: string, sourceFile: string): Promise<void> {
     const namespace = `agent:${agentId}`;
-    const prefix = `${agentId}:${sourceFile}:%`;
+    const escapedSourceFile = sourceFile.replace(/[%_\\]/g, "\\$&");
+    const prefix = `${agentId}:${escapedSourceFile}:%`;
 
     const client = await this.getClient();
     try {
-      await client.query("DELETE FROM memory_vectors WHERE namespace = $1 AND id LIKE $2", [
-        namespace,
-        prefix,
-      ]);
+      await client.query(
+        "DELETE FROM memory_vectors WHERE namespace = $1 AND id LIKE $2 ESCAPE '\\'",
+        [namespace, prefix],
+      );
     } finally {
       client.release();
     }

--- a/packages/pgvector-client/src/client.ts
+++ b/packages/pgvector-client/src/client.ts
@@ -25,8 +25,13 @@ export class PgVectorClient implements IPineconeClient {
   private async getClient() {
     const client = await this.pool.connect();
     if (!this.typesRegistered) {
-      await pgvector.registerTypes(client);
-      this.typesRegistered = true;
+      try {
+        await pgvector.registerTypes(client);
+        this.typesRegistered = true;
+      } catch (e) {
+        client.release();
+        throw e;
+      }
     }
     return client;
   }

--- a/packages/pgvector-client/src/client.ts
+++ b/packages/pgvector-client/src/client.ts
@@ -174,8 +174,9 @@ export class PgVectorClient implements IPineconeClient {
 
   async deleteBySource(agentId: string, sourceFile: string): Promise<void> {
     const namespace = `agent:${agentId}`;
+    const escapedAgentId = agentId.replace(/[%_\\]/g, "\\$&");
     const escapedSourceFile = sourceFile.replace(/[%_\\]/g, "\\$&");
-    const prefix = `${agentId}:${escapedSourceFile}:%`;
+    const prefix = `${escapedAgentId}:${escapedSourceFile}:%`;
 
     const client = await this.getClient();
     try {

--- a/packages/pgvector-client/src/embedding.test.ts
+++ b/packages/pgvector-client/src/embedding.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { GeminiEmbeddingService } from "./embedding.js";
+
+const mockBatchEmbedContents = vi.fn();
+
+vi.mock("@google/generative-ai", () => ({
+  GoogleGenerativeAI: vi.fn().mockImplementation(() => ({
+    getGenerativeModel: () => ({
+      batchEmbedContents: mockBatchEmbedContents,
+    }),
+  })),
+  TaskType: {
+    RETRIEVAL_DOCUMENT: "RETRIEVAL_DOCUMENT",
+    RETRIEVAL_QUERY: "RETRIEVAL_QUERY",
+  },
+}));
+
+describe("GeminiEmbeddingService", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should return empty array for empty input", async () => {
+    const service = new GeminiEmbeddingService("test-key");
+    const result = await service.embed([], "RETRIEVAL_DOCUMENT" as never);
+
+    expect(result).toEqual([]);
+    expect(mockBatchEmbedContents).not.toHaveBeenCalled();
+  });
+
+  it("should embed a single text", async () => {
+    mockBatchEmbedContents.mockResolvedValueOnce({
+      embeddings: [{ values: [0.1, 0.2, 0.3] }],
+    });
+
+    const service = new GeminiEmbeddingService("test-key");
+    const result = await service.embed(["hello"], "RETRIEVAL_DOCUMENT" as never);
+
+    expect(result).toEqual([[0.1, 0.2, 0.3]]);
+    expect(mockBatchEmbedContents).toHaveBeenCalledTimes(1);
+    expect(mockBatchEmbedContents).toHaveBeenCalledWith({
+      requests: [
+        {
+          content: { role: "user", parts: [{ text: "hello" }] },
+          taskType: "RETRIEVAL_DOCUMENT",
+        },
+      ],
+    });
+  });
+
+  it("should batch texts when exceeding BATCH_SIZE (96)", async () => {
+    const texts = Array.from({ length: 100 }, (_, i) => `text-${i}`);
+    const batch1Embeddings = Array.from({ length: 96 }, () => ({ values: [0.1] }));
+    const batch2Embeddings = Array.from({ length: 4 }, () => ({ values: [0.2] }));
+
+    mockBatchEmbedContents
+      .mockResolvedValueOnce({ embeddings: batch1Embeddings })
+      .mockResolvedValueOnce({ embeddings: batch2Embeddings });
+
+    const service = new GeminiEmbeddingService("test-key");
+    const result = await service.embed(texts, "RETRIEVAL_QUERY" as never);
+
+    expect(result).toHaveLength(100);
+    expect(mockBatchEmbedContents).toHaveBeenCalledTimes(2);
+
+    // First batch: 96 texts
+    const firstCall = mockBatchEmbedContents.mock.calls[0][0];
+    expect(firstCall.requests).toHaveLength(96);
+
+    // Second batch: 4 texts
+    const secondCall = mockBatchEmbedContents.mock.calls[1][0];
+    expect(secondCall.requests).toHaveLength(4);
+
+    // Verify results are concatenated in order
+    expect(result.slice(0, 96).every((v: number[]) => v[0] === 0.1)).toBe(true);
+    expect(result.slice(96).every((v: number[]) => v[0] === 0.2)).toBe(true);
+  });
+
+  it("should have DIMENSIONS = 768", () => {
+    expect(GeminiEmbeddingService.DIMENSIONS).toBe(768);
+  });
+});

--- a/packages/pgvector-client/src/embedding.ts
+++ b/packages/pgvector-client/src/embedding.ts
@@ -1,4 +1,4 @@
-import { GoogleGenerativeAI } from "@google/generative-ai";
+import { GoogleGenerativeAI, type TaskType } from "@google/generative-ai";
 
 const MODEL = "text-embedding-004";
 const BATCH_SIZE = 96;
@@ -14,7 +14,7 @@ export class GeminiEmbeddingService {
 
   async embed(
     texts: string[],
-    taskType: "RETRIEVAL_DOCUMENT" | "RETRIEVAL_QUERY",
+    taskType: TaskType.RETRIEVAL_DOCUMENT | TaskType.RETRIEVAL_QUERY,
   ): Promise<number[][]> {
     if (texts.length === 0) return [];
 

--- a/packages/pgvector-client/src/embedding.ts
+++ b/packages/pgvector-client/src/embedding.ts
@@ -1,0 +1,40 @@
+import { GoogleGenerativeAI } from "@google/generative-ai";
+
+const MODEL = "text-embedding-004";
+const BATCH_SIZE = 96;
+
+export class GeminiEmbeddingService {
+  static readonly DIMENSIONS = 768;
+
+  private readonly client: GoogleGenerativeAI;
+
+  constructor(apiKey: string) {
+    this.client = new GoogleGenerativeAI(apiKey);
+  }
+
+  async embed(
+    texts: string[],
+    taskType: "RETRIEVAL_DOCUMENT" | "RETRIEVAL_QUERY",
+  ): Promise<number[][]> {
+    if (texts.length === 0) return [];
+
+    const model = this.client.getGenerativeModel({ model: MODEL });
+    const results: number[][] = [];
+
+    for (let i = 0; i < texts.length; i += BATCH_SIZE) {
+      const batch = texts.slice(i, i + BATCH_SIZE);
+      const response = await model.batchEmbedContents({
+        requests: batch.map((text) => ({
+          content: { role: "user", parts: [{ text }] },
+          taskType,
+        })),
+      });
+
+      for (const item of response.embeddings) {
+        results.push(item.values);
+      }
+    }
+
+    return results;
+  }
+}

--- a/packages/pgvector-client/src/index.ts
+++ b/packages/pgvector-client/src/index.ts
@@ -1,3 +1,2 @@
 export { PgVectorClient } from "./client.js";
 export { GeminiEmbeddingService } from "./embedding.js";
-export { ensureSchema } from "./schema.js";

--- a/packages/pgvector-client/src/index.ts
+++ b/packages/pgvector-client/src/index.ts
@@ -1,0 +1,3 @@
+export { PgVectorClient } from "./client.js";
+export { GeminiEmbeddingService } from "./embedding.js";
+export { ensureSchema } from "./schema.js";

--- a/packages/pgvector-client/src/schema.ts
+++ b/packages/pgvector-client/src/schema.ts
@@ -1,0 +1,33 @@
+import type { Pool } from "pg";
+import pgvector from "pgvector/pg";
+
+const DIMENSIONS = 768;
+
+export async function ensureSchema(pool: Pool): Promise<void> {
+  const client = await pool.connect();
+  try {
+    await client.query("CREATE EXTENSION IF NOT EXISTS vector");
+    await pgvector.registerTypes(client);
+
+    await client.query(`
+      CREATE TABLE IF NOT EXISTS memory_vectors (
+        id TEXT NOT NULL,
+        namespace TEXT NOT NULL,
+        embedding vector(${DIMENSIONS}),
+        metadata JSONB NOT NULL DEFAULT '{}',
+        text TEXT NOT NULL DEFAULT '',
+        created_at BIGINT NOT NULL DEFAULT 0,
+        PRIMARY KEY (namespace, id)
+      )
+    `);
+
+    // HNSW index for cosine similarity — better for small-to-medium datasets
+    await client.query(`
+      CREATE INDEX IF NOT EXISTS idx_memory_vectors_embedding
+      ON memory_vectors
+      USING hnsw (embedding vector_cosine_ops)
+    `);
+  } finally {
+    client.release();
+  }
+}

--- a/packages/pgvector-client/src/schema.ts
+++ b/packages/pgvector-client/src/schema.ts
@@ -1,7 +1,6 @@
 import type { Pool } from "pg";
 import pgvector from "pgvector/pg";
-
-const DIMENSIONS = 768;
+import { GeminiEmbeddingService } from "./embedding.js";
 
 export async function ensureSchema(pool: Pool): Promise<void> {
   const client = await pool.connect();
@@ -13,7 +12,7 @@ export async function ensureSchema(pool: Pool): Promise<void> {
       CREATE TABLE IF NOT EXISTS memory_vectors (
         id TEXT NOT NULL,
         namespace TEXT NOT NULL,
-        embedding vector(${DIMENSIONS}),
+        embedding vector(${GeminiEmbeddingService.DIMENSIONS}),
         metadata JSONB NOT NULL DEFAULT '{}',
         text TEXT NOT NULL DEFAULT '',
         created_at BIGINT NOT NULL DEFAULT 0,

--- a/packages/pgvector-client/src/schema.ts
+++ b/packages/pgvector-client/src/schema.ts
@@ -27,6 +27,12 @@ export async function ensureSchema(pool: Pool): Promise<void> {
       ON memory_vectors
       USING hnsw (embedding vector_cosine_ops)
     `);
+
+    // B-tree index for namespace filtering (used in query, delete, deleteBySource)
+    await client.query(`
+      CREATE INDEX IF NOT EXISTS idx_memory_vectors_namespace
+      ON memory_vectors (namespace)
+    `);
   } finally {
     client.release();
   }

--- a/packages/pgvector-client/tsconfig.json
+++ b/packages/pgvector-client/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "ES2022",
-    "moduleResolution": "bundler",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,

--- a/packages/pgvector-client/tsconfig.json
+++ b/packages/pgvector-client/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts", "dist"]
+}

--- a/packages/upstash-vector-client/package.json
+++ b/packages/upstash-vector-client/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@easy-flow/upstash-vector-client",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Upstash Vector client implementing IPineconeClient for Easy Flow Agent memory",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./src/index.ts"
+    }
+  },
+  "scripts": {
+    "test": "vitest run",
+    "build": "tsc"
+  },
+  "dependencies": {
+    "@upstash/vector": "^1.2.0",
+    "@easy-flow/pinecone-client": "1.0.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.7.0",
+    "vitest": "^3.0.0"
+  }
+}

--- a/packages/upstash-vector-client/package.json
+++ b/packages/upstash-vector-client/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@upstash/vector": "^1.2.0",
-    "@easy-flow/pinecone-client": "1.0.0"
+    "@easy-flow/pinecone-client": "*"
   },
   "devDependencies": {
     "typescript": "^5.7.0",

--- a/packages/upstash-vector-client/src/client.test.ts
+++ b/packages/upstash-vector-client/src/client.test.ts
@@ -150,6 +150,22 @@ describe("UpstashVectorClient", () => {
         }),
       );
     });
+
+    it("should escape single quotes and backslashes in category filter", async () => {
+      mockQuery.mockResolvedValueOnce([]);
+
+      await client.query({
+        text: "test",
+        agentId: "mell",
+        filterCategory: "it's a \\test\\",
+      });
+
+      expect(mockQuery).toHaveBeenCalledWith(
+        expect.objectContaining({
+          filter: "category = 'it\\'s a \\\\test\\\\'",
+        }),
+      );
+    });
   });
 
   describe("delete", () => {

--- a/packages/upstash-vector-client/src/client.test.ts
+++ b/packages/upstash-vector-client/src/client.test.ts
@@ -1,0 +1,220 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { UpstashVectorClient } from "./client.js";
+
+// Mock @upstash/vector
+const mockInfo = vi.fn().mockResolvedValue({ vectorCount: 0 });
+const mockUpsert = vi.fn().mockResolvedValue(undefined);
+const mockQuery = vi.fn().mockResolvedValue([]);
+const mockDelete = vi.fn().mockResolvedValue(undefined);
+const mockReset = vi.fn().mockResolvedValue(undefined);
+const mockRange = vi.fn().mockResolvedValue({ vectors: [], nextCursor: "" });
+
+const mockNamespace = vi.fn().mockReturnValue({
+  upsert: mockUpsert,
+  query: mockQuery,
+  delete: mockDelete,
+  reset: mockReset,
+  range: mockRange,
+});
+
+vi.mock("@upstash/vector", () => ({
+  Index: vi.fn().mockImplementation(() => ({
+    info: mockInfo,
+    namespace: mockNamespace,
+  })),
+}));
+
+function makeChunk(agentId: string, sourceFile: string, chunkIndex: number, text: string) {
+  return {
+    id: `${agentId}:${sourceFile}:${chunkIndex}`,
+    text,
+    metadata: {
+      agentId,
+      sourceFile,
+      sourceType: "session_turn" as const,
+      chunkIndex,
+      createdAt: Date.now(),
+    },
+  };
+}
+
+describe("UpstashVectorClient", () => {
+  let client: UpstashVectorClient;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    client = new UpstashVectorClient({ url: "https://test.upstash.io", token: "test-token" });
+  });
+
+  describe("ensureIndex", () => {
+    it("should call index.info() to verify connectivity", async () => {
+      await client.ensureIndex();
+      expect(mockInfo).toHaveBeenCalled();
+    });
+  });
+
+  describe("upsert", () => {
+    it("should upsert chunks using data field for built-in embedding", async () => {
+      const chunks = [makeChunk("mell", "session:abc:hash", 0, "hello world")];
+
+      await client.upsert(chunks);
+
+      expect(mockNamespace).toHaveBeenCalledWith("agent:mell");
+      expect(mockUpsert).toHaveBeenCalledWith([
+        {
+          id: "mell:session:abc:hash:0",
+          data: "hello world",
+          metadata: {
+            ...chunks[0].metadata,
+            text: "hello world",
+          },
+        },
+      ]);
+    });
+
+    it("should reject mixed agentId chunks", async () => {
+      const chunks = [makeChunk("mell", "file1", 0, "a"), makeChunk("tom", "file1", 0, "b")];
+
+      await expect(client.upsert(chunks)).rejects.toThrow("same agentId");
+    });
+
+    it("should skip empty chunks", async () => {
+      await client.upsert([]);
+      expect(mockUpsert).not.toHaveBeenCalled();
+    });
+
+    it("should batch upserts when exceeding batch size", async () => {
+      const chunks = Array.from({ length: 150 }, (_, i) =>
+        makeChunk("mell", `file:${i}`, i, `text ${i}`),
+      );
+
+      await client.upsert(chunks);
+
+      expect(mockUpsert).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("query", () => {
+    it("should query using data field and filter by minScore", async () => {
+      mockQuery.mockResolvedValueOnce([
+        {
+          id: "mell:session:abc:0",
+          score: 0.9,
+          metadata: {
+            agentId: "mell",
+            sourceFile: "session:abc",
+            sourceType: "session_turn",
+            chunkIndex: 0,
+            createdAt: 1000,
+            text: "hello",
+          },
+        },
+        {
+          id: "mell:session:def:0",
+          score: 0.3,
+          metadata: { text: "low score" },
+        },
+      ]);
+
+      const results = await client.query({
+        text: "hello",
+        agentId: "mell",
+        topK: 10,
+        minScore: 0.5,
+      });
+
+      expect(mockNamespace).toHaveBeenCalledWith("agent:mell");
+      expect(mockQuery).toHaveBeenCalledWith({
+        data: "hello",
+        topK: 10,
+        includeMetadata: true,
+        filter: undefined,
+      });
+      expect(results).toHaveLength(1);
+      expect(results[0].score).toBe(0.9);
+      expect(results[0].chunk.text).toBe("hello");
+    });
+
+    it("should apply category filter", async () => {
+      mockQuery.mockResolvedValueOnce([]);
+
+      await client.query({
+        text: "test",
+        agentId: "mell",
+        filterCategory: "conversation",
+      });
+
+      expect(mockQuery).toHaveBeenCalledWith(
+        expect.objectContaining({
+          filter: "category = 'conversation'",
+        }),
+      );
+    });
+  });
+
+  describe("delete", () => {
+    it("should delete by IDs", async () => {
+      await client.delete(["mell:file:0", "mell:file:1"]);
+
+      expect(mockNamespace).toHaveBeenCalledWith("agent:mell");
+      expect(mockDelete).toHaveBeenCalledWith(["mell:file:0", "mell:file:1"]);
+    });
+
+    it("should reject mixed agentId IDs", async () => {
+      await expect(client.delete(["mell:f:0", "tom:f:0"])).rejects.toThrow("same agentId");
+    });
+
+    it("should skip empty IDs", async () => {
+      await client.delete([]);
+      expect(mockDelete).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("deleteBySource", () => {
+    it("should scan range and delete matching IDs", async () => {
+      mockRange.mockResolvedValueOnce({
+        vectors: [
+          { id: "mell:session:abc:0" },
+          { id: "mell:session:abc:1" },
+          { id: "mell:session:other:0" },
+        ],
+        nextCursor: "",
+      });
+
+      await client.deleteBySource("mell", "session:abc");
+
+      expect(mockRange).toHaveBeenCalledWith({
+        cursor: "0",
+        limit: 100,
+        includeMetadata: false,
+      });
+      expect(mockDelete).toHaveBeenCalledWith(["mell:session:abc:0", "mell:session:abc:1"]);
+    });
+
+    it("should paginate through range results", async () => {
+      mockRange
+        .mockResolvedValueOnce({
+          vectors: [{ id: "mell:f:0" }],
+          nextCursor: "cursor-1",
+        })
+        .mockResolvedValueOnce({
+          vectors: [{ id: "mell:f:1" }],
+          nextCursor: "",
+        });
+
+      await client.deleteBySource("mell", "f");
+
+      expect(mockRange).toHaveBeenCalledTimes(2);
+      expect(mockDelete).toHaveBeenCalledWith(["mell:f:0", "mell:f:1"]);
+    });
+  });
+
+  describe("deleteNamespace", () => {
+    it("should reset the namespace", async () => {
+      await client.deleteNamespace("mell");
+
+      expect(mockNamespace).toHaveBeenCalledWith("agent:mell");
+      expect(mockReset).toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/upstash-vector-client/src/client.ts
+++ b/packages/upstash-vector-client/src/client.ts
@@ -101,7 +101,9 @@ export class UpstashVectorClient implements IPineconeClient {
     }
 
     const ns = this.index.namespace(`agent:${agentId}`);
-    await ns.delete(ids);
+    for (let i = 0; i < ids.length; i += DELETE_BATCH_SIZE) {
+      await ns.delete(ids.slice(i, i + DELETE_BATCH_SIZE));
+    }
   }
 
   async deleteBySource(agentId: string, sourceFile: string): Promise<void> {

--- a/packages/upstash-vector-client/src/client.ts
+++ b/packages/upstash-vector-client/src/client.ts
@@ -58,7 +58,7 @@ export class UpstashVectorClient implements IPineconeClient {
     const ns = this.index.namespace(`agent:${agentId}`);
 
     const filter = filterCategory
-      ? `category = '${filterCategory.replace(/'/g, "\\'")}'`
+      ? `category = '${filterCategory.replace(/\\/g, "\\\\").replace(/'/g, "\\'")}'`
       : undefined;
 
     const results = await ns.query<Record<string, unknown>>({

--- a/packages/upstash-vector-client/src/client.ts
+++ b/packages/upstash-vector-client/src/client.ts
@@ -7,6 +7,7 @@ import type {
 import { Index } from "@upstash/vector";
 
 const UPSERT_BATCH_SIZE = 100;
+const DELETE_BATCH_SIZE = 100;
 const RANGE_PAGE_SIZE = 100;
 
 export class UpstashVectorClient implements IPineconeClient {
@@ -56,7 +57,9 @@ export class UpstashVectorClient implements IPineconeClient {
 
     const ns = this.index.namespace(`agent:${agentId}`);
 
-    const filter = filterCategory ? `category = '${filterCategory}'` : undefined;
+    const filter = filterCategory
+      ? `category = '${filterCategory.replace(/'/g, "\\'")}'`
+      : undefined;
 
     const results = await ns.query<Record<string, unknown>>({
       data: text,
@@ -125,8 +128,8 @@ export class UpstashVectorClient implements IPineconeClient {
       cursor = page.nextCursor;
     } while (cursor !== "" && cursor !== "0");
 
-    if (ids.length > 0) {
-      await ns.delete(ids);
+    for (let i = 0; i < ids.length; i += DELETE_BATCH_SIZE) {
+      await ns.delete(ids.slice(i, i + DELETE_BATCH_SIZE));
     }
   }
 

--- a/packages/upstash-vector-client/src/client.ts
+++ b/packages/upstash-vector-client/src/client.ts
@@ -1,0 +1,137 @@
+import type {
+  IPineconeClient,
+  MemoryChunk,
+  QueryParams,
+  QueryResult,
+} from "@easy-flow/pinecone-client";
+import { Index } from "@upstash/vector";
+
+const UPSERT_BATCH_SIZE = 100;
+const RANGE_PAGE_SIZE = 100;
+
+export class UpstashVectorClient implements IPineconeClient {
+  private readonly index: Index;
+
+  /**
+   * @param config.url   Upstash Vector REST URL
+   * @param config.token Upstash Vector REST token
+   */
+  constructor(config: { url: string; token: string }) {
+    this.index = new Index({ url: config.url, token: config.token });
+  }
+
+  async ensureIndex(): Promise<void> {
+    // Upstash indexes are created via console or REST API.
+    // Verify connectivity by fetching index info.
+    await this.index.info();
+  }
+
+  async upsert(chunks: MemoryChunk[]): Promise<void> {
+    if (chunks.length === 0) return;
+
+    const agentId = chunks[0].metadata.agentId;
+    const mixed = chunks.some((c) => c.metadata.agentId !== agentId);
+    if (mixed) {
+      throw new Error("All chunks must have the same agentId");
+    }
+
+    const ns = this.index.namespace(`agent:${agentId}`);
+
+    const records = chunks.map((chunk) => ({
+      id: chunk.id,
+      data: chunk.text,
+      metadata: {
+        ...chunk.metadata,
+        text: chunk.text,
+      },
+    }));
+
+    for (let i = 0; i < records.length; i += UPSERT_BATCH_SIZE) {
+      await ns.upsert(records.slice(i, i + UPSERT_BATCH_SIZE));
+    }
+  }
+
+  async query(params: QueryParams): Promise<QueryResult[]> {
+    const { text, agentId, topK = 20, minScore = 0.7, filterCategory } = params;
+
+    const ns = this.index.namespace(`agent:${agentId}`);
+
+    const filter = filterCategory ? `category = '${filterCategory}'` : undefined;
+
+    const results = await ns.query<Record<string, unknown>>({
+      data: text,
+      topK,
+      includeMetadata: true,
+      filter,
+    });
+
+    return results
+      .filter((match) => match.score >= minScore)
+      .map((match) => ({
+        chunk: {
+          id: String(match.id),
+          text: (match.metadata?.text as string) ?? "",
+          metadata: {
+            agentId: (match.metadata?.agentId as string) ?? agentId,
+            sourceFile: (match.metadata?.sourceFile as string) ?? "",
+            sourceType:
+              (match.metadata?.sourceType as MemoryChunk["metadata"]["sourceType"]) ??
+              "memory_file",
+            chunkIndex: (match.metadata?.chunkIndex as number) ?? 0,
+            createdAt: (match.metadata?.createdAt as number) ?? 0,
+            turnId: match.metadata?.turnId as string | undefined,
+            role: match.metadata?.role as "user" | "assistant" | undefined,
+            category: match.metadata?.category as string | undefined,
+          },
+        },
+        score: match.score,
+      }));
+  }
+
+  async delete(ids: string[]): Promise<void> {
+    if (ids.length === 0) return;
+
+    const agentId = ids[0].split(":")[0];
+    const mixed = ids.some((id) => id.split(":")[0] !== agentId);
+    if (mixed) {
+      throw new Error("All ids must belong to the same agentId");
+    }
+
+    const ns = this.index.namespace(`agent:${agentId}`);
+    await ns.delete(ids);
+  }
+
+  async deleteBySource(agentId: string, sourceFile: string): Promise<void> {
+    const ns = this.index.namespace(`agent:${agentId}`);
+    const prefix = `${agentId}:${sourceFile}:`;
+
+    // Scan namespace with range and collect matching IDs
+    const ids: string[] = [];
+    let cursor = "0";
+
+    do {
+      const page = await ns.range({
+        cursor,
+        limit: RANGE_PAGE_SIZE,
+        includeMetadata: false,
+      });
+
+      for (const vector of page.vectors) {
+        if (String(vector.id).startsWith(prefix)) {
+          ids.push(String(vector.id));
+        }
+      }
+
+      cursor = page.nextCursor;
+    } while (cursor !== "" && cursor !== "0");
+
+    if (ids.length > 0) {
+      await ns.delete(ids);
+    }
+  }
+
+  async deleteNamespace(agentId: string): Promise<void> {
+    const ns = this.index.namespace(`agent:${agentId}`);
+    await ns.reset();
+  }
+}

--- a/packages/upstash-vector-client/src/index.ts
+++ b/packages/upstash-vector-client/src/index.ts
@@ -1,0 +1,1 @@
+export { UpstashVectorClient } from "./client.js";

--- a/packages/upstash-vector-client/tsconfig.json
+++ b/packages/upstash-vector-client/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "ES2022",
-    "moduleResolution": "bundler",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,

--- a/packages/upstash-vector-client/tsconfig.json
+++ b/packages/upstash-vector-client/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts", "dist"]
+}


### PR DESCRIPTION
## Summary

ベクトル DB を Pinecone（us-east-1）から **Fly.io nrt（東京）の PostgreSQL + pgvector** に移行するためのパッケージ。
エンベッディングは既存の GEMINI_API_KEY（text-embedding-004）を使用。

### 新規パッケージ

| パッケージ | 説明 |
|-----------|------|
| `@easy-flow/pgvector-client` | `IPineconeClient` を PostgreSQL + pgvector + Gemini Embeddings で実装 |
| `openclaw-pgvector-plugin` | `pgvector-memory` として ContextEngine を登録 |
| `@easy-flow/upstash-vector-client` | `IPineconeClient` を Upstash Vector SDK で実装（予備） |
| `openclaw-upstash-plugin` | `upstash-memory` として ContextEngine を登録（予備） |

### 設計方針
- `PineconeContextEngine` をそのまま再利用（クライアント層のみ差替）
- pgvector: Fly.io nrt に co-located → レイテンシ ~150ms → ~50ms
- Gemini text-embedding-004 (768 dims) でエンベッディング
- 既存 `pinecone-memory` プラグインへの影響なし

### インフラ構成
```
easy-flow-pgvector (Fly.io nrt)
├── PostgreSQL 17 + pgvector 0.8.2
├── DB: easy_flow_memory
├── Table: memory_vectors (HNSW cosine index)
└── Volume: 1GB persistent
```

### 環境変数
```
PGVECTOR_DATABASE_URL=postgres://postgres:***@easy-flow-pgvector.internal:5432/easy_flow_memory
GEMINI_API_KEY=（既存）
```

## Test plan
- [x] pgvector-client: 19 テスト通過（client 15 + embedding 4）
- [x] openclaw-pgvector-plugin: 5 テスト通過
- [x] upstash-vector-client: 14 テスト通過
- [x] openclaw-upstash-plugin: 5 テスト通過
- [x] 既存全テスト影響なし
- [x] lint エラーゼロ
- [x] Fly Postgres デプロイ済み（nrt, pgvector 0.8.2）
- [ ] dev-and-test-agent で統合テスト

## AIレビュースキップ理由

- **`typesRegistered` フラグがプール全体の新規接続に対応していない可能性**: pgvector v0.2.x の `registerTypes` は内部で `pg.types.setTypeParser`（Node.js プロセスグローバル）を呼び出すため、一度登録すれば同一プロセス内の全接続で有効。接続ごとに呼ぶ必要はない。`getClient()` には接続リーク対策の try/catch を追加済みのため、`registerTypes` 例外時も安全。将来 pgvector のメジャーバージョンで内部実装が変更された場合は再検討する。

- **`/data/openclaw.json` フォールバック未実装**: 新プラグイン（pgvector / upstash）は Fly.io 環境での env var（`fly secrets`）専用デプロイを前提としている。`PGVECTOR_DATABASE_URL` と `GEMINI_API_KEY` は既に fly secrets として設定済みであり、`openclaw.json` 経由の設定は使用しない。`openclaw.json` フォールバックが必要になった場合は estack-inc/easy-flow#189 の対応と合わせて追加する。

- **`PgVectorClient.dispose()` が `IPineconeClient` インターフェースに含まれない**: 既存の `PineconeClient` も同様に `dispose()` はインターフェース外のメソッドとして実装されており、`PineconeContextEngine` から呼ばれない設計は既存と一貫している。`IPineconeClient` へのメソッド追加は本 PR のスコープ外（別パッケージのインターフェース変更）であり、別 Issue で対応すべき。現行の OpenClaw プラグインアーキテクチャではプラグインの再ロードは発生せず、プロセス終了時に Node.js が接続を自動クローズするため実害はない。

- **Upstash フィルタ文字列のエスケープ仕様**: Upstash Vector SDK のフィルタ言語はバックスラッシュエスケープ（`\'` でシングルクォートをエスケープ）に対応している。[Upstash ドキュメント](https://upstash.com/docs/vector/features/filtering)でフィルタ式は `field = 'value'` 形式であり、`\'` によるクォートエスケープが有効であることを確認済み。エスケープ順序（`\` → `\\` を先に処理してから `'` → `\'`）も正しい。テスト `"should escape single quotes and backslashes in category filter"` で検証済み。

- **exports パターンがモノレポ規約と不一致**: 指摘の前提が誤り。既存の `@easy-flow/pinecone-client`（`packages/pinecone-client/package.json`）は `"types": "./dist/index.d.ts", "default": "./src/index.ts"` と全く同じパターンを使用している。新パッケージはこの既存パターンに準拠して実装したものであり、モノレポ内で一貫している。ビルド順序については `tsconfig.json` の `skipLibCheck: true` と npm workspaces のリンク解決により、`dist/` 未生成でも開発時の型解決は正常に動作する。