### PR TITLE
fix(model-router): add required name to registerHook call

### DIFF
--- a/packages/model-router/src/index.test.ts
+++ b/packages/model-router/src/index.test.ts
@@ -43,7 +43,9 @@ describe("model-router plugin", () => {
     const api = createMockApi();
     register(api as unknown as import("openclaw/plugin-sdk").OpenClawPluginApi);
 
-    expect(api.registerHook).toHaveBeenCalledWith(["before_model_resolve"], expect.any(Function));
+    expect(api.registerHook).toHaveBeenCalledWith(["before_model_resolve"], expect.any(Function), {
+      name: "model-router-resolve",
+    });
   });
 
   it("登録後に info ログを出力する", () => {

--- a/packages/model-router/src/index.ts
+++ b/packages/model-router/src/index.ts
@@ -18,54 +18,58 @@ export default function register(api: OpenClawPluginApi): void {
   };
 
   // before_model_resolve: プロンプトと添付ファイルを分析してモデルをオーバーライド
-  api.registerHook(["before_model_resolve"], (event: unknown, _ctx: unknown) => {
-    try {
-      const e = event as { prompt?: string; attachments?: AttachmentHint[] };
-      const prompt = e.prompt ?? "";
-      const attachments = e.attachments ?? [];
+  api.registerHook(
+    ["before_model_resolve"],
+    (event: unknown, _ctx: unknown) => {
+      try {
+        const e = event as { prompt?: string; attachments?: AttachmentHint[] };
+        const prompt = e.prompt ?? "";
+        const attachments = e.attachments ?? [];
 
-      // 1. ファイルルーティング（最優先）
-      if (cfg.fileRouting.enabled && attachments.length > 0) {
-        const fileRoute = routeByAttachments(attachments, cfg.fileRouting.rules ?? []);
-        if (fileRoute) {
+        // 1. ファイルルーティング（最優先）
+        if (cfg.fileRouting.enabled && attachments.length > 0) {
+          const fileRoute = routeByAttachments(attachments, cfg.fileRouting.rules ?? []);
+          if (fileRoute) {
+            if (cfg.logging) {
+              api.logger.info(
+                `[model-router] → ${fileRoute.provider}/${fileRoute.model}` +
+                  ` (file: ${fileRoute.matchedRule}, prompt: "${prompt.slice(0, 40)}${prompt.length > 40 ? "..." : ""}")`,
+              );
+            }
+            return {
+              modelOverride: fileRoute.model,
+              providerOverride: fileRoute.provider,
+            };
+          }
+        }
+
+        // 2. テキストベースのルーティング
+        const result = classifyMessage(prompt, cfg);
+
+        if (result === "light") {
           if (cfg.logging) {
             api.logger.info(
-              `[model-router] → ${fileRoute.provider}/${fileRoute.model}` +
-                ` (file: ${fileRoute.matchedRule}, prompt: "${prompt.slice(0, 40)}${prompt.length > 40 ? "..." : ""}")`,
+              `[model-router] → ${cfg.lightProvider}/${cfg.lightModel}` +
+                ` (prompt: "${prompt.slice(0, 50)}${prompt.length > 50 ? "..." : ""}")`,
             );
           }
           return {
-            modelOverride: fileRoute.model,
-            providerOverride: fileRoute.provider,
+            modelOverride: cfg.lightModel,
+            providerOverride: cfg.lightProvider,
           };
         }
-      }
 
-      // 2. テキストベースのルーティング
-      const result = classifyMessage(prompt, cfg);
-
-      if (result === "light") {
         if (cfg.logging) {
-          api.logger.info(
-            `[model-router] → ${cfg.lightProvider}/${cfg.lightModel}` +
-              ` (prompt: "${prompt.slice(0, 50)}${prompt.length > 50 ? "..." : ""}")`,
-          );
+          api.logger.debug(`[model-router] → ${cfg.defaultProvider}/${cfg.defaultModel} (default)`);
         }
-        return {
-          modelOverride: cfg.lightModel,
-          providerOverride: cfg.lightProvider,
-        };
+        // void return = デフォルトモデル維持
+      } catch (err) {
+        // 例外時はデフォルトモデルを維持（void return）
+        api.logger.warn(`[model-router] classify error: ${err}`);
       }
-
-      if (cfg.logging) {
-        api.logger.debug(`[model-router] → ${cfg.defaultProvider}/${cfg.defaultModel} (default)`);
-      }
-      // void return = デフォルトモデル維持
-    } catch (err) {
-      // 例外時はデフォルトモデルを維持（void return）
-      api.logger.warn(`[model-router] classify error: ${err}`);
-    }
-  });
+    },
+    { name: "model-router-resolve" },
+  );
 
   api.logger.info("[model-router] plugin registered");
 }


### PR DESCRIPTION
## Summary

- Add `{ name: "model-router-resolve" }` to `api.registerHook()` call
- Without a name, OpenClaw's plugin registry silently skips the hook registration

## Root cause

OpenClaw's `registerHook` implementation (`src/plugins/registry.ts:226`) requires a `name` in the options parameter. When `name` is undefined, it logs a diagnostic warning and returns without registering the hook. The model-router was not providing this option, so the hook was never registered — meaning `before_model_resolve` events were never delivered to the plugin.

## Test plan

- [ ] Deploy to dev-and-test-agent, send "こんにちは" → log shows `[model-router] → anthropic/claude-haiku-4-5`