### PR TITLE
fix(pgvector-memory): api.pluginConfig 空時の fallback 設定読み込み

### DIFF
--- a/packages/openclaw-pgvector-plugin/src/index.test.ts
+++ b/packages/openclaw-pgvector-plugin/src/index.test.ts
@@ -1,3 +1,4 @@
+import * as fs from "node:fs";
 import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@easy-flow/pgvector-client", () => ({
@@ -9,6 +10,8 @@ vi.mock("@easy-flow/pinecone-context-engine", () => ({
     info: { id: "pgvector", name: "test", version: "1.0.0" },
   })),
 }));
+
+vi.mock("node:fs");
 
 import { PgVectorClient } from "@easy-flow/pgvector-client";
 import { PineconeContextEngine } from "@easy-flow/pinecone-context-engine";
@@ -37,6 +40,7 @@ describe("openclaw-pgvector-plugin", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(fs.readFileSync).mockReset();
     process.env = { ...originalEnv };
     delete process.env.PGVECTOR_DATABASE_URL;
     delete process.env.GEMINI_API_KEY;
@@ -122,6 +126,110 @@ describe("openclaw-pgvector-plugin", () => {
     expect(PgVectorClient).toHaveBeenCalledWith({
       databaseUrl: "postgres://config@localhost/db",
       geminiApiKey: "config-key",
+    });
+  });
+
+  describe("config fallback from openclaw.json", () => {
+    it("reads config from openclaw.json when api.pluginConfig is empty", () => {
+      const fallbackConfig = JSON.stringify({
+        plugins: {
+          entries: {
+            "pgvector-memory": {
+              config: {
+                databaseUrl: "postgres://fallback@localhost/db",
+                geminiApiKey: "fallback-key",
+                agentId: "fallback-agent",
+              },
+            },
+          },
+        },
+      });
+      vi.mocked(fs.readFileSync).mockReturnValue(fallbackConfig);
+
+      const api = createMockApi();
+      register(api as never);
+
+      expect(fs.readFileSync).toHaveBeenCalledWith("/data/openclaw.json", "utf8");
+      expect(api.registerContextEngine).toHaveBeenCalledWith(
+        "pgvector-memory",
+        expect.any(Function),
+      );
+      expect(api.logger.info).toHaveBeenCalledWith(
+        expect.stringContaining("agentId: fallback-agent"),
+      );
+    });
+
+    it("registers context engine with fallback config values", () => {
+      const fallbackConfig = JSON.stringify({
+        plugins: {
+          entries: {
+            "pgvector-memory": {
+              config: {
+                databaseUrl: "postgres://fallback@localhost/db",
+                geminiApiKey: "fallback-key",
+                agentId: "mell",
+                compactAfterDays: 14,
+              },
+            },
+          },
+        },
+      });
+      vi.mocked(fs.readFileSync).mockReturnValue(fallbackConfig);
+
+      const api = createMockApi();
+      register(api as never);
+
+      const factory = api.getRegisteredFactory();
+      factory?.();
+
+      expect(PgVectorClient).toHaveBeenCalledWith({
+        databaseUrl: "postgres://fallback@localhost/db",
+        geminiApiKey: "fallback-key",
+      });
+      expect(PineconeContextEngine).toHaveBeenCalledWith(
+        expect.objectContaining({
+          agentId: "mell",
+          compactAfterDays: 14,
+        }),
+      );
+    });
+
+    it("does not read openclaw.json when api.pluginConfig has values", () => {
+      const api = createMockApi({
+        databaseUrl: "postgres://config@localhost/db",
+        geminiApiKey: "config-key",
+      });
+      register(api as never);
+
+      expect(fs.readFileSync).not.toHaveBeenCalled();
+    });
+
+    it("disables plugin gracefully when openclaw.json read fails", () => {
+      vi.mocked(fs.readFileSync).mockImplementation(() => {
+        throw new Error("ENOENT: no such file or directory");
+      });
+
+      const api = createMockApi();
+      register(api as never);
+
+      expect(api.logger.debug).toHaveBeenCalledWith(
+        expect.stringContaining("readConfigFallback failed"),
+      );
+      expect(api.logger.warn).toHaveBeenCalledWith(expect.stringContaining("plugin disabled"));
+      expect(api.registerContextEngine).not.toHaveBeenCalled();
+    });
+
+    it("disables plugin when openclaw.json has no pgvector-memory entry", () => {
+      const fallbackConfig = JSON.stringify({
+        plugins: { entries: {} },
+      });
+      vi.mocked(fs.readFileSync).mockReturnValue(fallbackConfig);
+
+      const api = createMockApi();
+      register(api as never);
+
+      expect(api.logger.warn).toHaveBeenCalledWith(expect.stringContaining("plugin disabled"));
+      expect(api.registerContextEngine).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/openclaw-pgvector-plugin/src/index.ts
+++ b/packages/openclaw-pgvector-plugin/src/index.ts
@@ -1,3 +1,4 @@
+import * as fs from "node:fs";
 import { PgVectorClient } from "@easy-flow/pgvector-client";
 import { PineconeContextEngine } from "@easy-flow/pinecone-context-engine";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
@@ -11,8 +12,35 @@ type PluginConfig = {
   minQueryTokens?: number;
 };
 
+const OPENCLAW_CONFIG_PATH = "/data/openclaw.json";
+
+/**
+ * Fallback: read plugin config directly from openclaw.json when api.pluginConfig is empty.
+ *
+ * Auto-discovered extensions (loaded from /data/extensions/) may not receive config
+ * via api.pluginConfig due to entrypoint clearing plugins.load.paths.
+ * See: estack-inc/easy-flow#189
+ */
+function readConfigFallback(
+  configPath: string,
+  logger: Pick<OpenClawPluginApi["logger"], "debug">,
+): Partial<PluginConfig> {
+  try {
+    const raw = fs.readFileSync(configPath, "utf8");
+    const config = JSON.parse(raw);
+    return (config?.plugins?.entries?.["pgvector-memory"]?.config ?? {}) as Partial<PluginConfig>;
+  } catch (err) {
+    logger.debug(`readConfigFallback failed: ${err instanceof Error ? err.message : String(err)}`);
+    return {};
+  }
+}
+
 export default function register(api: OpenClawPluginApi): void {
-  const cfg = (api.pluginConfig ?? {}) as PluginConfig;
+  let cfg = (api.pluginConfig ?? {}) as PluginConfig;
+
+  if (Object.keys(cfg).length === 0) {
+    cfg = readConfigFallback(OPENCLAW_CONFIG_PATH, api.logger) as PluginConfig;
+  }
 
   const databaseUrl = cfg.databaseUrl ?? process.env.PGVECTOR_DATABASE_URL;
   const geminiApiKey = cfg.geminiApiKey ?? process.env.GEMINI_API_KEY;


### PR DESCRIPTION
## Summary
- auto-discovered extensions (`/data/extensions/`) では `api.pluginConfig` が空になる問題に対し、`openclaw.json` から直接設定を読み込む fallback を追加
- pinecone-memory プラグイン (#126) と同一パターンを適用
- メルでの pgvector ランタイム切り替え時に発見・修正済み

## Test plan
- [x] メル (gateway-a) で pgvector-memory ランタイム動作確認済み
- [x] Slack メッセージ送信 → pgvector 検索 → 正常応答を確認
- [x] レイテンシ計測: warm avg 396ms (Pinecone 710ms 比 44% 改善)

Ref: estack-inc/easy-flow#189