### PR TITLE
chore(model-router): remove debug prompt preview from logs

### DIFF
--- a/packages/model-router/src/index.ts
+++ b/packages/model-router/src/index.ts
@@ -35,11 +35,9 @@ export default function register(api: OpenClawPluginApi): void {
       const attachments = eventAttachments.length > 0 ? eventAttachments : promptMedia;
 
       if (cfg.logging) {
-        const preview = prompt.slice(0, 200).replace(/\n/g, "\\n");
         api.logger.info(
           `[model-router] hook fired: attachments=${attachments.length}` +
-            `(event=${eventAttachments.length},prompt=${promptMedia.length}), ${prompt.length}chars` +
-            ` | preview: "${preview}"`,
+            `(event=${eventAttachments.length},prompt=${promptMedia.length}), ${prompt.length}chars`,
         );
       }
 


### PR DESCRIPTION
本番展開前にデバッグ用プロンプトプレビューログを削除。attachments カウントログは維持。