### PR TITLE
fix(pgvector-memory): RAG モードが有効にならないバグを修正

### DIFF
--- a/packages/openclaw-pgvector-plugin/openclaw.plugin.json
+++ b/packages/openclaw-pgvector-plugin/openclaw.plugin.json
@@ -37,7 +37,9 @@
       "agentId": { "type": "string" },
       "compactAfterDays": { "type": "number", "minimum": 1, "maximum": 90 },
       "memoryHint": { "type": "string" },
-      "minQueryTokens": { "type": "number", "minimum": 1 }
+      "minQueryTokens": { "type": "number", "minimum": 1 },
+      "ragEnabled": { "type": "boolean" },
+      "agentsCorePath": { "type": "string" }
     }
   }
 }

--- a/packages/openclaw-pgvector-plugin/src/index.test.ts
+++ b/packages/openclaw-pgvector-plugin/src/index.test.ts
@@ -109,6 +109,46 @@ describe("openclaw-pgvector-plugin", () => {
     expect(api.logger.info).toHaveBeenCalledWith(expect.stringContaining("agentId: default"));
   });
 
+  it("should pass ragEnabled and agentsCorePath from env vars", () => {
+    process.env.PGVECTOR_DATABASE_URL = "postgres://test@localhost/db";
+    process.env.GEMINI_API_KEY = "test-key";
+    process.env.RAG_ENABLED = "true";
+    process.env.RAG_AGENTS_CORE_PATH = "/data/workspace/AGENTS-CORE.md";
+
+    const api = createMockApi();
+    register(api as never);
+
+    const factory = api.getRegisteredFactory();
+    factory?.();
+
+    expect(PineconeContextEngine).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ragEnabled: true,
+        agentsCorePath: "/data/workspace/AGENTS-CORE.md",
+      }),
+    );
+    expect(api.logger.info).toHaveBeenCalledWith(expect.stringContaining("ragEnabled: true"));
+  });
+
+  it("should default ragEnabled to false when RAG_ENABLED is not set", () => {
+    process.env.PGVECTOR_DATABASE_URL = "postgres://test@localhost/db";
+    process.env.GEMINI_API_KEY = "test-key";
+
+    const api = createMockApi();
+    register(api as never);
+
+    const factory = api.getRegisteredFactory();
+    factory?.();
+
+    expect(PineconeContextEngine).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ragEnabled: false,
+        agentsCorePath: undefined,
+      }),
+    );
+    expect(api.logger.info).toHaveBeenCalledWith(expect.stringContaining("ragEnabled: false"));
+  });
+
   it("should prefer plugin config over env vars", () => {
     process.env.PGVECTOR_DATABASE_URL = "postgres://env@localhost/db";
     process.env.GEMINI_API_KEY = "env-key";

--- a/packages/openclaw-pgvector-plugin/src/index.test.ts
+++ b/packages/openclaw-pgvector-plugin/src/index.test.ts
@@ -151,6 +151,50 @@ describe("openclaw-pgvector-plugin", () => {
     expect(api.logger.info).toHaveBeenCalledWith(expect.stringContaining("ragEnabled: false"));
   });
 
+  it("should pass ragEnabled and agentsCorePath from pluginConfig", () => {
+    const api = createMockApi({
+      databaseUrl: "postgres://config@localhost/db",
+      geminiApiKey: "config-key",
+      ragEnabled: true,
+      agentsCorePath: "/data/workspace/AGENTS-CORE.md",
+    });
+
+    register(api as never);
+
+    const factory = api.getRegisteredFactory();
+    factory?.();
+
+    expect(PineconeContextEngine).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ragEnabled: true,
+        agentsCorePath: "/data/workspace/AGENTS-CORE.md",
+      }),
+    );
+  });
+
+  it("should prefer pluginConfig ragEnabled over env var", () => {
+    process.env.PGVECTOR_DATABASE_URL = "postgres://test@localhost/db";
+    process.env.GEMINI_API_KEY = "test-key";
+    process.env.RAG_ENABLED = "false";
+
+    const api = createMockApi({
+      databaseUrl: "postgres://config@localhost/db",
+      geminiApiKey: "config-key",
+      ragEnabled: true,
+    });
+
+    register(api as never);
+
+    const factory = api.getRegisteredFactory();
+    factory?.();
+
+    expect(PineconeContextEngine).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ragEnabled: true,
+      }),
+    );
+  });
+
   it("should prefer plugin config over env vars", () => {
     process.env.PGVECTOR_DATABASE_URL = "postgres://env@localhost/db";
     process.env.GEMINI_API_KEY = "env-key";
@@ -259,6 +303,38 @@ describe("openclaw-pgvector-plugin", () => {
       );
       expect(api.logger.warn).toHaveBeenCalledWith(expect.stringContaining("plugin disabled"));
       expect(api.registerContextEngine).not.toHaveBeenCalled();
+    });
+
+    it("reads ragEnabled and agentsCorePath from openclaw.json fallback", () => {
+      const fallbackConfig = JSON.stringify({
+        plugins: {
+          entries: {
+            "pgvector-memory": {
+              config: {
+                databaseUrl: "postgres://fallback@localhost/db",
+                geminiApiKey: "fallback-key",
+                agentId: "fallback-agent",
+                ragEnabled: true,
+                agentsCorePath: "/data/workspace/AGENTS-CORE.md",
+              },
+            },
+          },
+        },
+      });
+      vi.mocked(fs.readFileSync).mockReturnValue(fallbackConfig);
+
+      const api = createMockApi();
+      register(api as never);
+
+      const factory = api.getRegisteredFactory();
+      factory?.();
+
+      expect(PineconeContextEngine).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ragEnabled: true,
+          agentsCorePath: "/data/workspace/AGENTS-CORE.md",
+        }),
+      );
     });
 
     it("disables plugin when openclaw.json has no pgvector-memory entry", () => {

--- a/packages/openclaw-pgvector-plugin/src/index.test.ts
+++ b/packages/openclaw-pgvector-plugin/src/index.test.ts
@@ -45,6 +45,8 @@ describe("openclaw-pgvector-plugin", () => {
     delete process.env.PGVECTOR_DATABASE_URL;
     delete process.env.GEMINI_API_KEY;
     delete process.env.OPENCLAW_AGENT_ID;
+    delete process.env.RAG_ENABLED;
+    delete process.env.RAG_AGENTS_CORE_PATH;
   });
 
   afterAll(() => {

--- a/packages/openclaw-pgvector-plugin/src/index.ts
+++ b/packages/openclaw-pgvector-plugin/src/index.ts
@@ -10,6 +10,8 @@ type PluginConfig = {
   compactAfterDays?: number;
   memoryHint?: string;
   minQueryTokens?: number;
+  ragEnabled?: boolean;
+  agentsCorePath?: string;
 };
 
 const OPENCLAW_CONFIG_PATH = "/data/openclaw.json";
@@ -54,8 +56,8 @@ export default function register(api: OpenClawPluginApi): void {
 
   const agentId = cfg.agentId ?? process.env.OPENCLAW_AGENT_ID ?? "default";
   const compactAfterDays = cfg.compactAfterDays ?? 7;
-  const ragEnabled = process.env.RAG_ENABLED === "true";
-  const agentsCorePath = process.env.RAG_AGENTS_CORE_PATH;
+  const ragEnabled = cfg.ragEnabled ?? process.env.RAG_ENABLED === "true";
+  const agentsCorePath = cfg.agentsCorePath ?? process.env.RAG_AGENTS_CORE_PATH;
 
   api.registerContextEngine("pgvector-memory", () => {
     const client = new PgVectorClient({ databaseUrl, geminiApiKey });

--- a/packages/openclaw-pgvector-plugin/src/index.ts
+++ b/packages/openclaw-pgvector-plugin/src/index.ts
@@ -54,6 +54,8 @@ export default function register(api: OpenClawPluginApi): void {
 
   const agentId = cfg.agentId ?? process.env.OPENCLAW_AGENT_ID ?? "default";
   const compactAfterDays = cfg.compactAfterDays ?? 7;
+  const ragEnabled = process.env.RAG_ENABLED === "true";
+  const agentsCorePath = process.env.RAG_AGENTS_CORE_PATH;
 
   api.registerContextEngine("pgvector-memory", () => {
     const client = new PgVectorClient({ databaseUrl, geminiApiKey });
@@ -63,10 +65,12 @@ export default function register(api: OpenClawPluginApi): void {
       compactAfterDays,
       memoryHint: cfg.memoryHint,
       minQueryTokens: cfg.minQueryTokens,
+      ragEnabled,
+      agentsCorePath,
     });
   });
 
   api.logger.info(
-    `pgvector-memory: registered (agentId: ${agentId}, compactAfterDays: ${compactAfterDays})`,
+    `pgvector-memory: registered (agentId: ${agentId}, compactAfterDays: ${compactAfterDays}, ragEnabled: ${ragEnabled})`,
   );
 }


### PR DESCRIPTION
## Summary

- `PineconeContextEngine` コンストラクタに `ragEnabled` / `agentsCorePath` を渡していなかったため、`RAG_ENABLED=true` でも Classic モード（`assembleClassic`）が使われていた
- 環境変数 `RAG_ENABLED`, `RAG_AGENTS_CORE_PATH` を読み取りコンストラクタに渡すよう修正
- ログに `ragEnabled` 状態を追加して動作確認を容易に

## 影響

全 pgvector-memory プラグイン利用インスタンス（19台）。修正版 tarball は全インスタンスにデプロイ済み。

## 検証

以下のインスタンスで RAG 動作を確認：
- `dev-and-test-agent`: results=2, latency=396ms
- `hub-spoke-agent`: results=4, latency=374ms  
- `hongmong-ochi-agent`: results=3, latency=451ms
- `central-hd-osada-agent`: results=1, latency=350ms

```
[PineconeContextEngine] mode=rag query_tokens=776 ns=agent:dev-and-test topK=10 results=2 latency=396ms
[PineconeContextEngine] rerank: session_turn=2 deduplicated=0
[PineconeContextEngine] merged: core_tokens=565 dynamic_tokens=482 total=1047 budget=1000000
```