### PR TITLE
fix(model-router): use api.on() for typed hook registration

### DIFF
--- a/packages/model-router/src/index.test.ts
+++ b/packages/model-router/src/index.test.ts
@@ -10,7 +10,7 @@ type MockApi = {
     error: ReturnType<typeof vi.fn>;
     debug: ReturnType<typeof vi.fn>;
   };
-  registerHook: ReturnType<typeof vi.fn>;
+  on: ReturnType<typeof vi.fn>;
 };
 
 function createMockApi(pluginConfig: Record<string, unknown> = {}): MockApi {
@@ -22,7 +22,7 @@ function createMockApi(pluginConfig: Record<string, unknown> = {}): MockApi {
       error: vi.fn(),
       debug: vi.fn(),
     },
-    registerHook: vi.fn(),
+    on: vi.fn(),
   };
 }
 
@@ -31,10 +31,7 @@ function callHook(
   api: MockApi,
   event: { prompt?: string; attachments?: { kind: string; mimeType?: string }[] },
 ) {
-  const [, handler] = api.registerHook.mock.calls[0] as [
-    string[],
-    (e: unknown, ctx: unknown) => unknown,
-  ];
+  const [, handler] = api.on.mock.calls[0] as [string, (e: unknown, ctx: unknown) => unknown];
   return handler(event, {});
 }
 
@@ -43,9 +40,7 @@ describe("model-router plugin", () => {
     const api = createMockApi();
     register(api as unknown as import("openclaw/plugin-sdk").OpenClawPluginApi);
 
-    expect(api.registerHook).toHaveBeenCalledWith(["before_model_resolve"], expect.any(Function), {
-      name: "model-router-resolve",
-    });
+    expect(api.on).toHaveBeenCalledWith("before_model_resolve", expect.any(Function));
   });
 
   it("登録後に info ログを出力する", () => {
@@ -272,10 +267,7 @@ describe("model-router plugin", () => {
     register(api as unknown as import("openclaw/plugin-sdk").OpenClawPluginApi);
 
     // ハンドラに null を渡して event.prompt アクセスで例外を発生させる
-    const [, handler] = api.registerHook.mock.calls[0] as [
-      string[],
-      (e: unknown, ctx: unknown) => unknown,
-    ];
+    const [, handler] = api.on.mock.calls[0] as [string, (e: unknown, ctx: unknown) => unknown];
     const result = handler(null, {});
 
     expect(result).toBeUndefined();

--- a/packages/model-router/src/index.ts
+++ b/packages/model-router/src/index.ts
@@ -18,58 +18,56 @@ export default function register(api: OpenClawPluginApi): void {
   };
 
   // before_model_resolve: プロンプトと添付ファイルを分析してモデルをオーバーライド
-  api.registerHook(
-    ["before_model_resolve"],
-    (event: unknown, _ctx: unknown) => {
-      try {
-        const e = event as { prompt?: string; attachments?: AttachmentHint[] };
-        const prompt = e.prompt ?? "";
-        const attachments = e.attachments ?? [];
+  // api.on() は typedHooks に登録され、hook runner が参照する新しい API
+  // api.registerHook() は旧 registry.hooks にしか書き込まないため使わない
+  api.on("before_model_resolve", (event: unknown, _ctx: unknown) => {
+    try {
+      const e = event as { prompt?: string; attachments?: AttachmentHint[] };
+      const prompt = e.prompt ?? "";
+      const attachments = e.attachments ?? [];
 
-        // 1. ファイルルーティング（最優先）
-        if (cfg.fileRouting.enabled && attachments.length > 0) {
-          const fileRoute = routeByAttachments(attachments, cfg.fileRouting.rules ?? []);
-          if (fileRoute) {
-            if (cfg.logging) {
-              api.logger.info(
-                `[model-router] → ${fileRoute.provider}/${fileRoute.model}` +
-                  ` (file: ${fileRoute.matchedRule}, prompt: "${prompt.slice(0, 40)}${prompt.length > 40 ? "..." : ""}")`,
-              );
-            }
-            return {
-              modelOverride: fileRoute.model,
-              providerOverride: fileRoute.provider,
-            };
-          }
-        }
-
-        // 2. テキストベースのルーティング
-        const result = classifyMessage(prompt, cfg);
-
-        if (result === "light") {
+      // 1. ファイルルーティング（最優先）
+      if (cfg.fileRouting.enabled && attachments.length > 0) {
+        const fileRoute = routeByAttachments(attachments, cfg.fileRouting.rules ?? []);
+        if (fileRoute) {
           if (cfg.logging) {
             api.logger.info(
-              `[model-router] → ${cfg.lightProvider}/${cfg.lightModel}` +
-                ` (prompt: "${prompt.slice(0, 50)}${prompt.length > 50 ? "..." : ""}")`,
+              `[model-router] → ${fileRoute.provider}/${fileRoute.model}` +
+                ` (file: ${fileRoute.matchedRule}, prompt: "${prompt.slice(0, 40)}${prompt.length > 40 ? "..." : ""}")`,
             );
           }
           return {
-            modelOverride: cfg.lightModel,
-            providerOverride: cfg.lightProvider,
+            modelOverride: fileRoute.model,
+            providerOverride: fileRoute.provider,
           };
         }
-
-        if (cfg.logging) {
-          api.logger.debug(`[model-router] → ${cfg.defaultProvider}/${cfg.defaultModel} (default)`);
-        }
-        // void return = デフォルトモデル維持
-      } catch (err) {
-        // 例外時はデフォルトモデルを維持（void return）
-        api.logger.warn(`[model-router] classify error: ${err}`);
       }
-    },
-    { name: "model-router-resolve" },
-  );
+
+      // 2. テキストベースのルーティング
+      const result = classifyMessage(prompt, cfg);
+
+      if (result === "light") {
+        if (cfg.logging) {
+          api.logger.info(
+            `[model-router] → ${cfg.lightProvider}/${cfg.lightModel}` +
+              ` (prompt: "${prompt.slice(0, 50)}${prompt.length > 50 ? "..." : ""}")`,
+          );
+        }
+        return {
+          modelOverride: cfg.lightModel,
+          providerOverride: cfg.lightProvider,
+        };
+      }
+
+      if (cfg.logging) {
+        api.logger.debug(`[model-router] → ${cfg.defaultProvider}/${cfg.defaultModel} (default)`);
+      }
+      // void return = デフォルトモデル維持
+    } catch (err) {
+      // 例外時はデフォルトモデルを維持（void return）
+      api.logger.warn(`[model-router] classify error: ${err}`);
+    }
+  });
 
   api.logger.info("[model-router] plugin registered");
 }


### PR DESCRIPTION
## Summary
- `api.registerHook()` は旧レジストリ（`registry.hooks`）にしか書き込まないため、hook runner が参照する `registry.typedHooks` にフックが登録されず、実行時にフックが発火しなかった
- `api.on("before_model_resolve", handler)` に変更し、正しく `typedHooks` に登録されるようにした

## Root Cause
OpenClaw のプラグインシステムには 2 つのフック登録パス:
1. `api.registerHook()` → `registry.hooks` + `registerInternalHook`（旧システム）
2. `api.on()` → `registry.typedHooks`（新システム、hook runner が参照）

model-router は `api.registerHook()` を使っていたため、`register()` 関数は成功し `[model-router] plugin registered` ログが出るが、実際のフックハンドラは hook runner から見えず発火しなかった。

## Test plan
- [ ] `npm test` 50/50 pass
- [ ] `npx biome check` clean
- [ ] dev-and-test-agent で再起動後、「おはよう」送信 → `[model-router] → anthropic/claude-haiku-4-5` ログ確認
- [ ] 画像添付送信 → `[model-router] → google/gemini-2.5-flash (file: image)` ログ確認