### PR TITLE
docs: codex-review に model: gpt-5.4 を追加

### DIFF
--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -105,6 +105,7 @@ jobs:
         if: steps.check_files.outputs.skip != 'true'
         uses: openai/codex-action@v1
         with:
+          model: gpt-5.4
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
           output-file: /tmp/review-result.md
           sandbox: workspace-write


### PR DESCRIPTION
## Summary

- codex-review.yml の codex-action に `model: gpt-5.4` を追加

## Test plan

- [ ] codex-review ワークフローが正常に動作すること