### PR TITLE
fix(model-router): detect [media attached:] format for image routing

### DIFF
--- a/packages/model-router/src/classifier.test.ts
+++ b/packages/model-router/src/classifier.test.ts
@@ -264,6 +264,62 @@ describe("routeByAttachments", () => {
 });
 
 describe("detectMediaInPrompt", () => {
+  // === [media attached: ...] 形式（OpenClaw 標準） ===
+  it("[media attached: /path (image/png)] → image hint", () => {
+    const hints = detectMediaInPrompt("[media attached: /data/media/abc.png (image/png)]");
+    expect(hints).toEqual([{ kind: "image", mimeType: "image/png" }]);
+  });
+
+  it("[media attached: /path (image/jpeg)] → image hint", () => {
+    const hints = detectMediaInPrompt("prefix\n[media attached: /data/img.jpg (image/jpeg)]\ntext");
+    expect(hints).toEqual([{ kind: "image", mimeType: "image/jpeg" }]);
+  });
+
+  it("[media attached: /path (video/mp4)] → video hint", () => {
+    const hints = detectMediaInPrompt("[media attached: /data/clip.mp4 (video/mp4)]");
+    expect(hints).toEqual([{ kind: "video", mimeType: "video/mp4" }]);
+  });
+
+  it("[media attached: /path (audio/mpeg)] → audio hint", () => {
+    const hints = detectMediaInPrompt("[media attached: /data/voice.mp3 (audio/mpeg)]");
+    expect(hints).toEqual([{ kind: "audio", mimeType: "audio/mpeg" }]);
+  });
+
+  it("[media attached: /path (application/pdf)] → document hint", () => {
+    const hints = detectMediaInPrompt("[media attached: /data/report.pdf (application/pdf)]");
+    expect(hints).toEqual([{ kind: "document", mimeType: "application/pdf" }]);
+  });
+
+  it("[media attached: /path (text/csv)] → document hint", () => {
+    const hints = detectMediaInPrompt("[media attached: /data/data.csv (text/csv)]");
+    expect(hints).toEqual([{ kind: "document", mimeType: "text/csv" }]);
+  });
+
+  it("[media attached N/M: ...] 複数添付形式", () => {
+    const prompt = [
+      "[media attached: 2 files]",
+      "[media attached 1/2: /data/a.png (image/png)]",
+      "[media attached 2/2: /data/b.pdf (application/pdf)]",
+    ].join("\n");
+    const hints = detectMediaInPrompt(prompt);
+    expect(hints).toHaveLength(2);
+    expect(hints[0]).toEqual({ kind: "image", mimeType: "image/png" });
+    expect(hints[1]).toEqual({ kind: "document", mimeType: "application/pdf" });
+  });
+
+  it("[media attached: ...] URL 付き形式", () => {
+    const hints = detectMediaInPrompt(
+      "[media attached: /data/photo.png (image/png) | https://example.com/photo.png]",
+    );
+    expect(hints).toEqual([{ kind: "image", mimeType: "image/png" }]);
+  });
+
+  it("[media attached: /path] MIME なし → 拡張子から推定", () => {
+    const hints = detectMediaInPrompt("[media attached: /data/photo.png]");
+    expect(hints).toEqual([{ kind: "image", mimeType: "image/png" }]);
+  });
+
+  // === MEDIA: 形式（レガシー / フォールバック） ===
   it("MEDIA: /path/to/image.png → image hint", () => {
     const hints = detectMediaInPrompt("Hello\nMEDIA: /tmp/photo.png\nworld");
     expect(hints).toEqual([{ kind: "image", mimeType: "image/png" }]);
@@ -294,12 +350,13 @@ describe("detectMediaInPrompt", () => {
     expect(hints).toEqual([{ kind: "image" }]);
   });
 
-  it("no MEDIA marker → empty", () => {
+  // === 共通 ===
+  it("マーカーなし → empty", () => {
     const hints = detectMediaInPrompt("Just a normal message");
     expect(hints).toEqual([]);
   });
 
-  it("multiple MEDIA markers → multiple hints", () => {
+  it("複数 MEDIA markers → multiple hints", () => {
     const hints = detectMediaInPrompt("MEDIA: /a.png\nMEDIA: /b.pdf");
     expect(hints).toHaveLength(2);
     expect(hints[0]).toEqual({ kind: "image", mimeType: "image/png" });

--- a/packages/model-router/src/classifier.ts
+++ b/packages/model-router/src/classifier.ts
@@ -68,13 +68,41 @@ export function routeByAttachments(
 }
 
 /**
- * プロンプト内のメディアマーカー（`MEDIA: /path/to/file`）を検出し、
- * AttachmentHint に変換する。
- * OpenClaw のチャネル（LINE 等）は画像をプロンプト内 MEDIA マーカーとして渡すため、
- * before_model_resolve 時点では attachments が空でもプロンプトにメディア参照が含まれる。
+ * プロンプト内のメディアマーカーを検出し、AttachmentHint に変換する。
+ *
+ * OpenClaw は LINE 等のチャネルから受信した画像を以下の形式でプロンプトに埋め込む:
+ *   - `[media attached: /path/to/file (image/png)]`           — 単体添付
+ *   - `[media attached 1/2: /path/to/file (image/png)]`       — 複数添付
+ *   - `[media attached: /path (image/png) | https://url]`     — URL 付き
+ *
+ * before_model_resolve フック発火時点でプロンプトに含まれるため、
+ * attachments が空でもプロンプトからメディア参照を検出できる。
  */
 export function detectMediaInPrompt(prompt: string): AttachmentHint[] {
   const hints: AttachmentHint[] = [];
+
+  // Pattern 1: [media attached: /path (type)] or [media attached N/M: /path (type)]
+  const mediaAttachedRe = /\[media attached(?:\s+\d+\/\d+)?:\s+([^\s\]]+)(?:\s+\(([^)]+)\))?/g;
+  let match: RegExpExecArray | null;
+  while ((match = mediaAttachedRe.exec(prompt)) !== null) {
+    const path = match[1] ?? "";
+    // サマリー行 "[media attached: 2 files]" をスキップ
+    if (/^\d+$/.test(path)) continue;
+    const mimeType = match[2]?.trim();
+    if (mimeType) {
+      hints.push({ kind: classifyMimeKind(mimeType), mimeType });
+    } else {
+      // MIME 不明 → 拡張子から推定
+      const inferred = inferMimeFromExt(path.toLowerCase());
+      hints.push(
+        inferred
+          ? { kind: classifyMimeKind(inferred), mimeType: inferred }
+          : { kind: "image" },
+      );
+    }
+  }
+
+  // Pattern 2: MEDIA: /path/to/file (legacy / future format)
   for (const line of prompt.split(/\r?\n/)) {
     const trimmed = line.trim();
     if (!trimmed.startsWith("MEDIA:")) continue;
@@ -82,19 +110,32 @@ export function detectMediaInPrompt(prompt: string): AttachmentHint[] {
     const raw = afterColon.match(/^`([^`]+)`$/)?.[1] ?? afterColon;
     if (!raw) continue;
     const lower = raw.toLowerCase();
-    if (/\.(png|jpe?g|gif|webp|bmp|svg|tiff?|ico|heic|heif)$/i.test(lower)) {
-      hints.push({ kind: "image", mimeType: inferMimeFromExt(lower) });
-    } else if (/\.(mp4|mov|avi|webm|mkv|flv|wmv)$/i.test(lower)) {
-      hints.push({ kind: "video", mimeType: inferMimeFromExt(lower) });
-    } else if (/\.(mp3|wav|ogg|flac|aac|m4a|wma)$/i.test(lower)) {
-      hints.push({ kind: "audio", mimeType: inferMimeFromExt(lower) });
-    } else if (/\.(pdf|docx?|xlsx?|pptx?|csv|tsv|txt)$/i.test(lower)) {
-      hints.push({ kind: "document", mimeType: inferMimeFromExt(lower) });
+    const inferred = inferMimeFromExt(lower);
+    if (inferred) {
+      hints.push({ kind: classifyMimeKind(inferred), mimeType: inferred });
     } else {
       hints.push({ kind: "image" }); // MEDIA: without extension → assume image
     }
   }
+
   return hints;
+}
+
+/** MIME type からメディア種別を分類する */
+function classifyMimeKind(mimeType: string): AttachmentHint["kind"] {
+  if (mimeType.startsWith("image/")) return "image";
+  if (mimeType.startsWith("video/")) return "video";
+  if (mimeType.startsWith("audio/")) return "audio";
+  if (
+    mimeType.startsWith("text/") ||
+    mimeType === "application/pdf" ||
+    mimeType.includes("document") ||
+    mimeType.includes("spreadsheet") ||
+    mimeType.includes("presentation")
+  ) {
+    return "document";
+  }
+  return "other";
 }
 
 function inferMimeFromExt(path: string): string | undefined {

--- a/packages/model-router/src/classifier.ts
+++ b/packages/model-router/src/classifier.ts
@@ -83,21 +83,18 @@ export function detectMediaInPrompt(prompt: string): AttachmentHint[] {
 
   // Pattern 1: [media attached: /path (type)] or [media attached N/M: /path (type)]
   const mediaAttachedRe = /\[media attached(?:\s+\d+\/\d+)?:\s+([^\s\]]+)(?:\s+\(([^)]+)\))?/g;
-  let match: RegExpExecArray | null;
-  while ((match = mediaAttachedRe.exec(prompt)) !== null) {
-    const path = match[1] ?? "";
+  for (const m of prompt.matchAll(mediaAttachedRe)) {
+    const path = m[1] ?? "";
     // サマリー行 "[media attached: 2 files]" をスキップ
     if (/^\d+$/.test(path)) continue;
-    const mimeType = match[2]?.trim();
+    const mimeType = m[2]?.trim();
     if (mimeType) {
       hints.push({ kind: classifyMimeKind(mimeType), mimeType });
     } else {
       // MIME 不明 → 拡張子から推定
       const inferred = inferMimeFromExt(path.toLowerCase());
       hints.push(
-        inferred
-          ? { kind: classifyMimeKind(inferred), mimeType: inferred }
-          : { kind: "image" },
+        inferred ? { kind: classifyMimeKind(inferred), mimeType: inferred } : { kind: "image" },
       );
     }
   }

--- a/packages/model-router/src/index.ts
+++ b/packages/model-router/src/index.ts
@@ -35,9 +35,11 @@ export default function register(api: OpenClawPluginApi): void {
       const attachments = eventAttachments.length > 0 ? eventAttachments : promptMedia;
 
       if (cfg.logging) {
+        const preview = prompt.slice(0, 200).replace(/\n/g, "\\n");
         api.logger.info(
           `[model-router] hook fired: attachments=${attachments.length}` +
-            `(event=${eventAttachments.length},prompt=${promptMedia.length}), ${prompt.length}chars`,
+            `(event=${eventAttachments.length},prompt=${promptMedia.length}), ${prompt.length}chars` +
+            ` | preview: "${preview}"`,
         );
       }
 


### PR DESCRIPTION
## Summary
- OpenClaw はメディア参照をプロンプト内に `[media attached: /path (mime/type)]` 形式で埋め込むが、以前の実装では `MEDIA:` 形式を検出していた
- `detectMediaInPrompt()` を `[media attached:]` 形式に対応するよう修正
- MIME type をアノテーションから直接抽出し、拡張子推定フォールバックも維持

## Changes
- `classifier.ts`: `[media attached(?:\s+\d+\/\d+)?:]` 正規表現で標準形式をパース、`classifyMimeKind()` 追加
- `classifier.test.ts`: [media attached:] 形式のテスト 9 件追加（67 テスト全パス）
- `index.ts`: デバッグ用プロンプトプレビューログ追加

## Test plan
- [ ] dev-and-test-agent にデプロイし画像送信でルーティング確認