### PR TITLE
feat(model-router): ファイル種別によるモデルルーティング

### DIFF
--- a/packages/model-router/openclaw.plugin.json
+++ b/packages/model-router/openclaw.plugin.json
@@ -2,5 +2,58 @@
   "id": "model-router",
   "kind": "plugin",
   "name": "Model Router",
-  "description": "Routes lightweight messages to Haiku and complex tasks to Sonnet based on rule-based classification"
+  "description": "Routes messages to optimal models: file attachments to Gemini Flash, lightweight text to Haiku, complex tasks to Sonnet",
+  "configSchema": {
+    "type": "object",
+    "properties": {
+      "defaultModel": {
+        "type": "string",
+        "description": "Default model for complex tasks"
+      },
+      "defaultProvider": {
+        "type": "string",
+        "description": "Default provider"
+      },
+      "lightModel": {
+        "type": "string",
+        "description": "Model for lightweight text messages"
+      },
+      "lightProvider": {
+        "type": "string",
+        "description": "Provider for lightweight text messages"
+      },
+      "maxTokensForLight": {
+        "type": "number",
+        "description": "Max estimated tokens for lightweight routing"
+      },
+      "fileRouting": {
+        "type": "object",
+        "description": "File-based model routing configuration",
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "description": "Enable file-based routing (requires openclaw with attachments support)"
+          },
+          "rules": {
+            "type": "array",
+            "description": "Routing rules evaluated in order; first match wins",
+            "items": {
+              "type": "object",
+              "properties": {
+                "label": { "type": "string" },
+                "mimePatterns": { "type": "array", "items": { "type": "string" } },
+                "model": { "type": "string" },
+                "provider": { "type": "string" }
+              },
+              "required": ["label", "mimePatterns", "model", "provider"]
+            }
+          }
+        }
+      },
+      "logging": {
+        "type": "boolean",
+        "description": "Enable routing decision logging"
+      }
+    }
+  }
 }

--- a/packages/model-router/src/classifier.test.ts
+++ b/packages/model-router/src/classifier.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { classifyMessage } from "./classifier.js";
-import { DEFAULT_CONFIG } from "./config.js";
+import { type AttachmentHint, classifyMessage, matchMimePattern, routeByAttachments } from "./classifier.js";
+import { DEFAULT_CONFIG, DEFAULT_FILE_ROUTING_RULES } from "./config.js";
 
 describe("classifyMessage", () => {
   it("挨拶（短文・preferLight）→ light", () => {
@@ -42,7 +42,6 @@ describe("classifyMessage", () => {
   });
 
   it("英語 forceDefault（code）が preferLight（ok）に勝つ", () => {
-    // "ok" が preferLight にマッチするが "code" が forceDefault にマッチ → default
     expect(classifyMessage("ok, let's write some code", DEFAULT_CONFIG)).toBe("default");
   });
 
@@ -60,5 +59,200 @@ describe("classifyMessage", () => {
 
   it("「〜を確認して」はパターン未一致で default（複雑タスク）", () => {
     expect(classifyMessage("このPRを確認して", DEFAULT_CONFIG)).toBe("default");
+  });
+});
+
+describe("matchMimePattern", () => {
+  it("完全一致", () => {
+    expect(matchMimePattern("image/png", "image/png")).toBe(true);
+  });
+
+  it("不一致", () => {
+    expect(matchMimePattern("image/png", "image/jpeg")).toBe(false);
+  });
+
+  it("ワイルドカード image/*", () => {
+    expect(matchMimePattern("image/png", "image/*")).toBe(true);
+    expect(matchMimePattern("image/jpeg", "image/*")).toBe(true);
+    expect(matchMimePattern("video/mp4", "image/*")).toBe(false);
+  });
+
+  it("ワイルドカード video/*", () => {
+    expect(matchMimePattern("video/mp4", "video/*")).toBe(true);
+    expect(matchMimePattern("video/webm", "video/*")).toBe(true);
+  });
+
+  it("ドットワイルドカード application/vnd.openxmlformats-officedocument.*", () => {
+    expect(
+      matchMimePattern(
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "application/vnd.openxmlformats-officedocument.*",
+      ),
+    ).toBe(true);
+    expect(
+      matchMimePattern(
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        "application/vnd.openxmlformats-officedocument.*",
+      ),
+    ).toBe(true);
+  });
+
+  it("ドットワイルドカード application/vnd.ms-*", () => {
+    expect(matchMimePattern("application/vnd.ms-excel", "application/vnd.ms-*")).toBe(true);
+    expect(matchMimePattern("application/vnd.ms-powerpoint", "application/vnd.ms-*")).toBe(true);
+  });
+
+  it("text/* は CSV/TSV/plain にマッチ", () => {
+    expect(matchMimePattern("text/csv", "text/*")).toBe(true);
+    expect(matchMimePattern("text/plain", "text/*")).toBe(true);
+    expect(matchMimePattern("text/tab-separated-values", "text/*")).toBe(true);
+  });
+});
+
+describe("routeByAttachments", () => {
+  const rules = DEFAULT_FILE_ROUTING_RULES;
+
+  it("画像添付 → gemini-2.5-flash", () => {
+    const attachments: AttachmentHint[] = [{ kind: "image", mimeType: "image/png" }];
+    const result = routeByAttachments(attachments, rules);
+    expect(result).toEqual({
+      model: "gemini-2.5-flash",
+      provider: "google",
+      matchedRule: "image",
+    });
+  });
+
+  it("動画添付 → gemini-2.5-flash", () => {
+    const attachments: AttachmentHint[] = [{ kind: "video", mimeType: "video/mp4" }];
+    const result = routeByAttachments(attachments, rules);
+    expect(result).toEqual({
+      model: "gemini-2.5-flash",
+      provider: "google",
+      matchedRule: "video",
+    });
+  });
+
+  it("音声添付 → gemini-2.5-flash", () => {
+    const attachments: AttachmentHint[] = [{ kind: "audio", mimeType: "audio/mpeg" }];
+    const result = routeByAttachments(attachments, rules);
+    expect(result).toEqual({
+      model: "gemini-2.5-flash",
+      provider: "google",
+      matchedRule: "audio",
+    });
+  });
+
+  it("PDF 添付 → gemini-2.5-flash", () => {
+    const attachments: AttachmentHint[] = [{ kind: "document", mimeType: "application/pdf" }];
+    const result = routeByAttachments(attachments, rules);
+    expect(result).toEqual({
+      model: "gemini-2.5-flash",
+      provider: "google",
+      matchedRule: "document",
+    });
+  });
+
+  it("Excel 添付 → gemini-2.5-flash", () => {
+    const attachments: AttachmentHint[] = [
+      {
+        kind: "document",
+        mimeType: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+      },
+    ];
+    const result = routeByAttachments(attachments, rules);
+    expect(result).toEqual({
+      model: "gemini-2.5-flash",
+      provider: "google",
+      matchedRule: "document",
+    });
+  });
+
+  it("Word 添付 → gemini-2.5-flash", () => {
+    const attachments: AttachmentHint[] = [
+      {
+        kind: "document",
+        mimeType: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+      },
+    ];
+    const result = routeByAttachments(attachments, rules);
+    expect(result).toEqual({
+      model: "gemini-2.5-flash",
+      provider: "google",
+      matchedRule: "document",
+    });
+  });
+
+  it("CSV 添付 → gemini-2.5-flash", () => {
+    const attachments: AttachmentHint[] = [{ kind: "document", mimeType: "text/csv" }];
+    const result = routeByAttachments(attachments, rules);
+    expect(result).toEqual({
+      model: "gemini-2.5-flash",
+      provider: "google",
+      matchedRule: "document",
+    });
+  });
+
+  it("ZIP 添付 → gemini-2.5-flash", () => {
+    const attachments: AttachmentHint[] = [{ kind: "other", mimeType: "application/zip" }];
+    const result = routeByAttachments(attachments, rules);
+    expect(result).toEqual({
+      model: "gemini-2.5-flash",
+      provider: "google",
+      matchedRule: "binary",
+    });
+  });
+
+  it("添付なし → null", () => {
+    expect(routeByAttachments([], rules)).toBeNull();
+  });
+
+  it("mimeType なし → kind ベースのフォールバック", () => {
+    const attachments: AttachmentHint[] = [{ kind: "image" }];
+    const result = routeByAttachments(attachments, rules);
+    expect(result).toEqual({
+      model: "gemini-2.5-flash",
+      provider: "google",
+      matchedRule: "image(kind)",
+    });
+  });
+
+  it("unknown kind + unknown mimeType → null", () => {
+    const attachments: AttachmentHint[] = [
+      { kind: "other", mimeType: "application/x-custom-format" },
+    ];
+    expect(routeByAttachments(attachments, rules)).toBeNull();
+  });
+
+  it("複数添付 → 最初にマッチしたルールが適用", () => {
+    const attachments: AttachmentHint[] = [
+      { kind: "document", mimeType: "text/plain" },
+      { kind: "image", mimeType: "image/png" },
+    ];
+    // image ルールが先に定義されているが、ルール順で評価
+    // rules[0] = image → text/plain はマッチしない → image/png はマッチ
+    const result = routeByAttachments(attachments, rules);
+    expect(result).toEqual({
+      model: "gemini-2.5-flash",
+      provider: "google",
+      matchedRule: "image",
+    });
+  });
+
+  it("カスタムルール → 指定モデルにルーティング", () => {
+    const customRules = [
+      {
+        label: "pdf-only",
+        mimePatterns: ["application/pdf"],
+        model: "gemini-2.5-pro",
+        provider: "google",
+      },
+    ];
+    const attachments: AttachmentHint[] = [{ kind: "document", mimeType: "application/pdf" }];
+    const result = routeByAttachments(attachments, customRules);
+    expect(result).toEqual({
+      model: "gemini-2.5-pro",
+      provider: "google",
+      matchedRule: "pdf-only",
+    });
   });
 });

--- a/packages/model-router/src/classifier.test.ts
+++ b/packages/model-router/src/classifier.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { type AttachmentHint, classifyMessage, matchMimePattern, routeByAttachments } from "./classifier.js";
+import {
+  type AttachmentHint,
+  classifyMessage,
+  matchMimePattern,
+  routeByAttachments,
+} from "./classifier.js";
 import { DEFAULT_CONFIG, DEFAULT_FILE_ROUTING_RULES } from "./config.js";
 
 describe("classifyMessage", () => {

--- a/packages/model-router/src/classifier.ts
+++ b/packages/model-router/src/classifier.ts
@@ -1,6 +1,71 @@
-import type { ModelRouterConfig } from "./config.js";
+import type { FileRoutingRule, ModelRouterConfig } from "./config.js";
 
 export type ClassificationResult = "light" | "default";
+
+/** Attachment metadata from the before_model_resolve event (openclaw/openclaw#65754). */
+export type AttachmentHint = {
+  kind: "image" | "video" | "audio" | "document" | "other";
+  mimeType?: string;
+};
+
+/** Result of file-based routing. null means no file routing applies. */
+export type FileRoutingResult = {
+  model: string;
+  provider: string;
+  matchedRule: string;
+} | null;
+
+/**
+ * Check if a MIME type matches a pattern.
+ * Supports exact match and trailing wildcard (e.g. "image/*").
+ */
+export function matchMimePattern(mimeType: string, pattern: string): boolean {
+  if (pattern === mimeType) return true;
+  if (pattern.endsWith("*")) {
+    // "image/*" → "image/", "application/vnd.ms-*" → "application/vnd.ms-"
+    const prefix = pattern.slice(0, -1);
+    return mimeType.startsWith(prefix);
+  }
+  return false;
+}
+
+/**
+ * Determine file-based routing from attachment metadata.
+ * Returns the first matching rule's model/provider, or null if no match.
+ */
+export function routeByAttachments(
+  attachments: ReadonlyArray<AttachmentHint>,
+  rules: FileRoutingRule[],
+): FileRoutingResult {
+  if (attachments.length === 0) return null;
+
+  for (const rule of rules) {
+    for (const attachment of attachments) {
+      const mimeType = attachment.mimeType;
+      if (mimeType && rule.mimePatterns.some((p) => matchMimePattern(mimeType, p))) {
+        return { model: rule.model, provider: rule.provider, matchedRule: rule.label };
+      }
+    }
+  }
+
+  // Fallback: if any attachment exists but no MIME match, route by kind
+  for (const rule of rules) {
+    for (const attachment of attachments) {
+      const kindToMime: Record<string, string> = {
+        image: "image/unknown",
+        video: "video/unknown",
+        audio: "audio/unknown",
+        document: "text/unknown",
+      };
+      const syntheticMime = kindToMime[attachment.kind];
+      if (syntheticMime && rule.mimePatterns.some((p) => matchMimePattern(syntheticMime, p))) {
+        return { model: rule.model, provider: rule.provider, matchedRule: `${rule.label}(kind)` };
+      }
+    }
+  }
+
+  return null;
+}
 
 /**
  * ユーザープロンプトを分類し、軽量モデルで処理可能かを判定する。

--- a/packages/model-router/src/config.ts
+++ b/packages/model-router/src/config.ts
@@ -1,3 +1,15 @@
+/** MIME pattern matching rule for file-based model routing. */
+export type FileRoutingRule = {
+  /** Human-readable label for logging. */
+  label: string;
+  /** MIME type patterns to match (supports trailing wildcard: "image/*"). */
+  mimePatterns: string[];
+  /** Model to route to when matched. */
+  model: string;
+  /** Provider to route to when matched. */
+  provider: string;
+};
+
 export type ModelRouterConfig = {
   defaultModel?: string;
   defaultProvider?: string;
@@ -8,8 +20,51 @@ export type ModelRouterConfig = {
     forceDefault?: string[];
     preferLight?: string[];
   };
+  /** File-based routing rules. Evaluated in order; first match wins. */
+  fileRouting?: {
+    enabled?: boolean;
+    rules?: FileRoutingRule[];
+  };
   logging?: boolean;
 };
+
+export const DEFAULT_FILE_ROUTING_RULES: FileRoutingRule[] = [
+  {
+    label: "image",
+    mimePatterns: ["image/*"],
+    model: "gemini-2.5-flash",
+    provider: "google",
+  },
+  {
+    label: "video",
+    mimePatterns: ["video/*"],
+    model: "gemini-2.5-flash",
+    provider: "google",
+  },
+  {
+    label: "audio",
+    mimePatterns: ["audio/*"],
+    model: "gemini-2.5-flash",
+    provider: "google",
+  },
+  {
+    label: "document",
+    mimePatterns: [
+      "application/pdf",
+      "application/vnd.openxmlformats-officedocument.*",
+      "application/vnd.ms-*",
+      "text/*",
+    ],
+    model: "gemini-2.5-flash",
+    provider: "google",
+  },
+  {
+    label: "binary",
+    mimePatterns: ["application/octet-stream", "application/zip", "application/gzip"],
+    model: "gemini-2.5-flash",
+    provider: "google",
+  },
+];
 
 export const DEFAULT_CONFIG: Required<ModelRouterConfig> = {
   defaultModel: "claude-sonnet-4-6",
@@ -31,7 +86,7 @@ export const DEFAULT_CONFIG: Required<ModelRouterConfig> = {
       "バグ",
       "エラー",
       "仕様",
-      // 英語（preferLight の英語キーワードとの誤分類を防ぐため）
+      // 英語
       "review",
       "code",
       "bug",
@@ -53,6 +108,10 @@ export const DEFAULT_CONFIG: Required<ModelRouterConfig> = {
       "はい",
       "いいえ",
     ],
+  },
+  fileRouting: {
+    enabled: true,
+    rules: DEFAULT_FILE_ROUTING_RULES,
   },
   logging: true,
 };

--- a/packages/model-router/src/index.test.ts
+++ b/packages/model-router/src/index.test.ts
@@ -27,12 +27,15 @@ function createMockApi(pluginConfig: Record<string, unknown> = {}): MockApi {
 }
 
 /** 登録済みの before_model_resolve ハンドラを取得して呼び出す */
-function callHook(api: MockApi, prompt: string) {
+function callHook(
+  api: MockApi,
+  event: { prompt?: string; attachments?: { kind: string; mimeType?: string }[] },
+) {
   const [, handler] = api.registerHook.mock.calls[0] as [
     string[],
-    (e: { prompt: string }, ctx: unknown) => unknown,
+    (e: unknown, ctx: unknown) => unknown,
   ];
-  return handler({ prompt }, {});
+  return handler(event, {});
 }
 
 describe("model-router plugin", () => {
@@ -54,7 +57,7 @@ describe("model-router plugin", () => {
     const api = createMockApi();
     register(api as unknown as import("openclaw/plugin-sdk").OpenClawPluginApi);
 
-    const result = callHook(api, "おはよう");
+    const result = callHook(api, { prompt: "おはよう" });
 
     expect(result).toEqual({
       modelOverride: "claude-haiku-4-5",
@@ -66,15 +69,143 @@ describe("model-router plugin", () => {
     const api = createMockApi();
     register(api as unknown as import("openclaw/plugin-sdk").OpenClawPluginApi);
 
-    const result = callHook(api, "このコードをレビューして");
+    const result = callHook(api, { prompt: "このコードをレビューして" });
 
     expect(result).toBeUndefined();
   });
 
+  // ===== ファイルルーティング =====
+
+  it("画像添付 → Gemini Flash にルーティング", () => {
+    const api = createMockApi();
+    register(api as unknown as import("openclaw/plugin-sdk").OpenClawPluginApi);
+
+    const result = callHook(api, {
+      prompt: "この画像を見て",
+      attachments: [{ kind: "image", mimeType: "image/png" }],
+    });
+
+    expect(result).toEqual({
+      modelOverride: "gemini-2.5-flash",
+      providerOverride: "google",
+    });
+  });
+
+  it("PDF 添付 → Gemini Flash にルーティング", () => {
+    const api = createMockApi();
+    register(api as unknown as import("openclaw/plugin-sdk").OpenClawPluginApi);
+
+    const result = callHook(api, {
+      prompt: "この資料を要約して",
+      attachments: [{ kind: "document", mimeType: "application/pdf" }],
+    });
+
+    expect(result).toEqual({
+      modelOverride: "gemini-2.5-flash",
+      providerOverride: "google",
+    });
+  });
+
+  it("Excel 添付 → Gemini Flash にルーティング", () => {
+    const api = createMockApi();
+    register(api as unknown as import("openclaw/plugin-sdk").OpenClawPluginApi);
+
+    const result = callHook(api, {
+      prompt: "売上データを分析して",
+      attachments: [
+        {
+          kind: "document",
+          mimeType: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        },
+      ],
+    });
+
+    expect(result).toEqual({
+      modelOverride: "gemini-2.5-flash",
+      providerOverride: "google",
+    });
+  });
+
+  it("ファイル添付がテキスト分類より優先される", () => {
+    const api = createMockApi();
+    register(api as unknown as import("openclaw/plugin-sdk").OpenClawPluginApi);
+
+    // "おはよう" は preferLight だが、画像添付があるので Gemini にルーティング
+    const result = callHook(api, {
+      prompt: "おはよう",
+      attachments: [{ kind: "image", mimeType: "image/jpeg" }],
+    });
+
+    expect(result).toEqual({
+      modelOverride: "gemini-2.5-flash",
+      providerOverride: "google",
+    });
+  });
+
+  it("添付なし + 軽量テキスト → Haiku", () => {
+    const api = createMockApi();
+    register(api as unknown as import("openclaw/plugin-sdk").OpenClawPluginApi);
+
+    const result = callHook(api, {
+      prompt: "おはよう",
+      attachments: [],
+    });
+
+    expect(result).toEqual({
+      modelOverride: "claude-haiku-4-5",
+      providerOverride: "anthropic",
+    });
+  });
+
+  it("fileRouting.enabled: false → ファイルルーティング無効", () => {
+    const api = createMockApi({ fileRouting: { enabled: false } });
+    register(api as unknown as import("openclaw/plugin-sdk").OpenClawPluginApi);
+
+    const result = callHook(api, {
+      prompt: "おはよう",
+      attachments: [{ kind: "image", mimeType: "image/png" }],
+    });
+
+    // ファイルルーティング無効なので、テキスト分類が適用
+    expect(result).toEqual({
+      modelOverride: "claude-haiku-4-5",
+      providerOverride: "anthropic",
+    });
+  });
+
+  it("カスタム fileRouting.rules が適用される", () => {
+    const api = createMockApi({
+      fileRouting: {
+        enabled: true,
+        rules: [
+          {
+            label: "custom-image",
+            mimePatterns: ["image/*"],
+            model: "gemini-2.5-pro",
+            provider: "google",
+          },
+        ],
+      },
+    });
+    register(api as unknown as import("openclaw/plugin-sdk").OpenClawPluginApi);
+
+    const result = callHook(api, {
+      prompt: "分析して",
+      attachments: [{ kind: "image", mimeType: "image/png" }],
+    });
+
+    expect(result).toEqual({
+      modelOverride: "gemini-2.5-pro",
+      providerOverride: "google",
+    });
+  });
+
+  // ===== 既存テスト（後方互換性） =====
+
   it("logging: true のとき軽量ルーティングで info ログを出力する", () => {
     const api = createMockApi({ logging: true });
     register(api as unknown as import("openclaw/plugin-sdk").OpenClawPluginApi);
-    callHook(api, "おはよう");
+    callHook(api, { prompt: "おはよう" });
 
     expect(api.logger.info).toHaveBeenCalledWith(
       expect.stringContaining("anthropic/claude-haiku-4-5"),
@@ -87,9 +218,23 @@ describe("model-router plugin", () => {
 
     // info は "plugin registered" のみ呼ばれる
     const infoCallsBefore = api.logger.info.mock.calls.length;
-    callHook(api, "おはよう");
+    callHook(api, { prompt: "おはよう" });
 
     expect(api.logger.info.mock.calls.length).toBe(infoCallsBefore);
+  });
+
+  it("logging: true のときファイルルーティングで info ログを出力する", () => {
+    const api = createMockApi({ logging: true });
+    register(api as unknown as import("openclaw/plugin-sdk").OpenClawPluginApi);
+    callHook(api, {
+      prompt: "この画像は何？",
+      attachments: [{ kind: "image", mimeType: "image/png" }],
+    });
+
+    expect(api.logger.info).toHaveBeenCalledWith(
+      expect.stringContaining("google/gemini-2.5-flash"),
+    );
+    expect(api.logger.info).toHaveBeenCalledWith(expect.stringContaining("file: image"));
   });
 
   it("pluginConfig.patterns でデフォルト設定を上書きできる", () => {
@@ -102,7 +247,7 @@ describe("model-router plugin", () => {
     register(api as unknown as import("openclaw/plugin-sdk").OpenClawPluginApi);
 
     // カスタム preferLight にマッチ → light
-    const lightResult = callHook(api, "hello");
+    const lightResult = callHook(api, { prompt: "hello" });
     expect(lightResult).toEqual({
       modelOverride: "claude-haiku-4-5",
       providerOverride: "anthropic",
@@ -116,7 +261,7 @@ describe("model-router plugin", () => {
       },
     });
     register(api2 as unknown as import("openclaw/plugin-sdk").OpenClawPluginApi);
-    const defaultResult = callHook(api2, "おはよう");
+    const defaultResult = callHook(api2, { prompt: "おはよう" });
     expect(defaultResult).toBeUndefined();
   });
 

--- a/packages/model-router/src/index.ts
+++ b/packages/model-router/src/index.ts
@@ -1,21 +1,47 @@
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
-import { classifyMessage } from "./classifier.js";
-import { DEFAULT_CONFIG, type ModelRouterConfig } from "./config.js";
+import { type AttachmentHint, classifyMessage, routeByAttachments } from "./classifier.js";
+import { DEFAULT_CONFIG, DEFAULT_FILE_ROUTING_RULES, type ModelRouterConfig } from "./config.js";
 
 export default function register(api: OpenClawPluginApi): void {
+  const rawConfig = api.pluginConfig as ModelRouterConfig;
   const cfg: Required<ModelRouterConfig> = {
     ...DEFAULT_CONFIG,
-    ...(api.pluginConfig as ModelRouterConfig),
+    ...rawConfig,
     patterns: {
       ...DEFAULT_CONFIG.patterns,
-      ...((api.pluginConfig as ModelRouterConfig)?.patterns ?? {}),
+      ...(rawConfig?.patterns ?? {}),
+    },
+    fileRouting: {
+      enabled: rawConfig?.fileRouting?.enabled ?? DEFAULT_CONFIG.fileRouting.enabled,
+      rules: rawConfig?.fileRouting?.rules ?? DEFAULT_FILE_ROUTING_RULES,
     },
   };
 
-  // before_model_resolve: プロンプトを分類してモデルをオーバーライド
+  // before_model_resolve: プロンプトと添付ファイルを分析してモデルをオーバーライド
   api.registerHook(["before_model_resolve"], (event: unknown, _ctx: unknown) => {
     try {
-      const prompt = (event as { prompt?: string }).prompt ?? "";
+      const e = event as { prompt?: string; attachments?: AttachmentHint[] };
+      const prompt = e.prompt ?? "";
+      const attachments = e.attachments ?? [];
+
+      // 1. ファイルルーティング（最優先）
+      if (cfg.fileRouting.enabled && attachments.length > 0) {
+        const fileRoute = routeByAttachments(attachments, cfg.fileRouting.rules ?? []);
+        if (fileRoute) {
+          if (cfg.logging) {
+            api.logger.info(
+              `[model-router] → ${fileRoute.provider}/${fileRoute.model}` +
+                ` (file: ${fileRoute.matchedRule}, prompt: "${prompt.slice(0, 40)}${prompt.length > 40 ? "..." : ""}")`,
+            );
+          }
+          return {
+            modelOverride: fileRoute.model,
+            providerOverride: fileRoute.provider,
+          };
+        }
+      }
+
+      // 2. テキストベースのルーティング
       const result = classifyMessage(prompt, cfg);
 
       if (result === "light") {


### PR DESCRIPTION
## Summary
- 画像・動画・PDF・Office・テキスト等のファイル添付を検出し、Gemini Flash にルーティング
- テキストのみのメッセージは従来どおり Sonnet/Haiku で処理（既存機能は後方互換維持）
- MIME パターンマッチング、kind フォールバック、カスタムルール対応

## 背景
hongmong-ochi-agent で画像大量送信による月間コスト急増（$140→$200）が発生。
ファイル処理を Gemini Flash にルーティングすることで約 80-95% のコスト削減を見込む。

## 変更内容
- `config.ts`: `FileRoutingRule` 型、デフォルトルール定義を追加
- `classifier.ts`: `matchMimePattern()`, `routeByAttachments()` を追加
- `index.ts`: ファイルルーティングをテキスト分類より優先で評価
- `openclaw.plugin.json`: `configSchema` に `fileRouting` セクション追加
- テスト: 50 テスト全通過（新規 20 テスト追加）

## 依存関係
- openclaw/openclaw#65754: `before_model_resolve` フックに `attachments` メタデータ追加が必要
  - マージされるまでは `attachments` が undefined のため、ファイルルーティングは発動しない
  - テキストベースのルーティング（既存機能）は即座に利用可能

## 設定例
```json
{
  "model-router": {
    "enabled": true,
    "config": {
      "fileRouting": {
        "enabled": true,
        "rules": [
          {
            "label": "image",
            "mimePatterns": ["image/*"],
            "model": "gemini-2.5-flash",
            "provider": "google"
          }
        ]
      }
    }
  }
}
```

## Test plan
- [x] 全 50 テスト通過（`npx vitest run packages/model-router`）
- [ ] openclaw/openclaw#65754 マージ後に E2E 検証
- [ ] hongmong-ochi-agent で有効化してコスト削減効果を測定

## Related
- estack-inc/easy-flow#210
- estack-inc/easy-flow#211
- openclaw/openclaw#65754