### PR TITLE
feat(migrate-memory): Pinecone → pgvector 会話メモリ移行コマンド

### DIFF
--- a/packages/migrate-memory/src/cli.ts
+++ b/packages/migrate-memory/src/cli.ts
@@ -400,10 +400,6 @@ async function runPineconeToPgvector(args: string[]): Promise<void> {
 
   const pgvectorClient = createClient("pgvector", dryRun);
 
-  if (!dryRun) {
-    await pgvectorClient.ensureIndex();
-  }
-
   // Resolve Pinecone host
   let pineconeHost = values["pinecone-host"] as string | undefined;
 

--- a/packages/migrate-memory/src/cli.ts
+++ b/packages/migrate-memory/src/cli.ts
@@ -468,7 +468,6 @@ async function runPineconeToPgvector(args: string[]): Promise<void> {
     pgvectorClient,
     namespaces,
     dryRun,
-    skipExisting: true,
     sourceTypes,
   });
 

--- a/packages/migrate-memory/src/cli.ts
+++ b/packages/migrate-memory/src/cli.ts
@@ -400,6 +400,10 @@ async function runPineconeToPgvector(args: string[]): Promise<void> {
 
   const pgvectorClient = createClient("pgvector", dryRun);
 
+  if (!dryRun) {
+    await pgvectorClient.ensureIndex();
+  }
+
   // Resolve Pinecone host
   let pineconeHost = values["pinecone-host"] as string | undefined;
 

--- a/packages/migrate-memory/src/cli.ts
+++ b/packages/migrate-memory/src/cli.ts
@@ -360,6 +360,7 @@ Text is re-embedded using Gemini (768-dim) since Pinecone uses 1024-dim vectors.
 Options:
   --namespace <ns>      Pinecone namespace to migrate (repeatable, e.g. agent:mell)
                         If not specified, migrates all namespaces from Pinecone
+  --pinecone-host <h>   Pinecone data plane host (auto-detected if omitted)
   --dry-run             Preview without writing to pgvector
   --include-all-types   Include all sourceTypes (not just session_turn/conversation)
   --help                Show this help message
@@ -375,6 +376,7 @@ async function runPineconeToPgvector(args: string[]): Promise<void> {
     args,
     options: {
       namespace: { type: "string", multiple: true },
+      "pinecone-host": { type: "string" },
       "dry-run": { type: "boolean", default: false },
       "include-all-types": { type: "boolean", default: false },
       help: { type: "boolean", default: false },
@@ -398,15 +400,22 @@ async function runPineconeToPgvector(args: string[]): Promise<void> {
 
   const pgvectorClient = createClient("pgvector", dryRun);
 
-  // Discover Pinecone host
-  console.log("🔍 Discovering Pinecone index host...");
-  const indexRes = await fetch("https://api.pinecone.io/indexes", {
-    headers: { "Api-Key": pineconeApiKey },
-  });
+  // Resolve Pinecone host
+  let pineconeHost = values["pinecone-host"] as string | undefined;
 
-  let pineconeHost: string;
+  if (!pineconeHost) {
+    console.log("🔍 Discovering Pinecone index host...");
+    const indexRes = await fetch("https://api.pinecone.io/indexes", {
+      headers: { "Api-Key": pineconeApiKey },
+    });
 
-  if (indexRes.ok) {
+    if (!indexRes.ok) {
+      console.error(
+        `Error: Failed to discover Pinecone host (${indexRes.status}). Specify --pinecone-host explicitly.`,
+      );
+      process.exit(1);
+    }
+
     const indexData = (await indexRes.json()) as {
       indexes: { name: string; host: string }[];
     };
@@ -416,10 +425,6 @@ async function runPineconeToPgvector(args: string[]): Promise<void> {
       process.exit(1);
     }
     pineconeHost = idx.host;
-  } else {
-    // Fallback: try known host
-    pineconeHost = "easy-flow-memory-pban3fu.svc.aped-4627-b74a.pinecone.io";
-    console.log(`  ⚠️ Could not list indexes, using known host: ${pineconeHost}`);
   }
 
   // Discover namespaces if not specified

--- a/packages/migrate-memory/src/cli.ts
+++ b/packages/migrate-memory/src/cli.ts
@@ -7,17 +7,19 @@ import { type Backend, createClient } from "./create-client.js";
 import { MemoryDeleter } from "./deleter.js";
 import { AgentsMigrator } from "./migrate-agents.js";
 import { Migrator } from "./migrator.js";
+import { migrateConversationMemory } from "./pinecone-to-pgvector.js";
 import { validateExcludePatterns } from "./preflight.js";
 
 function printUsage(): void {
   console.log(`Usage: easy-flow <command> [options]
 
 Commands:
-  migrate-memory    Migrate markdown files to vector DB
-  agents            Migrate AGENTS.md to vector DB (section-based chunking)
-  memory-delete     Delete memory from vector DB
-  bulk-migrate      Bulk migrate all EasyFlow instances
-  bulk-update       Bulk update easy-flow-agent on all instances
+  migrate-memory        Migrate markdown files to vector DB
+  agents                Migrate AGENTS.md to vector DB (section-based chunking)
+  memory-delete         Delete memory from vector DB
+  pinecone-to-pgvector  Migrate conversation memory from Pinecone to pgvector
+  bulk-migrate          Bulk migrate all EasyFlow instances
+  bulk-update           Bulk update easy-flow-agent on all instances
 
 Environment Variables:
   PINECONE_API_KEY         Required for pinecone backend
@@ -346,6 +348,127 @@ async function runBulkUpdate(args: string[]): Promise<void> {
   }
 }
 
+function printPineconeToPgvectorUsage(): void {
+  console.log(`Usage: easy-flow pinecone-to-pgvector [options]
+
+Migrate conversation memory (session_turn) from Pinecone to pgvector.
+AGENTS.md rules (agents_rule, memory_file) are skipped as they are already
+migrated via the 'agents' command.
+
+Text is re-embedded using Gemini (768-dim) since Pinecone uses 1024-dim vectors.
+
+Options:
+  --namespace <ns>      Pinecone namespace to migrate (repeatable, e.g. agent:mell)
+                        If not specified, migrates all namespaces from Pinecone
+  --dry-run             Preview without writing to pgvector
+  --include-all-types   Include all sourceTypes (not just session_turn/conversation)
+  --help                Show this help message
+
+Environment Variables (all required):
+  PINECONE_API_KEY         Pinecone API key (with list/fetch permissions)
+  PGVECTOR_DATABASE_URL    pgvector connection string
+  GEMINI_API_KEY           Gemini API key for re-embedding`);
+}
+
+async function runPineconeToPgvector(args: string[]): Promise<void> {
+  const { values } = parseArgs({
+    args,
+    options: {
+      namespace: { type: "string", multiple: true },
+      "dry-run": { type: "boolean", default: false },
+      "include-all-types": { type: "boolean", default: false },
+      help: { type: "boolean", default: false },
+    },
+    strict: true,
+  });
+
+  if (values.help) {
+    printPineconeToPgvectorUsage();
+    process.exit(0);
+  }
+
+  const dryRun = values["dry-run"] as boolean;
+  const includeAllTypes = values["include-all-types"] as boolean;
+
+  const pineconeApiKey = process.env.PINECONE_API_KEY;
+  if (!pineconeApiKey) {
+    console.error("Error: PINECONE_API_KEY environment variable is required");
+    process.exit(1);
+  }
+
+  const pgvectorClient = createClient("pgvector", dryRun);
+
+  // Discover Pinecone host
+  console.log("🔍 Discovering Pinecone index host...");
+  const indexRes = await fetch("https://api.pinecone.io/indexes", {
+    headers: { "Api-Key": pineconeApiKey },
+  });
+
+  let pineconeHost: string;
+
+  if (indexRes.ok) {
+    const indexData = (await indexRes.json()) as {
+      indexes: { name: string; host: string }[];
+    };
+    const idx = indexData.indexes.find((i) => i.name === "easy-flow-memory");
+    if (!idx) {
+      console.error("Error: easy-flow-memory index not found in Pinecone");
+      process.exit(1);
+    }
+    pineconeHost = idx.host;
+  } else {
+    // Fallback: try known host
+    pineconeHost = "easy-flow-memory-pban3fu.svc.aped-4627-b74a.pinecone.io";
+    console.log(`  ⚠️ Could not list indexes, using known host: ${pineconeHost}`);
+  }
+
+  // Discover namespaces if not specified
+  let namespaces = (values.namespace as string[] | undefined) ?? [];
+
+  if (namespaces.length === 0) {
+    console.log("📋 Discovering namespaces from Pinecone...");
+    const statsRes = await fetch(`https://${pineconeHost}/describe_index_stats`, {
+      method: "POST",
+      headers: { "Api-Key": pineconeApiKey, "Content-Type": "application/json" },
+      body: "{}",
+    });
+
+    if (!statsRes.ok) {
+      console.error(`Error: Failed to get Pinecone stats: ${statsRes.status}`);
+      process.exit(1);
+    }
+
+    const stats = (await statsRes.json()) as {
+      namespaces: Record<string, { vectorCount: number }>;
+    };
+    namespaces = Object.keys(stats.namespaces).sort(
+      (a, b) => (stats.namespaces[b].vectorCount ?? 0) - (stats.namespaces[a].vectorCount ?? 0),
+    );
+
+    console.log(`  Found ${namespaces.length} namespaces`);
+    for (const ns of namespaces) {
+      console.log(`    ${ns}: ${stats.namespaces[ns].vectorCount} vectors`);
+    }
+  }
+
+  const sourceTypes = includeAllTypes ? undefined : ["session_turn", "conversation"];
+
+  const results = await migrateConversationMemory({
+    pineconeApiKey,
+    pineconeHost,
+    pgvectorClient,
+    namespaces,
+    dryRun,
+    skipExisting: true,
+    sourceTypes,
+  });
+
+  const hasErrors = results.some((r) => r.errors > 0);
+  if (hasErrors) {
+    process.exitCode = 1;
+  }
+}
+
 async function main(): Promise<void> {
   const subcommand = process.argv[2];
 
@@ -360,6 +483,8 @@ async function main(): Promise<void> {
     await runAgents(process.argv.slice(3));
   } else if (subcommand === "memory-delete") {
     await runDelete(process.argv.slice(3));
+  } else if (subcommand === "pinecone-to-pgvector") {
+    await runPineconeToPgvector(process.argv.slice(3));
   } else if (subcommand === "bulk-migrate") {
     await runBulkMigrate(process.argv.slice(3));
   } else if (subcommand === "bulk-update") {

--- a/packages/migrate-memory/src/cli.ts
+++ b/packages/migrate-memory/src/cli.ts
@@ -7,7 +7,7 @@ import { type Backend, createClient } from "./create-client.js";
 import { MemoryDeleter } from "./deleter.js";
 import { AgentsMigrator } from "./migrate-agents.js";
 import { Migrator } from "./migrator.js";
-import { migrateConversationMemory } from "./pinecone-to-pgvector.js";
+import { migrateConversationMemory, pineconeHeaders } from "./pinecone-to-pgvector.js";
 import { validateExcludePatterns } from "./preflight.js";
 
 function printUsage(): void {
@@ -406,7 +406,7 @@ async function runPineconeToPgvector(args: string[]): Promise<void> {
   if (!pineconeHost) {
     console.log("🔍 Discovering Pinecone index host...");
     const indexRes = await fetch("https://api.pinecone.io/indexes", {
-      headers: { "Api-Key": pineconeApiKey },
+      headers: pineconeHeaders(pineconeApiKey),
     });
 
     if (!indexRes.ok) {
@@ -434,7 +434,7 @@ async function runPineconeToPgvector(args: string[]): Promise<void> {
     console.log("📋 Discovering namespaces from Pinecone...");
     const statsRes = await fetch(`https://${pineconeHost}/describe_index_stats`, {
       method: "POST",
-      headers: { "Api-Key": pineconeApiKey, "Content-Type": "application/json" },
+      headers: { ...pineconeHeaders(pineconeApiKey), "Content-Type": "application/json" },
       body: "{}",
     });
 

--- a/packages/migrate-memory/src/pinecone-to-pgvector.test.ts
+++ b/packages/migrate-memory/src/pinecone-to-pgvector.test.ts
@@ -54,7 +54,9 @@ describe("pineconeList", () => {
     expect(result.nextToken).toBe("token123");
     expect(fetchMock).toHaveBeenCalledWith(
       expect.stringContaining("host.pinecone.io/vectors/list"),
-      expect.objectContaining({ headers: { "Api-Key": "api-key" } }),
+      expect.objectContaining({
+        headers: { "Api-Key": "api-key", "X-Pinecone-Api-Version": "2025-04" },
+      }),
     );
   });
 

--- a/packages/migrate-memory/src/pinecone-to-pgvector.test.ts
+++ b/packages/migrate-memory/src/pinecone-to-pgvector.test.ts
@@ -1,0 +1,411 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  type MigrateOptions,
+  migrateConversationMemory,
+  pineconeFetch,
+  pineconeList,
+} from "./pinecone-to-pgvector.js";
+
+// --- fetch mock ---
+const fetchMock = vi.fn<(input: string | URL | Request, init?: RequestInit) => Promise<Response>>();
+vi.stubGlobal("fetch", fetchMock);
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  } as Response;
+}
+
+// --- mock pgvector client ---
+function createMockClient() {
+  return {
+    upsert: vi.fn(async () => {}),
+    query: vi.fn(async () => []),
+    delete: vi.fn(async () => {}),
+    deleteBySource: vi.fn(async () => {}),
+    deleteNamespace: vi.fn(async () => {}),
+    ensureIndex: vi.fn(async () => {}),
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("pineconeList", () => {
+  it("should list vector IDs with pagination", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        vectors: [{ id: "v1" }, { id: "v2" }],
+        pagination: { next: "token123" },
+      }),
+    );
+
+    const result = await pineconeList("host.pinecone.io", "api-key", "agent:mell");
+
+    expect(result.ids).toEqual(["v1", "v2"]);
+    expect(result.nextToken).toBe("token123");
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining("host.pinecone.io/vectors/list"),
+      expect.objectContaining({ headers: { "Api-Key": "api-key" } }),
+    );
+  });
+
+  it("should return empty ids when no vectors", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ vectors: [] }));
+
+    const result = await pineconeList("host.pinecone.io", "api-key", "agent:test");
+
+    expect(result.ids).toEqual([]);
+    expect(result.nextToken).toBeUndefined();
+  });
+
+  it("should pass paginationToken when provided", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ vectors: [{ id: "v3" }] }));
+
+    await pineconeList("host.pinecone.io", "api-key", "agent:test", "page-token");
+
+    const calledUrl = fetchMock.mock.calls[0][0] as string;
+    expect(calledUrl).toContain("paginationToken=page-token");
+  });
+
+  it("should throw on non-OK response", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ error: "unauthorized" }, 401));
+
+    await expect(pineconeList("host.pinecone.io", "api-key", "agent:test")).rejects.toThrow(
+      "Pinecone list failed: 401",
+    );
+  });
+});
+
+describe("pineconeFetch", () => {
+  it("should fetch vectors with metadata", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        vectors: {
+          "mell:turn:1:0": {
+            metadata: {
+              agentId: "mell",
+              sourceType: "session_turn",
+              sourceFile: "session:abc",
+              chunkIndex: 0,
+              createdAt: 1000,
+              text: "hello",
+              role: "user",
+            },
+          },
+        },
+      }),
+    );
+
+    const result = await pineconeFetch("host.pinecone.io", "api-key", "agent:mell", [
+      "mell:turn:1:0",
+    ]);
+
+    expect(result.size).toBe(1);
+    expect(result.get("mell:turn:1:0")?.text).toBe("hello");
+    expect(result.get("mell:turn:1:0")?.sourceType).toBe("session_turn");
+  });
+
+  it("should throw on non-OK response", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ error: "not found" }, 404));
+
+    await expect(
+      pineconeFetch("host.pinecone.io", "api-key", "agent:test", ["id1"]),
+    ).rejects.toThrow("Pinecone fetch failed: 404");
+  });
+});
+
+describe("migrateConversationMemory", () => {
+  function createOptions(overrides: Partial<MigrateOptions> = {}): MigrateOptions {
+    return {
+      pineconeApiKey: "test-key",
+      pineconeHost: "host.pinecone.io",
+      pgvectorClient: createMockClient(),
+      namespaces: ["agent:test"],
+      dryRun: false,
+      skipExisting: true,
+      sourceTypes: ["session_turn", "conversation"],
+      ...overrides,
+    };
+  }
+
+  it("should migrate conversation memory and skip non-conversation vectors", async () => {
+    // List returns 3 IDs
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({ vectors: [{ id: "v1" }, { id: "v2" }, { id: "v3" }] }),
+    );
+    // Fetch returns metadata: 2 conversation, 1 agents_rule
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        vectors: {
+          v1: {
+            metadata: {
+              agentId: "test",
+              sourceType: "session_turn",
+              sourceFile: "session:abc",
+              chunkIndex: 0,
+              createdAt: 1000,
+              text: "user message",
+            },
+          },
+          v2: {
+            metadata: {
+              agentId: "test",
+              sourceType: "agents_rule",
+              sourceFile: "AGENTS.md",
+              chunkIndex: 0,
+              createdAt: 2000,
+              text: "rule text",
+            },
+          },
+          v3: {
+            metadata: {
+              agentId: "test",
+              sourceType: "conversation",
+              sourceFile: "session:def",
+              chunkIndex: 0,
+              createdAt: 3000,
+              text: "assistant reply",
+            },
+          },
+        },
+      }),
+    );
+
+    const opts = createOptions();
+    const results = await migrateConversationMemory(opts);
+
+    expect(results).toHaveLength(1);
+    expect(results[0].totalPinecone).toBe(3);
+    expect(results[0].migrated).toBe(2);
+    expect(results[0].skippedExisting).toBe(1); // agents_rule skipped
+    expect(opts.pgvectorClient.upsert).toHaveBeenCalledTimes(1);
+
+    const upsertedChunks = vi.mocked(opts.pgvectorClient.upsert).mock.calls[0][0];
+    expect(upsertedChunks).toHaveLength(2);
+    expect(upsertedChunks[0].metadata.sourceType).toBe("session_turn");
+    expect(upsertedChunks[1].metadata.sourceType).toBe("conversation");
+  });
+
+  it("should not upsert in dry-run mode", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ vectors: [{ id: "v1" }] }));
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        vectors: {
+          v1: {
+            metadata: {
+              agentId: "test",
+              sourceType: "session_turn",
+              sourceFile: "session:abc",
+              chunkIndex: 0,
+              createdAt: 1000,
+              text: "hello",
+            },
+          },
+        },
+      }),
+    );
+
+    const opts = createOptions({ dryRun: true });
+    const results = await migrateConversationMemory(opts);
+
+    expect(results[0].migrated).toBe(1);
+    expect(opts.pgvectorClient.upsert).not.toHaveBeenCalled();
+  });
+
+  it("should handle empty namespace", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ vectors: [] }));
+
+    const results = await migrateConversationMemory(createOptions());
+
+    expect(results[0].totalPinecone).toBe(0);
+    expect(results[0].migrated).toBe(0);
+  });
+
+  it("should skip vectors without text", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ vectors: [{ id: "v1" }, { id: "v2" }] }));
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        vectors: {
+          v1: {
+            metadata: {
+              agentId: "test",
+              sourceType: "session_turn",
+              sourceFile: "session:abc",
+              chunkIndex: 0,
+              createdAt: 1000,
+              text: "",
+            },
+          },
+          v2: {
+            metadata: {
+              agentId: "test",
+              sourceType: "session_turn",
+              sourceFile: "session:def",
+              chunkIndex: 0,
+              createdAt: 2000,
+              text: "valid text",
+            },
+          },
+        },
+      }),
+    );
+
+    const results = await migrateConversationMemory(createOptions());
+
+    expect(results[0].skippedNoText).toBe(1);
+    expect(results[0].migrated).toBe(1);
+  });
+
+  it("should handle upsert errors gracefully", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ vectors: [{ id: "v1" }] }));
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        vectors: {
+          v1: {
+            metadata: {
+              agentId: "test",
+              sourceType: "session_turn",
+              sourceFile: "session:abc",
+              chunkIndex: 0,
+              createdAt: 1000,
+              text: "hello",
+            },
+          },
+        },
+      }),
+    );
+
+    const client = createMockClient();
+    client.upsert.mockRejectedValueOnce(new Error("DB connection failed"));
+
+    const results = await migrateConversationMemory(createOptions({ pgvectorClient: client }));
+
+    expect(results[0].errors).toBe(1);
+    expect(results[0].migrated).toBe(0);
+  });
+
+  it("should handle pagination across multiple pages", async () => {
+    // Page 1: returns 2 IDs with pagination token
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        vectors: [{ id: "v1" }, { id: "v2" }],
+        pagination: { next: "page2token" },
+      }),
+    );
+    // Page 2: returns 1 ID, no more pages
+    fetchMock.mockResolvedValueOnce(jsonResponse({ vectors: [{ id: "v3" }] }));
+    // Fetch for all 3 IDs
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        vectors: {
+          v1: {
+            metadata: {
+              agentId: "test",
+              sourceType: "session_turn",
+              sourceFile: "s:1",
+              chunkIndex: 0,
+              createdAt: 1000,
+              text: "msg1",
+            },
+          },
+          v2: {
+            metadata: {
+              agentId: "test",
+              sourceType: "session_turn",
+              sourceFile: "s:2",
+              chunkIndex: 0,
+              createdAt: 2000,
+              text: "msg2",
+            },
+          },
+          v3: {
+            metadata: {
+              agentId: "test",
+              sourceType: "session_turn",
+              sourceFile: "s:3",
+              chunkIndex: 0,
+              createdAt: 3000,
+              text: "msg3",
+            },
+          },
+        },
+      }),
+    );
+
+    const results = await migrateConversationMemory(createOptions());
+
+    expect(results[0].totalPinecone).toBe(3);
+    expect(results[0].migrated).toBe(3);
+    // Verify pagination token was passed in second list call
+    const secondListUrl = fetchMock.mock.calls[1][0] as string;
+    expect(secondListUrl).toContain("paginationToken=page2token");
+  });
+
+  it("should migrate multiple namespaces", async () => {
+    // Namespace 1: agent:a
+    fetchMock.mockResolvedValueOnce(jsonResponse({ vectors: [{ id: "a1" }] }));
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        vectors: {
+          a1: {
+            metadata: {
+              agentId: "a",
+              sourceType: "session_turn",
+              sourceFile: "s:1",
+              chunkIndex: 0,
+              createdAt: 1000,
+              text: "msg from a",
+            },
+          },
+        },
+      }),
+    );
+    // Namespace 2: agent:b
+    fetchMock.mockResolvedValueOnce(jsonResponse({ vectors: [{ id: "b1" }, { id: "b2" }] }));
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        vectors: {
+          b1: {
+            metadata: {
+              agentId: "b",
+              sourceType: "session_turn",
+              sourceFile: "s:2",
+              chunkIndex: 0,
+              createdAt: 2000,
+              text: "msg from b",
+            },
+          },
+          b2: {
+            metadata: {
+              agentId: "b",
+              sourceType: "session_turn",
+              sourceFile: "s:3",
+              chunkIndex: 0,
+              createdAt: 3000,
+              text: "msg2 from b",
+            },
+          },
+        },
+      }),
+    );
+
+    const results = await migrateConversationMemory(
+      createOptions({ namespaces: ["agent:a", "agent:b"] }),
+    );
+
+    expect(results).toHaveLength(2);
+    expect(results[0].namespace).toBe("agent:a");
+    expect(results[0].migrated).toBe(1);
+    expect(results[1].namespace).toBe("agent:b");
+    expect(results[1].migrated).toBe(2);
+  });
+});

--- a/packages/migrate-memory/src/pinecone-to-pgvector.test.ts
+++ b/packages/migrate-memory/src/pinecone-to-pgvector.test.ts
@@ -221,6 +221,38 @@ describe("migrateConversationMemory", () => {
 
     expect(results[0].migrated).toBe(1);
     expect(opts.pgvectorClient.upsert).not.toHaveBeenCalled();
+    expect(opts.pgvectorClient.ensureIndex).not.toHaveBeenCalled();
+  });
+
+  it("should call ensureIndex before upserting in non-dry-run mode", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ vectors: [{ id: "v1" }] }));
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        vectors: {
+          v1: {
+            metadata: {
+              agentId: "test",
+              sourceType: "session_turn",
+              sourceFile: "session:abc",
+              chunkIndex: 0,
+              createdAt: 1000,
+              text: "hello",
+            },
+          },
+        },
+      }),
+    );
+
+    const opts = createOptions({ dryRun: false });
+    await migrateConversationMemory(opts);
+
+    expect(opts.pgvectorClient.ensureIndex).toHaveBeenCalledTimes(1);
+    expect(opts.pgvectorClient.upsert).toHaveBeenCalledTimes(1);
+
+    // ensureIndex must be called before upsert
+    const ensureIndexOrder = opts.pgvectorClient.ensureIndex.mock.invocationCallOrder[0];
+    const upsertOrder = opts.pgvectorClient.upsert.mock.invocationCallOrder[0];
+    expect(ensureIndexOrder).toBeLessThan(upsertOrder);
   });
 
   it("should handle empty namespace", async () => {

--- a/packages/migrate-memory/src/pinecone-to-pgvector.test.ts
+++ b/packages/migrate-memory/src/pinecone-to-pgvector.test.ts
@@ -131,7 +131,7 @@ describe("migrateConversationMemory", () => {
       pgvectorClient: createMockClient(),
       namespaces: ["agent:test"],
       dryRun: false,
-      skipExisting: true,
+
       sourceTypes: ["session_turn", "conversation"],
       ...overrides,
     };
@@ -186,7 +186,7 @@ describe("migrateConversationMemory", () => {
     expect(results).toHaveLength(1);
     expect(results[0].totalPinecone).toBe(3);
     expect(results[0].migrated).toBe(2);
-    expect(results[0].skippedExisting).toBe(1); // agents_rule skipped
+    expect(results[0].skippedByFilter).toBe(1); // agents_rule skipped
     expect(opts.pgvectorClient.upsert).toHaveBeenCalledTimes(1);
 
     const upsertedChunks = vi.mocked(opts.pgvectorClient.upsert).mock.calls[0][0];
@@ -384,7 +384,7 @@ describe("migrateConversationMemory", () => {
     const results = await migrateConversationMemory(createOptions({ sourceTypes: undefined }));
 
     expect(results[0].migrated).toBe(2);
-    expect(results[0].skippedExisting).toBe(0);
+    expect(results[0].skippedByFilter).toBe(0);
   });
 
   it("should migrate multiple namespaces", async () => {
@@ -444,5 +444,34 @@ describe("migrateConversationMemory", () => {
     expect(results[0].migrated).toBe(1);
     expect(results[1].namespace).toBe("agent:b");
     expect(results[1].migrated).toBe(2);
+  });
+
+  it("should work with idempotent upsert (ON CONFLICT) without skipExisting", async () => {
+    // Simulate two runs of the same data — pgvector upsert is idempotent
+    fetchMock.mockResolvedValueOnce(jsonResponse({ vectors: [{ id: "v1" }] }));
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        vectors: {
+          v1: {
+            metadata: {
+              agentId: "test",
+              sourceType: "session_turn",
+              sourceFile: "session:abc",
+              chunkIndex: 0,
+              createdAt: 1000,
+              text: "hello",
+            },
+          },
+        },
+      }),
+    );
+
+    const opts = createOptions();
+    const results = await migrateConversationMemory(opts);
+
+    // First run succeeds
+    expect(results[0].migrated).toBe(1);
+    expect(opts.pgvectorClient.upsert).toHaveBeenCalledTimes(1);
+    // No skipExisting option needed — upsert ON CONFLICT handles idempotency at DB level
   });
 });

--- a/packages/migrate-memory/src/pinecone-to-pgvector.test.ts
+++ b/packages/migrate-memory/src/pinecone-to-pgvector.test.ts
@@ -192,7 +192,9 @@ describe("migrateConversationMemory", () => {
     const upsertedChunks = vi.mocked(opts.pgvectorClient.upsert).mock.calls[0][0];
     expect(upsertedChunks).toHaveLength(2);
     expect(upsertedChunks[0].metadata.sourceType).toBe("session_turn");
-    expect(upsertedChunks[1].metadata.sourceType).toBe("conversation");
+    // "conversation" is normalized to "session_turn" with category "conversation"
+    expect(upsertedChunks[1].metadata.sourceType).toBe("session_turn");
+    expect(upsertedChunks[1].metadata.category).toBe("conversation");
   });
 
   it("should not upsert in dry-run mode", async () => {

--- a/packages/migrate-memory/src/pinecone-to-pgvector.test.ts
+++ b/packages/migrate-memory/src/pinecone-to-pgvector.test.ts
@@ -352,6 +352,41 @@ describe("migrateConversationMemory", () => {
     expect(secondListUrl).toContain("paginationToken=page2token");
   });
 
+  it("should include all sourceTypes when sourceTypes is undefined", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ vectors: [{ id: "v1" }, { id: "v2" }] }));
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        vectors: {
+          v1: {
+            metadata: {
+              agentId: "test",
+              sourceType: "session_turn",
+              sourceFile: "session:abc",
+              chunkIndex: 0,
+              createdAt: 1000,
+              text: "conversation text",
+            },
+          },
+          v2: {
+            metadata: {
+              agentId: "test",
+              sourceType: "agents_rule",
+              sourceFile: "AGENTS.md",
+              chunkIndex: 0,
+              createdAt: 2000,
+              text: "rule text",
+            },
+          },
+        },
+      }),
+    );
+
+    const results = await migrateConversationMemory(createOptions({ sourceTypes: undefined }));
+
+    expect(results[0].migrated).toBe(2);
+    expect(results[0].skippedExisting).toBe(0);
+  });
+
   it("should migrate multiple namespaces", async () => {
     // Namespace 1: agent:a
     fetchMock.mockResolvedValueOnce(jsonResponse({ vectors: [{ id: "a1" }] }));

--- a/packages/migrate-memory/src/pinecone-to-pgvector.ts
+++ b/packages/migrate-memory/src/pinecone-to-pgvector.ts
@@ -240,6 +240,11 @@ export async function migrateConversationMemory(opts: MigrateOptions): Promise<M
   console.log(`Dry run: ${opts.dryRun}`);
   console.log();
 
+  // Ensure pgvector schema exists before upserting (skip in dry-run mode)
+  if (!opts.dryRun) {
+    await opts.pgvectorClient.ensureIndex();
+  }
+
   const results: MigrateResult[] = [];
 
   for (const ns of opts.namespaces) {

--- a/packages/migrate-memory/src/pinecone-to-pgvector.ts
+++ b/packages/migrate-memory/src/pinecone-to-pgvector.ts
@@ -35,14 +35,13 @@ export interface MigrateOptions {
   pgvectorClient: IPineconeClient;
   namespaces: string[];
   dryRun: boolean;
-  skipExisting: boolean;
   sourceTypes?: string[];
 }
 
 export interface MigrateResult {
   namespace: string;
   totalPinecone: number;
-  skippedExisting: number;
+  skippedByFilter: number;
   skippedNoText: number;
   migrated: number;
   errors: number;
@@ -118,7 +117,7 @@ async function migrateNamespace(opts: MigrateOptions, namespace: string): Promis
   const result: MigrateResult = {
     namespace,
     totalPinecone: 0,
-    skippedExisting: 0,
+    skippedByFilter: 0,
     skippedNoText: 0,
     migrated: 0,
     errors: 0,
@@ -157,7 +156,7 @@ async function migrateNamespace(opts: MigrateOptions, namespace: string): Promis
     for (const [id, meta] of vectors) {
       // Filter by sourceType (conversation memory only, unless sourceTypes is null = include all)
       if (sourceTypeFilter && !sourceTypeFilter.has(meta.sourceType)) {
-        result.skippedExisting++;
+        result.skippedByFilter++;
         continue;
       }
 
@@ -197,7 +196,7 @@ async function migrateNamespace(opts: MigrateOptions, namespace: string): Promis
   }
 
   console.log(
-    `  🔍 Conversation memory: ${chunksToMigrate.length} chunks (skipped ${result.skippedExisting} non-conversation, ${result.skippedNoText} no-text)`,
+    `  🔍 Conversation memory: ${chunksToMigrate.length} chunks (skipped ${result.skippedByFilter} non-conversation, ${result.skippedNoText} no-text)`,
   );
 
   if (chunksToMigrate.length === 0) return result;
@@ -248,7 +247,7 @@ export async function migrateConversationMemory(opts: MigrateOptions): Promise<M
     const result = await migrateNamespace(opts, ns);
     results.push(result);
     console.log(
-      `  ✅ Done: ${result.migrated} migrated, ${result.skippedExisting} skipped, ${result.errors} errors`,
+      `  ✅ Done: ${result.migrated} migrated, ${result.skippedByFilter} skipped, ${result.errors} errors`,
     );
   }
 
@@ -266,7 +265,7 @@ export async function migrateConversationMemory(opts: MigrateOptions): Promise<M
 
   for (const r of results) {
     console.log(
-      `${r.namespace.padEnd(30)} ${String(r.totalPinecone).padStart(10)} ${String(r.migrated).padStart(10)} ${String(r.skippedExisting + r.skippedNoText).padStart(10)} ${String(r.errors).padStart(10)}`,
+      `${r.namespace.padEnd(30)} ${String(r.totalPinecone).padStart(10)} ${String(r.migrated).padStart(10)} ${String(r.skippedByFilter + r.skippedNoText).padStart(10)} ${String(r.errors).padStart(10)}`,
     );
     totalMigrated += r.migrated;
     totalErrors += r.errors;

--- a/packages/migrate-memory/src/pinecone-to-pgvector.ts
+++ b/packages/migrate-memory/src/pinecone-to-pgvector.ts
@@ -1,0 +1,273 @@
+/**
+ * Pinecone → pgvector 会話メモリ移行
+ *
+ * Pinecone に蓄積された会話メモリ（session_turn）を pgvector に移行する。
+ * AGENTS.md ルール（agents_rule, memory_file）は既に migrate-memory agents コマンドで
+ * 投入済みのため、会話メモリのみを対象とする。
+ *
+ * 注意: Pinecone は 1024 次元（Pinecone Integrated Inference）、
+ * pgvector は 768 次元（Gemini text-embedding-004）のため、
+ * テキストを取得して Gemini で再 embedding する。
+ */
+
+import type { IPineconeClient, MemoryChunk } from "@easy-flow/pinecone-client";
+
+const PINECONE_LIST_LIMIT = 100;
+const PINECONE_FETCH_BATCH = 100;
+const UPSERT_BATCH_SIZE = 50;
+const GEMINI_RATE_LIMIT_DELAY_MS = 200;
+
+interface PineconeVectorMetadata {
+  agentId: string;
+  category?: string;
+  chunkIndex: number;
+  createdAt: number;
+  role?: string;
+  sourceFile: string;
+  sourceType: string;
+  text: string;
+  turnId?: string;
+}
+
+interface MigrateOptions {
+  pineconeApiKey: string;
+  pineconeHost: string;
+  pgvectorClient: IPineconeClient;
+  namespaces: string[];
+  dryRun: boolean;
+  skipExisting: boolean;
+  sourceTypes?: string[];
+}
+
+interface MigrateResult {
+  namespace: string;
+  totalPinecone: number;
+  skippedExisting: number;
+  skippedNoText: number;
+  migrated: number;
+  errors: number;
+}
+
+async function pineconeList(
+  host: string,
+  apiKey: string,
+  namespace: string,
+  paginationToken?: string,
+): Promise<{ ids: string[]; nextToken?: string }> {
+  const url = new URL(`https://${host}/vectors/list`);
+  url.searchParams.set("namespace", namespace);
+  url.searchParams.set("limit", String(PINECONE_LIST_LIMIT));
+  if (paginationToken) {
+    url.searchParams.set("paginationToken", paginationToken);
+  }
+
+  const res = await fetch(url.toString(), {
+    headers: { "Api-Key": apiKey },
+  });
+
+  if (!res.ok) {
+    throw new Error(`Pinecone list failed: ${res.status} ${await res.text()}`);
+  }
+
+  const data = (await res.json()) as {
+    vectors?: { id: string }[];
+    pagination?: { next?: string };
+  };
+
+  return {
+    ids: (data.vectors ?? []).map((v) => v.id),
+    nextToken: data.pagination?.next,
+  };
+}
+
+async function pineconeFetch(
+  host: string,
+  apiKey: string,
+  namespace: string,
+  ids: string[],
+): Promise<Map<string, PineconeVectorMetadata>> {
+  const url = new URL(`https://${host}/vectors/fetch`);
+  url.searchParams.set("namespace", namespace);
+  for (const id of ids) {
+    url.searchParams.append("ids", id);
+  }
+
+  const res = await fetch(url.toString(), {
+    headers: { "Api-Key": apiKey },
+  });
+
+  if (!res.ok) {
+    throw new Error(`Pinecone fetch failed: ${res.status} ${await res.text()}`);
+  }
+
+  const data = (await res.json()) as {
+    vectors: Record<string, { metadata: PineconeVectorMetadata }>;
+  };
+
+  const result = new Map<string, PineconeVectorMetadata>();
+  for (const [id, v] of Object.entries(data.vectors ?? {})) {
+    if (v.metadata) {
+      result.set(id, v.metadata);
+    }
+  }
+  return result;
+}
+
+async function migrateNamespace(opts: MigrateOptions, namespace: string): Promise<MigrateResult> {
+  const agentId = namespace.replace("agent:", "");
+  const result: MigrateResult = {
+    namespace,
+    totalPinecone: 0,
+    skippedExisting: 0,
+    skippedNoText: 0,
+    migrated: 0,
+    errors: 0,
+  };
+
+  const sourceTypeFilter = new Set(opts.sourceTypes ?? ["session_turn", "conversation"]);
+
+  // Phase 1: List all vector IDs from Pinecone
+  console.log(`  📋 Listing vectors in ${namespace}...`);
+  const allIds: string[] = [];
+  let nextToken: string | undefined;
+
+  do {
+    const page = await pineconeList(opts.pineconeHost, opts.pineconeApiKey, namespace, nextToken);
+    allIds.push(...page.ids);
+    nextToken = page.nextToken;
+  } while (nextToken);
+
+  result.totalPinecone = allIds.length;
+  console.log(`  📊 Total vectors in Pinecone: ${allIds.length}`);
+
+  if (allIds.length === 0) return result;
+
+  // Phase 2: Fetch metadata in batches and filter conversation memory
+  const chunksToMigrate: MemoryChunk[] = [];
+
+  for (let i = 0; i < allIds.length; i += PINECONE_FETCH_BATCH) {
+    const batchIds = allIds.slice(i, i + PINECONE_FETCH_BATCH);
+    const vectors = await pineconeFetch(
+      opts.pineconeHost,
+      opts.pineconeApiKey,
+      namespace,
+      batchIds,
+    );
+
+    for (const [id, meta] of vectors) {
+      // Filter by sourceType (conversation memory only)
+      if (!sourceTypeFilter.has(meta.sourceType)) {
+        result.skippedExisting++;
+        continue;
+      }
+
+      // Skip vectors without text
+      if (!meta.text || meta.text.trim().length === 0) {
+        result.skippedNoText++;
+        continue;
+      }
+
+      chunksToMigrate.push({
+        id,
+        text: meta.text,
+        metadata: {
+          agentId,
+          sourceFile: meta.sourceFile,
+          sourceType: meta.sourceType as MemoryChunk["metadata"]["sourceType"],
+          chunkIndex: meta.chunkIndex ?? 0,
+          createdAt: meta.createdAt ?? Date.now(),
+          turnId: meta.turnId,
+          role: meta.role as "user" | "assistant" | undefined,
+          category: meta.category,
+        },
+      });
+    }
+
+    if ((i + PINECONE_FETCH_BATCH) % 500 === 0 || i + PINECONE_FETCH_BATCH >= allIds.length) {
+      console.log(
+        `  📥 Fetched ${Math.min(i + PINECONE_FETCH_BATCH, allIds.length)}/${allIds.length} vectors, ${chunksToMigrate.length} conversation chunks found`,
+      );
+    }
+  }
+
+  console.log(
+    `  🔍 Conversation memory: ${chunksToMigrate.length} chunks (skipped ${result.skippedExisting} non-conversation, ${result.skippedNoText} no-text)`,
+  );
+
+  if (chunksToMigrate.length === 0) return result;
+
+  if (opts.dryRun) {
+    result.migrated = chunksToMigrate.length;
+    console.log(`  [DRY RUN] Would migrate ${chunksToMigrate.length} chunks`);
+    return result;
+  }
+
+  // Phase 3: Upsert to pgvector in batches (PgVectorClient.upsert re-embeds with Gemini)
+  for (let i = 0; i < chunksToMigrate.length; i += UPSERT_BATCH_SIZE) {
+    const batch = chunksToMigrate.slice(i, i + UPSERT_BATCH_SIZE);
+    try {
+      await opts.pgvectorClient.upsert(batch);
+      result.migrated += batch.length;
+
+      const progress = Math.min(i + UPSERT_BATCH_SIZE, chunksToMigrate.length);
+      console.log(`  ⬆️  Upserted ${progress}/${chunksToMigrate.length} chunks`);
+
+      // Rate limit for Gemini embedding API
+      if (i + UPSERT_BATCH_SIZE < chunksToMigrate.length) {
+        await new Promise((resolve) => setTimeout(resolve, GEMINI_RATE_LIMIT_DELAY_MS));
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`  ❌ Batch upsert failed at offset ${i}: ${msg}`);
+      result.errors += batch.length;
+    }
+  }
+
+  return result;
+}
+
+export async function migrateConversationMemory(opts: MigrateOptions): Promise<MigrateResult[]> {
+  console.log(`\n${"=".repeat(60)}`);
+  console.log(`Pinecone → pgvector 会話メモリ移行`);
+  console.log(`${"=".repeat(60)}`);
+  console.log(`Pinecone host: ${opts.pineconeHost}`);
+  console.log(`Namespaces: ${opts.namespaces.join(", ")}`);
+  console.log(`Dry run: ${opts.dryRun}`);
+  console.log();
+
+  const results: MigrateResult[] = [];
+
+  for (const ns of opts.namespaces) {
+    console.log(`\n--- ${ns} ---`);
+    const result = await migrateNamespace(opts, ns);
+    results.push(result);
+    console.log(
+      `  ✅ Done: ${result.migrated} migrated, ${result.skippedExisting} skipped, ${result.errors} errors`,
+    );
+  }
+
+  // Summary
+  console.log(`\n${"=".repeat(60)}`);
+  console.log("Summary");
+  console.log(`${"=".repeat(60)}`);
+  console.log(
+    `${"Namespace".padEnd(30)} ${"Pinecone".padStart(10)} ${"Migrated".padStart(10)} ${"Skipped".padStart(10)} ${"Errors".padStart(10)}`,
+  );
+  console.log("-".repeat(70));
+
+  let totalMigrated = 0;
+  let totalErrors = 0;
+
+  for (const r of results) {
+    console.log(
+      `${r.namespace.padEnd(30)} ${String(r.totalPinecone).padStart(10)} ${String(r.migrated).padStart(10)} ${String(r.skippedExisting + r.skippedNoText).padStart(10)} ${String(r.errors).padStart(10)}`,
+    );
+    totalMigrated += r.migrated;
+    totalErrors += r.errors;
+  }
+
+  console.log("-".repeat(70));
+  console.log(`Total migrated: ${totalMigrated}, errors: ${totalErrors}`);
+
+  return results;
+}

--- a/packages/migrate-memory/src/pinecone-to-pgvector.ts
+++ b/packages/migrate-memory/src/pinecone-to-pgvector.ts
@@ -29,7 +29,7 @@ interface PineconeVectorMetadata {
   turnId?: string;
 }
 
-interface MigrateOptions {
+export interface MigrateOptions {
   pineconeApiKey: string;
   pineconeHost: string;
   pgvectorClient: IPineconeClient;
@@ -39,7 +39,7 @@ interface MigrateOptions {
   sourceTypes?: string[];
 }
 
-interface MigrateResult {
+export interface MigrateResult {
   namespace: string;
   totalPinecone: number;
   skippedExisting: number;
@@ -48,7 +48,7 @@ interface MigrateResult {
   errors: number;
 }
 
-async function pineconeList(
+export async function pineconeList(
   host: string,
   apiKey: string,
   namespace: string,
@@ -80,7 +80,7 @@ async function pineconeList(
   };
 }
 
-async function pineconeFetch(
+export async function pineconeFetch(
   host: string,
   apiKey: string,
   namespace: string,

--- a/packages/migrate-memory/src/pinecone-to-pgvector.ts
+++ b/packages/migrate-memory/src/pinecone-to-pgvector.ts
@@ -167,18 +167,24 @@ async function migrateNamespace(opts: MigrateOptions, namespace: string): Promis
         continue;
       }
 
+      // Normalize "conversation" to "session_turn" (canonical sourceType for conversation memory)
+      const normalizedSourceType =
+        meta.sourceType === "conversation" ? "session_turn" : meta.sourceType;
+      const normalizedCategory =
+        meta.sourceType === "conversation" ? (meta.category ?? "conversation") : meta.category;
+
       chunksToMigrate.push({
         id,
         text: meta.text,
         metadata: {
           agentId,
           sourceFile: meta.sourceFile,
-          sourceType: meta.sourceType as MemoryChunk["metadata"]["sourceType"],
+          sourceType: normalizedSourceType as MemoryChunk["metadata"]["sourceType"],
           chunkIndex: meta.chunkIndex ?? 0,
           createdAt: meta.createdAt ?? Date.now(),
           turnId: meta.turnId,
           role: meta.role as "user" | "assistant" | undefined,
-          category: meta.category,
+          category: normalizedCategory,
         },
       });
     }

--- a/packages/migrate-memory/src/pinecone-to-pgvector.ts
+++ b/packages/migrate-memory/src/pinecone-to-pgvector.ts
@@ -124,7 +124,7 @@ async function migrateNamespace(opts: MigrateOptions, namespace: string): Promis
     errors: 0,
   };
 
-  const sourceTypeFilter = new Set(opts.sourceTypes ?? ["session_turn", "conversation"]);
+  const sourceTypeFilter = opts.sourceTypes ? new Set(opts.sourceTypes) : null;
 
   // Phase 1: List all vector IDs from Pinecone
   console.log(`  📋 Listing vectors in ${namespace}...`);
@@ -155,8 +155,8 @@ async function migrateNamespace(opts: MigrateOptions, namespace: string): Promis
     );
 
     for (const [id, meta] of vectors) {
-      // Filter by sourceType (conversation memory only)
-      if (!sourceTypeFilter.has(meta.sourceType)) {
+      // Filter by sourceType (conversation memory only, unless sourceTypes is null = include all)
+      if (sourceTypeFilter && !sourceTypeFilter.has(meta.sourceType)) {
         result.skippedExisting++;
         continue;
       }

--- a/packages/migrate-memory/src/pinecone-to-pgvector.ts
+++ b/packages/migrate-memory/src/pinecone-to-pgvector.ts
@@ -16,6 +16,14 @@ const PINECONE_LIST_LIMIT = 100;
 const PINECONE_FETCH_BATCH = 100;
 const UPSERT_BATCH_SIZE = 50;
 const GEMINI_RATE_LIMIT_DELAY_MS = 200;
+const PINECONE_API_VERSION = "2025-04";
+
+export function pineconeHeaders(apiKey: string): Record<string, string> {
+  return {
+    "Api-Key": apiKey,
+    "X-Pinecone-Api-Version": PINECONE_API_VERSION,
+  };
+}
 
 interface PineconeVectorMetadata {
   agentId: string;
@@ -61,7 +69,7 @@ export async function pineconeList(
   }
 
   const res = await fetch(url.toString(), {
-    headers: { "Api-Key": apiKey },
+    headers: pineconeHeaders(apiKey),
   });
 
   if (!res.ok) {
@@ -92,7 +100,7 @@ export async function pineconeFetch(
   }
 
   const res = await fetch(url.toString(), {
-    headers: { "Api-Key": apiKey },
+    headers: pineconeHeaders(apiKey),
   });
 
   if (!res.ok) {


### PR DESCRIPTION
## Summary

- pgvector 移行時に AGENTS.md ルールのみ移行し、Pinecone に蓄積された会話メモリ（session_turn）が移行されていなかった
- `pinecone-to-pgvector` コマンドを migrate-memory CLI に追加
- Pinecone REST API でベクトルを列挙・取得 → Gemini で再 embedding（1024→768dim）→ pgvector に upsert

### 移行対象

| namespace | 会話メモリ |
|-----------|--------:|
| mell | 9,691 |
| net | 3,754 |
| tom | 3,557 |
| hongmong-ochi | 1,929 |
| temin | 1,885 |
| その他 12 ns | 2,189 |
| **合計** | **23,005** |

### 使い方

```bash
# dry-run（全 namespace）
PINECONE_API_KEY=... PGVECTOR_DATABASE_URL=... GEMINI_API_KEY=... \
  npx tsx src/cli.ts pinecone-to-pgvector --dry-run

# 特定 namespace のみ実行
npx tsx src/cli.ts pinecone-to-pgvector --namespace agent:mell

# 全 namespace 一括実行
npx tsx src/cli.ts pinecone-to-pgvector
```

Closes estack-inc/easy-flow#247

## Test plan

- [x] `--dry-run` で全 17 namespace の列挙・フィルタリングが正常動作（23,005 chunks）
- [x] session_turn/conversation のみ抽出、agents_rule/memory_file はスキップ
- [x] ビルド成功（tsc）
- [x] biome lint パス
- [ ] 実環境で mell namespace の実移行テスト