### PR TITLE
fix(pinecone-memory): api.pluginConfig 空時の fallback 設定読み込み

### DIFF
--- a/packages/openclaw-pinecone-plugin/src/index.test.ts
+++ b/packages/openclaw-pinecone-plugin/src/index.test.ts
@@ -1,5 +1,5 @@
 import * as fs from "node:fs";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@easy-flow/pinecone-client", () => ({
   PineconeClient: vi.fn().mockImplementation((config) => ({
@@ -295,6 +295,10 @@ describe("pinecone-memory plugin", () => {
 
   describe("config fallback from openclaw.json", () => {
     beforeEach(() => {
+      vi.mocked(fs.readFileSync).mockReset();
+    });
+
+    afterAll(() => {
       vi.mocked(fs.readFileSync).mockReset();
     });
 

--- a/packages/openclaw-pinecone-plugin/src/index.test.ts
+++ b/packages/openclaw-pinecone-plugin/src/index.test.ts
@@ -1,5 +1,5 @@
 import * as fs from "node:fs";
-import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@easy-flow/pinecone-client", () => ({
   PineconeClient: vi.fn().mockImplementation((config) => ({
@@ -40,6 +40,10 @@ function createMockApi(pluginConfig: Record<string, unknown> = {}) {
 }
 
 describe("pinecone-memory plugin", () => {
+  beforeEach(() => {
+    vi.mocked(fs.readFileSync).mockReset();
+  });
+
   it("warns and does not register when API key is missing", () => {
     const originalEnv = process.env.PINECONE_API_KEY;
     delete process.env.PINECONE_API_KEY;
@@ -294,14 +298,6 @@ describe("pinecone-memory plugin", () => {
   });
 
   describe("config fallback from openclaw.json", () => {
-    beforeEach(() => {
-      vi.mocked(fs.readFileSync).mockReset();
-    });
-
-    afterAll(() => {
-      vi.mocked(fs.readFileSync).mockReset();
-    });
-
     it("reads config from openclaw.json when api.pluginConfig is empty", () => {
       const fallbackConfig = JSON.stringify({
         plugins: {

--- a/packages/openclaw-pinecone-plugin/src/index.test.ts
+++ b/packages/openclaw-pinecone-plugin/src/index.test.ts
@@ -1,5 +1,5 @@
 import * as fs from "node:fs";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@easy-flow/pinecone-client", () => ({
   PineconeClient: vi.fn().mockImplementation((config) => ({
@@ -294,6 +294,10 @@ describe("pinecone-memory plugin", () => {
   });
 
   describe("config fallback from openclaw.json", () => {
+    beforeEach(() => {
+      vi.mocked(fs.readFileSync).mockReset();
+    });
+
     it("reads config from openclaw.json when api.pluginConfig is empty", () => {
       const fallbackConfig = JSON.stringify({
         plugins: {
@@ -315,7 +319,7 @@ describe("pinecone-memory plugin", () => {
 
       expect(fs.readFileSync).toHaveBeenCalledWith("/data/openclaw.json", "utf8");
       expect(api.logger.info).toHaveBeenCalledWith(
-        expect.stringContaining("using fallback from openclaw.json"),
+        expect.stringContaining("loaded config from openclaw.json"),
       );
       expect(api.registerContextEngine).toHaveBeenCalled();
       expect(api.logger.info).toHaveBeenCalledWith(
@@ -324,12 +328,11 @@ describe("pinecone-memory plugin", () => {
     });
 
     it("does not read openclaw.json when api.pluginConfig has values", () => {
-      vi.mocked(fs.readFileSync).mockClear();
       const api = createMockApi({ apiKey: "direct-key", agentId: "direct-agent" });
       register(api as any);
 
       expect(fs.readFileSync).not.toHaveBeenCalled();
-      expect(api.logger.info).not.toHaveBeenCalledWith(expect.stringContaining("using fallback"));
+      expect(api.logger.info).not.toHaveBeenCalledWith(expect.stringContaining("loaded config"));
     });
 
     it("falls back gracefully when openclaw.json is unreadable", () => {
@@ -343,6 +346,10 @@ describe("pinecone-memory plugin", () => {
       const api = createMockApi({});
       register(api as any);
 
+      // Fallback returned empty → warn log
+      expect(api.logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining("fallback returned no config"),
+      );
       // No apiKey from fallback or env → plugin disabled
       expect(api.logger.warn).toHaveBeenCalledWith(
         expect.stringContaining("PINECONE_API_KEY not set"),

--- a/packages/openclaw-pinecone-plugin/src/index.test.ts
+++ b/packages/openclaw-pinecone-plugin/src/index.test.ts
@@ -1,3 +1,4 @@
+import * as fs from "node:fs";
 import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@easy-flow/pinecone-client", () => ({
@@ -13,6 +14,8 @@ vi.mock("@easy-flow/pinecone-context-engine", () => ({
     ingest: vi.fn(),
   })),
 }));
+
+vi.mock("node:fs");
 
 import { PineconeClient } from "@easy-flow/pinecone-client";
 import { PineconeContextEngine } from "@easy-flow/pinecone-context-engine";
@@ -288,6 +291,69 @@ describe("pinecone-memory plugin", () => {
     } else {
       process.env.RAG_TOKEN_BUDGET = originalBudget;
     }
+  });
+
+  describe("config fallback from openclaw.json", () => {
+    it("reads config from openclaw.json when api.pluginConfig is empty", () => {
+      const fallbackConfig = JSON.stringify({
+        plugins: {
+          entries: {
+            "pinecone-memory": {
+              config: {
+                apiKey: "fallback-key",
+                agentId: "fallback-agent",
+                memoryHint: "fallback hint",
+              },
+            },
+          },
+        },
+      });
+      vi.mocked(fs.readFileSync).mockReturnValue(fallbackConfig);
+
+      const api = createMockApi({});
+      register(api as any);
+
+      expect(fs.readFileSync).toHaveBeenCalledWith("/data/openclaw.json", "utf8");
+      expect(api.logger.info).toHaveBeenCalledWith(
+        expect.stringContaining("using fallback from openclaw.json"),
+      );
+      expect(api.registerContextEngine).toHaveBeenCalled();
+      expect(api.logger.info).toHaveBeenCalledWith(
+        expect.stringContaining("agentId: fallback-agent"),
+      );
+    });
+
+    it("does not read openclaw.json when api.pluginConfig has values", () => {
+      vi.mocked(fs.readFileSync).mockClear();
+      const api = createMockApi({ apiKey: "direct-key", agentId: "direct-agent" });
+      register(api as any);
+
+      expect(fs.readFileSync).not.toHaveBeenCalled();
+      expect(api.logger.info).not.toHaveBeenCalledWith(expect.stringContaining("using fallback"));
+    });
+
+    it("falls back gracefully when openclaw.json is unreadable", () => {
+      vi.mocked(fs.readFileSync).mockImplementation(() => {
+        throw new Error("ENOENT");
+      });
+
+      const originalEnv = process.env.PINECONE_API_KEY;
+      delete process.env.PINECONE_API_KEY;
+
+      const api = createMockApi({});
+      register(api as any);
+
+      // No apiKey from fallback or env → plugin disabled
+      expect(api.logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining("PINECONE_API_KEY not set"),
+      );
+
+      if (originalEnv === undefined) {
+        delete process.env.PINECONE_API_KEY;
+      } else {
+        process.env.PINECONE_API_KEY = originalEnv;
+      }
+    });
   });
 
   it("logs mode: rag when ragEnabled is true via pluginConfig", () => {

--- a/packages/openclaw-pinecone-plugin/src/index.ts
+++ b/packages/openclaw-pinecone-plugin/src/index.ts
@@ -58,9 +58,20 @@ const OPENCLAW_CONFIG_PATH = "/data/openclaw.json";
 export default function register(api: OpenClawPluginApi): void {
   const apiCfg = (api.pluginConfig ?? {}) as PluginConfig;
   const hasApiConfig = Object.keys(apiCfg).length > 0;
-  const cfg: PluginConfig = hasApiConfig ? apiCfg : { ...readConfigFallback(OPENCLAW_CONFIG_PATH) };
-  if (!hasApiConfig) {
-    api.logger.info("pinecone-memory: api.pluginConfig empty — using fallback from openclaw.json");
+  let cfg: PluginConfig;
+  if (hasApiConfig) {
+    cfg = apiCfg;
+  } else {
+    const fallback = readConfigFallback(OPENCLAW_CONFIG_PATH);
+    const hasFallback = Object.keys(fallback).length > 0;
+    cfg = { ...fallback };
+    if (hasFallback) {
+      api.logger.info("pinecone-memory: api.pluginConfig empty — loaded config from openclaw.json");
+    } else {
+      api.logger.warn(
+        "pinecone-memory: api.pluginConfig empty and openclaw.json fallback returned no config",
+      );
+    }
   }
 
   const apiKey = cfg.apiKey ?? process.env.PINECONE_API_KEY;

--- a/packages/openclaw-pinecone-plugin/src/index.ts
+++ b/packages/openclaw-pinecone-plugin/src/index.ts
@@ -24,15 +24,16 @@ type PluginConfig = {
  * via api.pluginConfig due to entrypoint clearing plugins.load.paths.
  * See: estack-inc/easy-flow#189
  */
-function readConfigFallback(configPath: string): Partial<PluginConfig> {
+function readConfigFallback(
+  configPath: string,
+  logger: Pick<OpenClawPluginApi["logger"], "debug">,
+): Partial<PluginConfig> {
   try {
     const raw = fs.readFileSync(configPath, "utf8");
     const config = JSON.parse(raw);
     return (config?.plugins?.entries?.["pinecone-memory"]?.config ?? {}) as Partial<PluginConfig>;
   } catch (err) {
-    console.debug(
-      `[pinecone-memory] readConfigFallback failed: ${err instanceof Error ? err.message : String(err)}`,
-    );
+    logger.debug(`readConfigFallback failed: ${err instanceof Error ? err.message : String(err)}`);
     return {};
   }
 }
@@ -65,7 +66,7 @@ export default function register(api: OpenClawPluginApi): void {
   if (hasApiConfig) {
     cfg = apiCfg;
   } else {
-    const fallback = readConfigFallback(OPENCLAW_CONFIG_PATH);
+    const fallback = readConfigFallback(OPENCLAW_CONFIG_PATH, api.logger);
     const hasFallback = Object.keys(fallback).length > 0;
     cfg = { ...fallback };
     if (hasFallback) {

--- a/packages/openclaw-pinecone-plugin/src/index.ts
+++ b/packages/openclaw-pinecone-plugin/src/index.ts
@@ -1,3 +1,4 @@
+import * as fs from "node:fs";
 import { PineconeClient } from "@easy-flow/pinecone-client";
 import { PineconeContextEngine } from "@easy-flow/pinecone-context-engine";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
@@ -15,6 +16,23 @@ type PluginConfig = {
   ragMinScore?: number;
   ragTopK?: number;
 };
+
+/**
+ * Fallback: read plugin config directly from openclaw.json when api.pluginConfig is empty.
+ *
+ * Auto-discovered extensions (loaded from /data/extensions/) may not receive config
+ * via api.pluginConfig due to entrypoint clearing plugins.load.paths.
+ * See: estack-inc/easy-flow#189
+ */
+function readConfigFallback(configPath: string): Partial<PluginConfig> {
+  try {
+    const raw = fs.readFileSync(configPath, "utf8");
+    const config = JSON.parse(raw);
+    return (config?.plugins?.entries?.["pinecone-memory"]?.config ?? {}) as Partial<PluginConfig>;
+  } catch {
+    return {};
+  }
+}
 
 function parseFiniteNumber(value: string | undefined): number | undefined {
   if (value === undefined || value === "") return undefined;
@@ -35,8 +53,15 @@ function parseScoreFloat(value: string | undefined): number | undefined {
   return n >= 0 && n <= 1 ? n : undefined;
 }
 
+const OPENCLAW_CONFIG_PATH = "/data/openclaw.json";
+
 export default function register(api: OpenClawPluginApi): void {
-  const cfg = (api.pluginConfig ?? {}) as PluginConfig;
+  const apiCfg = (api.pluginConfig ?? {}) as PluginConfig;
+  const hasApiConfig = Object.keys(apiCfg).length > 0;
+  const cfg: PluginConfig = hasApiConfig ? apiCfg : { ...readConfigFallback(OPENCLAW_CONFIG_PATH) };
+  if (!hasApiConfig) {
+    api.logger.info("pinecone-memory: api.pluginConfig empty — using fallback from openclaw.json");
+  }
 
   const apiKey = cfg.apiKey ?? process.env.PINECONE_API_KEY;
   if (!apiKey) {

--- a/packages/openclaw-pinecone-plugin/src/index.ts
+++ b/packages/openclaw-pinecone-plugin/src/index.ts
@@ -29,7 +29,10 @@ function readConfigFallback(configPath: string): Partial<PluginConfig> {
     const raw = fs.readFileSync(configPath, "utf8");
     const config = JSON.parse(raw);
     return (config?.plugins?.entries?.["pinecone-memory"]?.config ?? {}) as Partial<PluginConfig>;
-  } catch {
+  } catch (err) {
+    console.debug(
+      `[pinecone-memory] readConfigFallback failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
     return {};
   }
 }


### PR DESCRIPTION
## Summary

- `api.pluginConfig` が空の場合に `/data/openclaw.json` から直接 plugin config を読む fallback ロジックを追加
- auto-discovered extensions が entrypoint の `plugins.load.paths = []` により config を受け取れない問題への対策
- fallback 使用時はログに `"using fallback from openclaw.json"` を出力

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `packages/openclaw-pinecone-plugin/src/index.ts` | `readConfigFallback()` 追加、register() で空チェック → fallback |
| `packages/openclaw-pinecone-plugin/src/index.test.ts` | fallback テスト 3 件追加 |

## Test plan

- [x] openclaw-pinecone-plugin: 16 passed
- [x] 全パッケージ: 207 passed
- [x] biome lint: clean
- [ ] 社内インスタンスで fallback ログ確認

Refs: estack-inc/easy-flow#189