### PR TITLE
feat(model-router): detect MEDIA: markers in prompt for image routing

### DIFF
--- a/packages/model-router/src/classifier.test.ts
+++ b/packages/model-router/src/classifier.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   type AttachmentHint,
   classifyMessage,
+  detectMediaInPrompt,
   matchMimePattern,
   routeByAttachments,
 } from "./classifier.js";
@@ -259,5 +260,49 @@ describe("routeByAttachments", () => {
       provider: "google",
       matchedRule: "pdf-only",
     });
+  });
+});
+
+describe("detectMediaInPrompt", () => {
+  it("MEDIA: /path/to/image.png → image hint", () => {
+    const hints = detectMediaInPrompt("Hello\nMEDIA: /tmp/photo.png\nworld");
+    expect(hints).toEqual([{ kind: "image", mimeType: "image/png" }]);
+  });
+
+  it("MEDIA: `backtick path` → image hint", () => {
+    const hints = detectMediaInPrompt("MEDIA: `/data/uploads/screenshot.jpg`");
+    expect(hints).toEqual([{ kind: "image", mimeType: "image/jpeg" }]);
+  });
+
+  it("MEDIA: video.mp4 → video hint", () => {
+    const hints = detectMediaInPrompt("MEDIA: /tmp/clip.mp4");
+    expect(hints).toEqual([{ kind: "video", mimeType: "video/mp4" }]);
+  });
+
+  it("MEDIA: audio.mp3 → audio hint", () => {
+    const hints = detectMediaInPrompt("MEDIA: /tmp/voice.mp3");
+    expect(hints).toEqual([{ kind: "audio", mimeType: "audio/mpeg" }]);
+  });
+
+  it("MEDIA: document.pdf → document hint", () => {
+    const hints = detectMediaInPrompt("MEDIA: /tmp/report.pdf");
+    expect(hints).toEqual([{ kind: "document", mimeType: "application/pdf" }]);
+  });
+
+  it("MEDIA: without extension → assume image", () => {
+    const hints = detectMediaInPrompt("MEDIA: /tmp/unknown_file");
+    expect(hints).toEqual([{ kind: "image" }]);
+  });
+
+  it("no MEDIA marker → empty", () => {
+    const hints = detectMediaInPrompt("Just a normal message");
+    expect(hints).toEqual([]);
+  });
+
+  it("multiple MEDIA markers → multiple hints", () => {
+    const hints = detectMediaInPrompt("MEDIA: /a.png\nMEDIA: /b.pdf");
+    expect(hints).toHaveLength(2);
+    expect(hints[0]).toEqual({ kind: "image", mimeType: "image/png" });
+    expect(hints[1]).toEqual({ kind: "document", mimeType: "application/pdf" });
   });
 });

--- a/packages/model-router/src/classifier.ts
+++ b/packages/model-router/src/classifier.ts
@@ -68,6 +68,56 @@ export function routeByAttachments(
 }
 
 /**
+ * プロンプト内のメディアマーカー（`MEDIA: /path/to/file`）を検出し、
+ * AttachmentHint に変換する。
+ * OpenClaw のチャネル（LINE 等）は画像をプロンプト内 MEDIA マーカーとして渡すため、
+ * before_model_resolve 時点では attachments が空でもプロンプトにメディア参照が含まれる。
+ */
+export function detectMediaInPrompt(prompt: string): AttachmentHint[] {
+  const hints: AttachmentHint[] = [];
+  for (const line of prompt.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed.startsWith("MEDIA:")) continue;
+    const afterColon = trimmed.slice(6).trim();
+    const raw = afterColon.match(/^`([^`]+)`$/)?.[1] ?? afterColon;
+    if (!raw) continue;
+    const lower = raw.toLowerCase();
+    if (/\.(png|jpe?g|gif|webp|bmp|svg|tiff?|ico|heic|heif)$/i.test(lower)) {
+      hints.push({ kind: "image", mimeType: inferMimeFromExt(lower) });
+    } else if (/\.(mp4|mov|avi|webm|mkv|flv|wmv)$/i.test(lower)) {
+      hints.push({ kind: "video", mimeType: inferMimeFromExt(lower) });
+    } else if (/\.(mp3|wav|ogg|flac|aac|m4a|wma)$/i.test(lower)) {
+      hints.push({ kind: "audio", mimeType: inferMimeFromExt(lower) });
+    } else if (/\.(pdf|docx?|xlsx?|pptx?|csv|tsv|txt)$/i.test(lower)) {
+      hints.push({ kind: "document", mimeType: inferMimeFromExt(lower) });
+    } else {
+      hints.push({ kind: "image" }); // MEDIA: without extension → assume image
+    }
+  }
+  return hints;
+}
+
+function inferMimeFromExt(path: string): string | undefined {
+  const ext = path.match(/\.([a-z0-9]+)$/i)?.[1]?.toLowerCase();
+  if (!ext) return undefined;
+  const map: Record<string, string> = {
+    png: "image/png",
+    jpg: "image/jpeg",
+    jpeg: "image/jpeg",
+    gif: "image/gif",
+    webp: "image/webp",
+    mp4: "video/mp4",
+    mov: "video/quicktime",
+    mp3: "audio/mpeg",
+    wav: "audio/wav",
+    pdf: "application/pdf",
+    csv: "text/csv",
+    txt: "text/plain",
+  };
+  return map[ext];
+}
+
+/**
  * ユーザープロンプトを分類し、軽量モデルで処理可能かを判定する。
  *
  * 判定優先順位:

--- a/packages/model-router/src/index.ts
+++ b/packages/model-router/src/index.ts
@@ -1,5 +1,10 @@
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
-import { type AttachmentHint, classifyMessage, routeByAttachments } from "./classifier.js";
+import {
+  type AttachmentHint,
+  classifyMessage,
+  detectMediaInPrompt,
+  routeByAttachments,
+} from "./classifier.js";
 import { DEFAULT_CONFIG, DEFAULT_FILE_ROUTING_RULES, type ModelRouterConfig } from "./config.js";
 
 export default function register(api: OpenClawPluginApi): void {
@@ -24,7 +29,17 @@ export default function register(api: OpenClawPluginApi): void {
     try {
       const e = event as { prompt?: string; attachments?: AttachmentHint[] };
       const prompt = e.prompt ?? "";
-      const attachments = e.attachments ?? [];
+      // attachments: upstream hook event から取得 + プロンプト内 MEDIA: マーカーから補完
+      const eventAttachments = e.attachments ?? [];
+      const promptMedia = detectMediaInPrompt(prompt);
+      const attachments = eventAttachments.length > 0 ? eventAttachments : promptMedia;
+
+      if (cfg.logging) {
+        api.logger.info(
+          `[model-router] hook fired: attachments=${attachments.length}` +
+            `(event=${eventAttachments.length},prompt=${promptMedia.length}), ${prompt.length}chars`,
+        );
+      }
 
       // 1. ファイルルーティング（最優先）
       if (cfg.fileRouting.enabled && attachments.length > 0) {


### PR DESCRIPTION
## Summary
- LINE チャネルは画像を `MEDIA: /path/to/file` マーカーとしてプロンプトテキスト内に渡すため、hook event の attachments は空になる
- `detectMediaInPrompt()` を追加し、プロンプト内の MEDIA マーカーからファイル種別を検出
- 画像・動画・音声・ドキュメント添付時に Gemini Flash へルーティング可能に
- upstream の openclaw パッチ不要で自己完結する実装

## Changes
- `classifier.ts`: `detectMediaInPrompt()` + `inferMimeFromExt()` 追加
- `index.ts`: プロンプト内メディア検出を hook ハンドラに統合、診断ログ追加
- `classifier.test.ts`: `detectMediaInPrompt` の 8 テスト追加（全 58 テストパス）

## Test plan
- [ ] dev-and-test-agent にデプロイし画像送信でログ確認
- [ ] `[model-router] hook fired: attachments=1(event=0,prompt=1)` が出力されることを確認
- [ ] `[model-router] → google/gemini-2.5-flash (file: image)` でルーティングされることを確認