### PR TITLE
feat(pinecone-context-engine): RAG クエリ truncation で外れ値レイテンシを防止

### DIFF
--- a/packages/openclaw-pinecone-plugin/openclaw.plugin.json
+++ b/packages/openclaw-pinecone-plugin/openclaw.plugin.json
@@ -56,6 +56,11 @@
         "minimum": 1,
         "maximum": 100
       },
+      "maxQueryTokens": {
+        "type": "number",
+        "minimum": 0,
+        "maximum": 10000
+      },
       "ragEnabled": {
         "type": "boolean"
       },

--- a/packages/openclaw-pinecone-plugin/openclaw.plugin.json
+++ b/packages/openclaw-pinecone-plugin/openclaw.plugin.json
@@ -37,6 +37,12 @@
       "placeholder": "20",
       "help": "クエリがこのトークン数未満の場合 'thin' と判定（デフォルト: 20）",
       "advanced": true
+    },
+    "maxQueryTokens": {
+      "label": "Max Query Tokens",
+      "placeholder": "1024",
+      "help": "Embedding API に送信するクエリの最大トークン数。0 = 無制限（デフォルト: 1024）",
+      "advanced": true
     }
   },
   "configSchema": {

--- a/packages/openclaw-pinecone-plugin/openclaw.plugin.json
+++ b/packages/openclaw-pinecone-plugin/openclaw.plugin.json
@@ -57,7 +57,7 @@
         "maximum": 100
       },
       "maxQueryTokens": {
-        "type": "number",
+        "type": "integer",
         "minimum": 0,
         "maximum": 10000
       },

--- a/packages/openclaw-pinecone-plugin/src/index.test.ts
+++ b/packages/openclaw-pinecone-plugin/src/index.test.ts
@@ -108,12 +108,13 @@ describe("pinecone-memory plugin", () => {
     expect(api.logger.info).toHaveBeenCalledWith(expect.stringContaining("compactAfterDays: 14"));
   });
 
-  it("passes memoryHint and minQueryTokens to PineconeContextEngine", () => {
+  it("passes memoryHint, minQueryTokens, and maxQueryTokens to PineconeContextEngine", () => {
     const api = createMockApi({
       apiKey: "test-key",
       agentId: "mell",
       memoryHint: "eSTACK AI agent",
       minQueryTokens: 30,
+      maxQueryTokens: 512,
     });
     register(api as any);
 
@@ -125,6 +126,7 @@ describe("pinecone-memory plugin", () => {
         agentId: "mell",
         memoryHint: "eSTACK AI agent",
         minQueryTokens: 30,
+        maxQueryTokens: 512,
       }),
     );
   });

--- a/packages/openclaw-pinecone-plugin/src/index.ts
+++ b/packages/openclaw-pinecone-plugin/src/index.ts
@@ -10,6 +10,7 @@ type PluginConfig = {
   compactAfterDays?: number;
   memoryHint?: string;
   minQueryTokens?: number;
+  maxQueryTokens?: number;
   ragEnabled?: boolean;
   agentsCorePath?: string;
   ragTokenBudget?: number;
@@ -102,6 +103,7 @@ export default function register(api: OpenClawPluginApi): void {
       compactAfterDays,
       memoryHint: cfg.memoryHint,
       minQueryTokens: cfg.minQueryTokens,
+      maxQueryTokens: cfg.maxQueryTokens,
       ragEnabled,
       agentsCorePath,
       ragTokenBudget,

--- a/packages/pinecone-context-engine/src/pinecone-context-engine-parallel.test.ts
+++ b/packages/pinecone-context-engine/src/pinecone-context-engine-parallel.test.ts
@@ -186,6 +186,36 @@ describe("PineconeContextEngineParallel", () => {
     });
   });
 
+  describe("query truncation", () => {
+    it("maxQueryTokens を超えるクエリが truncation される", async () => {
+      (mockPineconeClient.query as any).mockResolvedValue([]);
+      const consoleSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+
+      const truncEngine = new PineconeContextEngineParallel({
+        pineconeClient: mockPineconeClient,
+        agentId: "test-agent",
+        maxQueryTokens: 500,
+      });
+
+      // ~750 tokens (500 CJK × 1.5)
+      const longMessage = "質".repeat(500);
+      const messages: AgentMessage[] = [
+        { id: "1", role: "user", content: longMessage, timestamp: Date.now() },
+      ];
+
+      const result = await truncEngine.assemble({ sessionId: "s1", messages });
+      // Wait for contextPromise to complete
+      if (result.contextPromise) await result.contextPromise;
+
+      const truncationLog = consoleSpy.mock.calls.find(
+        (call) => typeof call[0] === "string" && call[0].includes("query truncated"),
+      );
+      expect(truncationLog).toBeDefined();
+
+      consoleSpy.mockRestore();
+    });
+  });
+
   describe("ragEnabled warning", () => {
     it("warns when ragEnabled=true is passed", () => {
       const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});

--- a/packages/pinecone-context-engine/src/pinecone-context-engine-parallel.ts
+++ b/packages/pinecone-context-engine/src/pinecone-context-engine-parallel.ts
@@ -14,7 +14,7 @@ import { EmptyFallbackContextEngine, FallbackContextEngine } from "./fallback-ad
 import {
   ASSEMBLE_TIMEOUT_MS,
   buildEnrichedQuery,
-  buildQueryFromRecentTurns,
+  buildQueryWithTruncation,
   buildSystemPromptAddition,
   DEFAULT_COMPACT_AFTER_DAYS,
   DEFAULT_INGEST_ROLES,
@@ -24,6 +24,7 @@ import {
   DEFAULT_TOKEN_BUDGET,
   DEFAULT_TOP_K,
   readOldTurns,
+  resolveMaxQueryTokens,
   withRetry,
 } from "./shared.js";
 import type { PineconeContextEngineParams } from "./types.js";
@@ -62,6 +63,7 @@ export class PineconeContextEngineParallel implements ContextEngine {
   private readonly defaultCategory: string;
   private readonly memoryHint?: string;
   private readonly minQueryTokens: number;
+  private readonly maxQueryTokens: number;
 
   constructor(params: PineconeContextEngineParams) {
     if (params.ragEnabled) {
@@ -82,6 +84,7 @@ export class PineconeContextEngineParallel implements ContextEngine {
     this.defaultCategory = params.defaultCategory ?? "conversation";
     this.memoryHint = params.memoryHint;
     this.minQueryTokens = params.minQueryTokens ?? DEFAULT_MIN_QUERY_TOKENS;
+    this.maxQueryTokens = resolveMaxQueryTokens(params.maxQueryTokens);
   }
 
   async bootstrap(_params: { sessionId: string; sessionFile: string }): Promise<BootstrapResult> {
@@ -160,16 +163,22 @@ export class PineconeContextEngineParallel implements ContextEngine {
     messages: AgentMessage[];
     tokenBudget?: number;
   }): Promise<ParallelAssembleResult> {
-    const baseQuery = buildQueryFromRecentTurns(params.messages);
+    const truncation = buildQueryWithTruncation(params.messages, this.maxQueryTokens);
 
-    if (!baseQuery) {
+    if (!truncation.query) {
       return {
         messages: params.messages,
         estimatedTokens: 0,
       };
     }
 
-    const queryText = buildEnrichedQuery(baseQuery, this.memoryHint, this.minQueryTokens);
+    if (truncation.truncated) {
+      console.info(
+        `[PineconeContextEngineParallel] query truncated: before=${truncation.originalTokens} after=${truncation.truncatedTokens} turns_used=${truncation.turnsUsed} turns_total=${truncation.turnsTotal}`,
+      );
+    }
+
+    const queryText = buildEnrichedQuery(truncation.query, this.memoryHint, this.minQueryTokens);
     const budget = params.tokenBudget ?? this.tokenBudget;
 
     // START PINECONE QUERY IMMEDIATELY - DO NOT AWAIT

--- a/packages/pinecone-context-engine/src/pinecone-context-engine-parallel.ts
+++ b/packages/pinecone-context-engine/src/pinecone-context-engine-parallel.ts
@@ -27,6 +27,7 @@ import {
   resolveMaxQueryTokens,
   withRetry,
 } from "./shared.js";
+import { estimateTokens } from "./token-estimator.js";
 import type { PineconeContextEngineParams } from "./types.js";
 
 /**
@@ -178,7 +179,12 @@ export class PineconeContextEngineParallel implements ContextEngine {
       );
     }
 
-    const queryText = buildEnrichedQuery(truncation.query, this.memoryHint, this.minQueryTokens);
+    const enrichedQuery = buildEnrichedQuery(
+      truncation.query,
+      this.memoryHint,
+      this.minQueryTokens,
+    );
+    const queryText = this.capQuery(enrichedQuery);
     const budget = params.tokenBudget ?? this.tokenBudget;
 
     // START PINECONE QUERY IMMEDIATELY - DO NOT AWAIT
@@ -304,5 +310,19 @@ export class PineconeContextEngineParallel implements ContextEngine {
 
   async dispose(): Promise<void> {
     // No resources to release
+  }
+
+  /**
+   * Ensure the final query text (including memoryHint) does not exceed maxQueryTokens.
+   */
+  private capQuery(queryText: string): string {
+    if (this.maxQueryTokens <= 0) return queryText;
+    if (estimateTokens(queryText) <= this.maxQueryTokens) return queryText;
+    const newlineIndex = queryText.lastIndexOf("\n");
+    if (newlineIndex > 0) {
+      const base = queryText.slice(0, newlineIndex);
+      if (estimateTokens(base) <= this.maxQueryTokens) return base;
+    }
+    return queryText;
   }
 }

--- a/packages/pinecone-context-engine/src/pinecone-context-engine-parallel.ts
+++ b/packages/pinecone-context-engine/src/pinecone-context-engine-parallel.ts
@@ -184,7 +184,7 @@ export class PineconeContextEngineParallel implements ContextEngine {
       this.memoryHint,
       this.minQueryTokens,
     );
-    const queryText = this.capQuery(enrichedQuery);
+    const queryText = this.capQuery(enrichedQuery, truncation.query);
     const budget = params.tokenBudget ?? this.tokenBudget;
 
     // START PINECONE QUERY IMMEDIATELY - DO NOT AWAIT
@@ -314,15 +314,11 @@ export class PineconeContextEngineParallel implements ContextEngine {
 
   /**
    * Ensure the final query text (including memoryHint) does not exceed maxQueryTokens.
+   * If it does, fall back to the base query without memoryHint enrichment.
    */
-  private capQuery(queryText: string): string {
-    if (this.maxQueryTokens <= 0) return queryText;
-    if (estimateTokens(queryText) <= this.maxQueryTokens) return queryText;
-    const newlineIndex = queryText.lastIndexOf("\n");
-    if (newlineIndex > 0) {
-      const base = queryText.slice(0, newlineIndex);
-      if (estimateTokens(base) <= this.maxQueryTokens) return base;
-    }
-    return queryText;
+  private capQuery(enrichedQuery: string, baseQuery: string): string {
+    if (this.maxQueryTokens <= 0) return enrichedQuery;
+    if (estimateTokens(enrichedQuery) <= this.maxQueryTokens) return enrichedQuery;
+    return baseQuery;
   }
 }

--- a/packages/pinecone-context-engine/src/pinecone-context-engine.test.ts
+++ b/packages/pinecone-context-engine/src/pinecone-context-engine.test.ts
@@ -1108,7 +1108,7 @@ describe("PineconeContextEngine - query truncation", () => {
     }
   });
 
-  it("truncation + memoryHint の併用: memoryHint はトークン上限に含まれない", async () => {
+  it("truncation + memoryHint の併用: 最終クエリが maxQueryTokens 以内に収まる", async () => {
     const client = createMockClient();
     client.query.mockResolvedValue([]);
 
@@ -1125,12 +1125,35 @@ describe("PineconeContextEngine - query truncation", () => {
 
     await engine.assemble({ sessionId: "s1", messages });
 
-    // The query passed to Pinecone should include memoryHint
     const queryParams = client.query.mock.calls[0][0] as QueryParams;
+    // Base query (~14 tokens) + memoryHint (~6 tokens) ≈ 20 tokens < 100
+    // Both fit within budget, so memoryHint is included
     expect(queryParams.text).toContain("eSTACK AI agent service");
-    // memoryHint should be appended AFTER truncation check
-    // The base query (~14 tokens) is under 100, so no truncation on the base
-    // memoryHint is added after, and is NOT counted toward the 100 token limit
+    // Final query must not exceed maxQueryTokens
+    expect(estimateTokens(queryParams.text)).toBeLessThanOrEqual(100);
+  });
+
+  it("memoryHint が maxQueryTokens を超える場合は memoryHint を除外する", async () => {
+    const client = createMockClient();
+    client.query.mockResolvedValue([]);
+
+    const engine = new PineconeContextEngine({
+      pineconeClient: client,
+      agentId: "test-agent",
+      maxQueryTokens: 20,
+      memoryHint: "eSTACK AI agent service for central holdings corporation",
+      minQueryTokens: 200, // Force thin detection
+    });
+
+    // ~14 tokens base, + memoryHint ~13 tokens = ~27 > 20
+    const messages = [{ role: "user" as const, content: "あの件どうなった？" }];
+
+    await engine.assemble({ sessionId: "s1", messages });
+
+    const queryParams = client.query.mock.calls[0][0] as QueryParams;
+    // memoryHint should be stripped because it would exceed maxQueryTokens
+    expect(queryParams.text).not.toContain("eSTACK AI agent service");
+    expect(estimateTokens(queryParams.text)).toBeLessThanOrEqual(20);
   });
 });
 

--- a/packages/pinecone-context-engine/src/pinecone-context-engine.test.ts
+++ b/packages/pinecone-context-engine/src/pinecone-context-engine.test.ts
@@ -1155,6 +1155,31 @@ describe("PineconeContextEngine - query truncation", () => {
     expect(queryParams.text).not.toContain("eSTACK AI agent service");
     expect(estimateTokens(queryParams.text)).toBeLessThanOrEqual(20);
   });
+
+  it("複数行 memoryHint が maxQueryTokens を超える場合も baseQuery にフォールバックする", async () => {
+    const client = createMockClient();
+    client.query.mockResolvedValue([]);
+
+    const multiLineHint = "eSTACK AI agent\nfor central holdings\ncorporation service";
+    const engine = new PineconeContextEngine({
+      pineconeClient: client,
+      agentId: "test-agent",
+      maxQueryTokens: 20,
+      memoryHint: multiLineHint,
+      minQueryTokens: 200, // Force thin detection
+    });
+
+    const messages = [{ role: "user" as const, content: "あの件どうなった？" }];
+
+    await engine.assemble({ sessionId: "s1", messages });
+
+    const queryParams = client.query.mock.calls[0][0] as QueryParams;
+    // Multi-line memoryHint must be fully stripped
+    expect(queryParams.text).not.toContain("eSTACK AI agent");
+    expect(queryParams.text).not.toContain("central holdings");
+    expect(queryParams.text).not.toContain("corporation service");
+    expect(estimateTokens(queryParams.text)).toBeLessThanOrEqual(20);
+  });
 });
 
 describe("resolveMaxQueryTokens", () => {

--- a/packages/pinecone-context-engine/src/pinecone-context-engine.test.ts
+++ b/packages/pinecone-context-engine/src/pinecone-context-engine.test.ts
@@ -8,7 +8,7 @@ import {
   isQueryThin,
   PineconeContextEngine,
 } from "./pinecone-context-engine.js";
-import { buildQueryWithTruncation } from "./shared.js";
+import { buildQueryWithTruncation, resolveMaxQueryTokens } from "./shared.js";
 import { estimateTokens } from "./token-estimator.js";
 import type { IPineconeClient } from "./types.js";
 
@@ -1131,5 +1131,39 @@ describe("PineconeContextEngine - query truncation", () => {
     // memoryHint should be appended AFTER truncation check
     // The base query (~14 tokens) is under 100, so no truncation on the base
     // memoryHint is added after, and is NOT counted toward the 100 token limit
+  });
+});
+
+describe("resolveMaxQueryTokens", () => {
+  afterEach(() => {
+    delete process.env.RAG_MAX_QUERY_TOKENS;
+  });
+
+  it("負の RAG_MAX_QUERY_TOKENS はデフォルト値にフォールバックする", () => {
+    process.env.RAG_MAX_QUERY_TOKENS = "-1";
+    expect(resolveMaxQueryTokens()).toBe(1024);
+  });
+
+  it("NaN の RAG_MAX_QUERY_TOKENS はデフォルト値にフォールバックする", () => {
+    process.env.RAG_MAX_QUERY_TOKENS = "abc";
+    expect(resolveMaxQueryTokens()).toBe(1024);
+  });
+
+  it("負の param 値はデフォルト値にフォールバックする", () => {
+    expect(resolveMaxQueryTokens(-5)).toBe(1024);
+  });
+
+  it("env=0 は無制限として扱われる", () => {
+    process.env.RAG_MAX_QUERY_TOKENS = "0";
+    expect(resolveMaxQueryTokens(2000)).toBe(0);
+  });
+
+  it("正の env 値が param より優先される", () => {
+    process.env.RAG_MAX_QUERY_TOKENS = "500";
+    expect(resolveMaxQueryTokens(2000)).toBe(500);
+  });
+
+  it("env 未設定時は param が使用される", () => {
+    expect(resolveMaxQueryTokens(2000)).toBe(2000);
   });
 });

--- a/packages/pinecone-context-engine/src/pinecone-context-engine.test.ts
+++ b/packages/pinecone-context-engine/src/pinecone-context-engine.test.ts
@@ -8,6 +8,7 @@ import {
   isQueryThin,
   PineconeContextEngine,
 } from "./pinecone-context-engine.js";
+import { buildQueryWithTruncation } from "./shared.js";
 import { estimateTokens } from "./token-estimator.js";
 import type { IPineconeClient } from "./types.js";
 
@@ -995,5 +996,140 @@ describe("estimateTokens", () => {
 
   it("returns 0 for empty string", () => {
     expect(estimateTokens("")).toBe(0);
+  });
+});
+
+describe("buildQueryWithTruncation", () => {
+  it("query_tokens < maxQueryTokens の場合 truncation なし", () => {
+    const messages = [
+      { role: "user" as const, content: "Hello world" },
+      { role: "assistant" as const, content: "Hi there" },
+    ];
+    const result = buildQueryWithTruncation(messages, 1024);
+    expect(result.truncated).toBe(false);
+    expect(result.query).toContain("Hello world");
+    expect(result.query).toContain("Hi there");
+    expect(result.turnsUsed).toBe(2);
+  });
+
+  it("query_tokens > maxQueryTokens の場合 truncation 発生、最新ターンが保持される", () => {
+    // 各ターンが ~750 tokens (500 CJK chars × 1.5 = 750)
+    const longText1 = "古".repeat(500);
+    const longText2 = "中".repeat(500);
+    const latestText = "新".repeat(500);
+    const messages = [
+      { role: "user" as const, content: longText1 },
+      { role: "assistant" as const, content: longText2 },
+      { role: "user" as const, content: latestText },
+    ];
+    // maxTokens = 800 — only the latest turn (~750) fits
+    const result = buildQueryWithTruncation(messages, 800);
+    expect(result.truncated).toBe(true);
+    expect(result.query).toContain(latestText);
+    expect(result.query).not.toContain(longText1);
+    expect(result.turnsUsed).toBe(1);
+    expect(result.turnsTotal).toBe(3);
+    expect(result.originalTokens).toBeGreaterThan(800);
+    expect(result.truncatedTokens).toBeLessThanOrEqual(800);
+  });
+
+  it("maxQueryTokens = 0 の場合は無制限（truncation なし）", () => {
+    const longText = "あ".repeat(10000); // ~15000 tokens
+    const messages = [{ role: "user" as const, content: longText }];
+    const result = buildQueryWithTruncation(messages, 0);
+    expect(result.truncated).toBe(false);
+    expect(result.query).toBe(longText);
+    expect(result.originalTokens).toBeGreaterThan(1024);
+  });
+
+  it("セッション履歴が 1 ターンのみ、かつ上限超過の場合テキストを末尾から切り詰め", () => {
+    const longText = "東".repeat(2000); // ~3000 tokens
+    const messages = [{ role: "user" as const, content: longText }];
+    const result = buildQueryWithTruncation(messages, 1024);
+    expect(result.truncated).toBe(true);
+    expect(result.truncatedTokens).toBeLessThanOrEqual(1024);
+    expect(result.turnsUsed).toBe(1);
+    // Text should be a prefix of the original
+    expect(longText.startsWith(result.query)).toBe(true);
+    expect(result.query.length).toBeLessThan(longText.length);
+  });
+
+  it("日本語テキストのトークン推定が CJK 1.5 tokens/char で正しく行われる", () => {
+    // 100 CJK chars × 1.5 = 150 tokens → within 200 budget
+    const japaneseText = "漢".repeat(100);
+    const result = buildQueryWithTruncation(
+      [{ role: "user" as const, content: japaneseText }],
+      200,
+    );
+    expect(result.truncated).toBe(false);
+    expect(result.originalTokens).toBe(150);
+
+    // 200 CJK chars × 1.5 = 300 tokens → exceeds 200 budget
+    const longerText = "漢".repeat(200);
+    const result2 = buildQueryWithTruncation([{ role: "user" as const, content: longerText }], 200);
+    expect(result2.truncated).toBe(true);
+    expect(result2.truncatedTokens).toBeLessThanOrEqual(200);
+  });
+});
+
+describe("PineconeContextEngine - query truncation", () => {
+  it("環境変数 RAG_MAX_QUERY_TOKENS が configSchema より優先される", async () => {
+    const client = createMockClient();
+    client.query.mockResolvedValue([]);
+
+    const originalEnv = process.env.RAG_MAX_QUERY_TOKENS;
+    try {
+      process.env.RAG_MAX_QUERY_TOKENS = "500";
+
+      const engine = new PineconeContextEngine({
+        pineconeClient: client,
+        agentId: "test-agent",
+        maxQueryTokens: 2000, // param は無視される
+      });
+
+      // ~750 tokens (500 CJK × 1.5) — exceeds env limit of 500
+      const longMessage = "質".repeat(500);
+      const messages = [{ role: "user" as const, content: longMessage }];
+      const consoleSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+
+      await engine.assemble({ sessionId: "s1", messages });
+
+      // Truncation should have occurred (env=500 < 750 tokens)
+      const truncationLog = consoleSpy.mock.calls.find(
+        (call) => typeof call[0] === "string" && call[0].includes("query truncated"),
+      );
+      expect(truncationLog).toBeDefined();
+    } finally {
+      if (originalEnv === undefined) {
+        delete process.env.RAG_MAX_QUERY_TOKENS;
+      } else {
+        process.env.RAG_MAX_QUERY_TOKENS = originalEnv;
+      }
+    }
+  });
+
+  it("truncation + memoryHint の併用: memoryHint はトークン上限に含まれない", async () => {
+    const client = createMockClient();
+    client.query.mockResolvedValue([]);
+
+    const engine = new PineconeContextEngine({
+      pineconeClient: client,
+      agentId: "test-agent",
+      maxQueryTokens: 100,
+      memoryHint: "eSTACK AI agent service",
+      minQueryTokens: 200, // Force thin detection so memoryHint is appended
+    });
+
+    // Short message that fits within 100 token budget
+    const messages = [{ role: "user" as const, content: "あの件どうなった？" }];
+
+    await engine.assemble({ sessionId: "s1", messages });
+
+    // The query passed to Pinecone should include memoryHint
+    const queryParams = client.query.mock.calls[0][0] as QueryParams;
+    expect(queryParams.text).toContain("eSTACK AI agent service");
+    // memoryHint should be appended AFTER truncation check
+    // The base query (~14 tokens) is under 100, so no truncation on the base
+    // memoryHint is added after, and is NOT counted toward the 100 token limit
   });
 });

--- a/packages/pinecone-context-engine/src/pinecone-context-engine.test.ts
+++ b/packages/pinecone-context-engine/src/pinecone-context-engine.test.ts
@@ -1189,4 +1189,13 @@ describe("resolveMaxQueryTokens", () => {
   it("env 未設定時は param が使用される", () => {
     expect(resolveMaxQueryTokens(2000)).toBe(2000);
   });
+
+  it("param=1 は最小値 2 にクランプされる", () => {
+    expect(resolveMaxQueryTokens(1)).toBe(2);
+  });
+
+  it("env=1 は最小値 2 にクランプされる", () => {
+    process.env.RAG_MAX_QUERY_TOKENS = "1";
+    expect(resolveMaxQueryTokens()).toBe(2);
+  });
 });

--- a/packages/pinecone-context-engine/src/pinecone-context-engine.ts
+++ b/packages/pinecone-context-engine/src/pinecone-context-engine.ts
@@ -15,11 +15,12 @@ import { rerankChunks } from "./reranker.js";
 import {
   ASSEMBLE_TIMEOUT_MS,
   buildEnrichedQuery,
-  buildQueryFromRecentTurns,
+  buildQueryWithTruncation,
   buildRagSystemPromptAddition,
   buildSystemPromptAddition,
   DEFAULT_COMPACT_AFTER_DAYS,
   DEFAULT_INGEST_ROLES,
+  DEFAULT_MAX_QUERY_TOKENS,
   DEFAULT_MIN_QUERY_TOKENS,
   DEFAULT_MIN_SCORE,
   DEFAULT_RAG_MIN_SCORE,
@@ -61,6 +62,7 @@ export class PineconeContextEngine implements ContextEngine {
   private readonly ragTokenBudget: number;
   private readonly ragMinScore: number;
   private readonly ragTopK: number;
+  private readonly maxQueryTokens: number;
 
   constructor(params: PineconeContextEngineParams) {
     this.client = params.pineconeClient;
@@ -81,6 +83,14 @@ export class PineconeContextEngine implements ContextEngine {
     this.ragTokenBudget = params.ragTokenBudget ?? DEFAULT_RAG_TOKEN_BUDGET;
     this.ragMinScore = params.ragMinScore ?? DEFAULT_RAG_MIN_SCORE;
     this.ragTopK = params.ragTopK ?? DEFAULT_RAG_TOP_K;
+
+    // RAG_MAX_QUERY_TOKENS env var > constructor param > default
+    const envMaxQueryTokens = process.env.RAG_MAX_QUERY_TOKENS;
+    const parsedEnv = envMaxQueryTokens !== undefined ? Number(envMaxQueryTokens) : undefined;
+    this.maxQueryTokens =
+      parsedEnv !== undefined && !Number.isNaN(parsedEnv)
+        ? parsedEnv
+        : (params.maxQueryTokens ?? DEFAULT_MAX_QUERY_TOKENS);
   }
 
   async bootstrap(_params: { sessionId: string; sessionFile: string }): Promise<BootstrapResult> {
@@ -169,16 +179,22 @@ export class PineconeContextEngine implements ContextEngine {
     tokenBudget?: number;
   }): Promise<AssembleResult> {
     try {
-      const baseQuery = buildQueryFromRecentTurns(params.messages);
+      const truncation = buildQueryWithTruncation(params.messages, this.maxQueryTokens);
 
-      if (!baseQuery) {
+      if (!truncation.query) {
         return {
           messages: params.messages,
           estimatedTokens: 0,
         };
       }
 
-      const queryText = this.enrichQuery(baseQuery);
+      if (truncation.truncated) {
+        console.info(
+          `[PineconeContextEngine] query truncated: before=${truncation.originalTokens} after=${truncation.truncatedTokens} turns_used=${truncation.turnsUsed} turns_total=${truncation.turnsTotal}`,
+        );
+      }
+
+      const queryText = this.enrichQuery(truncation.query);
 
       const results = await Promise.race([
         withRetry(() =>
@@ -228,10 +244,17 @@ export class PineconeContextEngine implements ContextEngine {
         ? readAgentsCore(this.agentsCorePath)
         : Promise.resolve("");
 
-      // 2. 検索クエリを生成（同期処理）
-      const baseQuery = buildQueryFromRecentTurns(params.messages);
-      const queryTokens = baseQuery ? estimateTokens(baseQuery) : 0;
+      // 2. 検索クエリを生成（同期処理）+ truncation
+      const truncation = buildQueryWithTruncation(params.messages, this.maxQueryTokens);
+      const baseQuery = truncation.query;
+      const queryTokens = truncation.truncatedTokens;
       const totalBudget = params.tokenBudget ?? this.ragTokenBudget;
+
+      if (truncation.truncated) {
+        console.info(
+          `[PineconeContextEngine] query truncated: before=${truncation.originalTokens} after=${truncation.truncatedTokens} turns_used=${truncation.turnsUsed} turns_total=${truncation.turnsTotal}`,
+        );
+      }
 
       if (!baseQuery) {
         // クエリなし → AGENTS-CORE.md のみ返却

--- a/packages/pinecone-context-engine/src/pinecone-context-engine.ts
+++ b/packages/pinecone-context-engine/src/pinecone-context-engine.ts
@@ -20,7 +20,6 @@ import {
   buildSystemPromptAddition,
   DEFAULT_COMPACT_AFTER_DAYS,
   DEFAULT_INGEST_ROLES,
-  DEFAULT_MAX_QUERY_TOKENS,
   DEFAULT_MIN_QUERY_TOKENS,
   DEFAULT_MIN_SCORE,
   DEFAULT_RAG_MIN_SCORE,
@@ -31,6 +30,7 @@ import {
   DEFAULT_TOP_K,
   readAgentsCore,
   readOldTurns,
+  resolveMaxQueryTokens,
   withRetry,
 } from "./shared.js";
 import { estimateTokens } from "./token-estimator.js";
@@ -84,13 +84,7 @@ export class PineconeContextEngine implements ContextEngine {
     this.ragMinScore = params.ragMinScore ?? DEFAULT_RAG_MIN_SCORE;
     this.ragTopK = params.ragTopK ?? DEFAULT_RAG_TOP_K;
 
-    // RAG_MAX_QUERY_TOKENS env var > constructor param > default
-    const envMaxQueryTokens = process.env.RAG_MAX_QUERY_TOKENS;
-    const parsedEnv = envMaxQueryTokens !== undefined ? Number(envMaxQueryTokens) : undefined;
-    this.maxQueryTokens =
-      parsedEnv !== undefined && !Number.isNaN(parsedEnv)
-        ? parsedEnv
-        : (params.maxQueryTokens ?? DEFAULT_MAX_QUERY_TOKENS);
+    this.maxQueryTokens = resolveMaxQueryTokens(params.maxQueryTokens);
   }
 
   async bootstrap(_params: { sessionId: string; sessionFile: string }): Promise<BootstrapResult> {

--- a/packages/pinecone-context-engine/src/pinecone-context-engine.ts
+++ b/packages/pinecone-context-engine/src/pinecone-context-engine.ts
@@ -188,7 +188,7 @@ export class PineconeContextEngine implements ContextEngine {
         );
       }
 
-      const queryText = this.capQuery(this.enrichQuery(truncation.query));
+      const queryText = this.capQuery(this.enrichQuery(truncation.query), truncation.query);
 
       const results = await Promise.race([
         withRetry(() =>
@@ -270,7 +270,7 @@ export class PineconeContextEngine implements ContextEngine {
         return { messages: params.messages, estimatedTokens: 0 };
       }
 
-      const queryText = this.capQuery(this.enrichQuery(baseQuery));
+      const queryText = this.capQuery(this.enrichQuery(baseQuery), baseQuery);
 
       // 3. AGENTS-CORE.md と Pinecone セマンティック検索を並列実行
       const pineconePromise = Promise.race([
@@ -462,17 +462,11 @@ export class PineconeContextEngine implements ContextEngine {
 
   /**
    * Ensure the final query text (including memoryHint) does not exceed maxQueryTokens.
-   * If it does, fall back to the query without memoryHint enrichment.
+   * If it does, fall back to the base query without memoryHint enrichment.
    */
-  private capQuery(queryText: string): string {
-    if (this.maxQueryTokens <= 0) return queryText;
-    if (estimateTokens(queryText) <= this.maxQueryTokens) return queryText;
-    // Strip memoryHint by splitting at the first newline added by buildEnrichedQuery
-    const newlineIndex = queryText.lastIndexOf("\n");
-    if (newlineIndex > 0) {
-      const base = queryText.slice(0, newlineIndex);
-      if (estimateTokens(base) <= this.maxQueryTokens) return base;
-    }
-    return queryText;
+  private capQuery(enrichedQuery: string, baseQuery: string): string {
+    if (this.maxQueryTokens <= 0) return enrichedQuery;
+    if (estimateTokens(enrichedQuery) <= this.maxQueryTokens) return enrichedQuery;
+    return baseQuery;
   }
 }

--- a/packages/pinecone-context-engine/src/pinecone-context-engine.ts
+++ b/packages/pinecone-context-engine/src/pinecone-context-engine.ts
@@ -188,7 +188,7 @@ export class PineconeContextEngine implements ContextEngine {
         );
       }
 
-      const queryText = this.enrichQuery(truncation.query);
+      const queryText = this.capQuery(this.enrichQuery(truncation.query));
 
       const results = await Promise.race([
         withRetry(() =>
@@ -270,7 +270,7 @@ export class PineconeContextEngine implements ContextEngine {
         return { messages: params.messages, estimatedTokens: 0 };
       }
 
-      const queryText = this.enrichQuery(baseQuery);
+      const queryText = this.capQuery(this.enrichQuery(baseQuery));
 
       // 3. AGENTS-CORE.md と Pinecone セマンティック検索を並列実行
       const pineconePromise = Promise.race([
@@ -458,5 +458,21 @@ export class PineconeContextEngine implements ContextEngine {
 
   private enrichQuery(baseQuery: string): string {
     return buildEnrichedQuery(baseQuery, this.memoryHint, this.minQueryTokens);
+  }
+
+  /**
+   * Ensure the final query text (including memoryHint) does not exceed maxQueryTokens.
+   * If it does, fall back to the query without memoryHint enrichment.
+   */
+  private capQuery(queryText: string): string {
+    if (this.maxQueryTokens <= 0) return queryText;
+    if (estimateTokens(queryText) <= this.maxQueryTokens) return queryText;
+    // Strip memoryHint by splitting at the first newline added by buildEnrichedQuery
+    const newlineIndex = queryText.lastIndexOf("\n");
+    if (newlineIndex > 0) {
+      const base = queryText.slice(0, newlineIndex);
+      if (estimateTokens(base) <= this.maxQueryTokens) return base;
+    }
+    return queryText;
   }
 }

--- a/packages/pinecone-context-engine/src/shared.ts
+++ b/packages/pinecone-context-engine/src/shared.ts
@@ -37,6 +37,13 @@ export const DEFAULT_RAG_MIN_SCORE = 0.75;
 export const DEFAULT_RAG_TOP_K = 10;
 
 /**
+ * Default maximum tokens for the query text sent to Embedding API.
+ * Gemini text-embedding-004 accepts up to 2,048 tokens; 1,024 provides
+ * a safety margin while covering normal conversation lengths.
+ */
+export const DEFAULT_MAX_QUERY_TOKENS = 1024;
+
+/**
  * Determine if a query is "thin" — too short or lacking proper nouns to
  * produce good Pinecone vector-search results.
  */
@@ -103,6 +110,121 @@ export function buildQueryFromRecentTurns(messages: AgentMessage[]): string {
     .map((m) => (typeof m.content === "string" ? m.content : JSON.stringify(m.content)))
     .filter((t) => t.length > 0);
   return texts.join("\n");
+}
+
+export interface TruncationResult {
+  query: string;
+  truncated: boolean;
+  originalTokens: number;
+  truncatedTokens: number;
+  turnsUsed: number;
+  turnsTotal: number;
+}
+
+/**
+ * Build a query from recent turns with token-budget truncation.
+ *
+ * When the full query exceeds `maxTokens`, turns are selected from newest
+ * to oldest. The most recent message is always included (truncated at the
+ * character level if it alone exceeds the budget). `maxTokens <= 0` disables
+ * truncation (unlimited).
+ */
+export function buildQueryWithTruncation(
+  messages: AgentMessage[],
+  maxTokens: number,
+): TruncationResult {
+  const recent = messages.slice(-RECENT_TURNS_FOR_QUERY);
+  const texts = recent
+    .map((m) => (typeof m.content === "string" ? m.content : JSON.stringify(m.content)))
+    .filter((t) => t.length > 0);
+  const fullQuery = texts.join("\n");
+  const originalTokens = estimateTokens(fullQuery);
+
+  // maxTokens <= 0 means unlimited
+  if (maxTokens <= 0 || originalTokens <= maxTokens) {
+    return {
+      query: fullQuery,
+      truncated: false,
+      originalTokens,
+      truncatedTokens: originalTokens,
+      turnsUsed: texts.length,
+      turnsTotal: messages.length,
+    };
+  }
+
+  // Iterate from newest turn, accumulating within budget
+  const selected: string[] = [];
+  let usedTokens = 0;
+
+  for (let i = texts.length - 1; i >= 0; i--) {
+    const text = texts[i];
+    const textTokens = estimateTokens(text);
+
+    if (i === texts.length - 1) {
+      // Most recent message — always include, truncate text if needed
+      if (textTokens > maxTokens) {
+        selected.push(truncateTextToTokenBudget(text, maxTokens));
+        usedTokens = maxTokens;
+      } else {
+        selected.push(text);
+        usedTokens = textTokens;
+      }
+      continue;
+    }
+
+    // Account for newline separator (+1 token approximation)
+    const separatorTokens = 1;
+    if (usedTokens + textTokens + separatorTokens > maxTokens) {
+      break;
+    }
+    selected.push(text);
+    usedTokens += textTokens + separatorTokens;
+  }
+
+  // Reverse to restore chronological order
+  selected.reverse();
+
+  const truncatedQuery = selected.join("\n");
+  return {
+    query: truncatedQuery,
+    truncated: true,
+    originalTokens,
+    truncatedTokens: estimateTokens(truncatedQuery),
+    turnsUsed: selected.length,
+    turnsTotal: messages.length,
+  };
+}
+
+/**
+ * Truncate text to fit within a token budget by removing characters from the end.
+ */
+function truncateTextToTokenBudget(text: string, maxTokens: number): string {
+  let tokens = 0;
+  let endIndex = 0;
+
+  for (const char of text) {
+    const code = char.codePointAt(0)!;
+    let charTokens: number;
+    if (code <= 0x7f) {
+      charTokens = 0.25;
+    } else if (
+      (code >= 0x3000 && code <= 0x9fff) ||
+      (code >= 0xf900 && code <= 0xfaff) ||
+      (code >= 0xac00 && code <= 0xd7af)
+    ) {
+      charTokens = 1.5;
+    } else if (code >= 0xff00 && code <= 0xffef) {
+      charTokens = 1.0;
+    } else {
+      charTokens = 1.0;
+    }
+
+    if (Math.ceil(tokens + charTokens) > maxTokens) break;
+    tokens += charTokens;
+    endIndex += char.length;
+  }
+
+  return text.slice(0, endIndex);
 }
 
 export async function readOldTurns(

--- a/packages/pinecone-context-engine/src/shared.ts
+++ b/packages/pinecone-context-engine/src/shared.ts
@@ -44,6 +44,27 @@ export const DEFAULT_RAG_TOP_K = 10;
 export const DEFAULT_MAX_QUERY_TOKENS = 1024;
 
 /**
+ * Resolve the effective maxQueryTokens value from env var, param, and default.
+ *
+ * Priority: RAG_MAX_QUERY_TOKENS env > param > DEFAULT_MAX_QUERY_TOKENS.
+ * Only `0` is treated as "unlimited". Negative values and NaN are ignored
+ * (fall through to the next source).
+ */
+export function resolveMaxQueryTokens(paramValue?: number): number {
+  const envRaw = process.env.RAG_MAX_QUERY_TOKENS;
+  if (envRaw !== undefined) {
+    const parsed = Number(envRaw);
+    if (!Number.isNaN(parsed) && parsed >= 0) {
+      return parsed;
+    }
+  }
+  if (paramValue !== undefined && paramValue >= 0) {
+    return paramValue;
+  }
+  return DEFAULT_MAX_QUERY_TOKENS;
+}
+
+/**
  * Determine if a query is "thin" — too short or lacking proper nouns to
  * produce good Pinecone vector-search results.
  */

--- a/packages/pinecone-context-engine/src/shared.ts
+++ b/packages/pinecone-context-engine/src/shared.ts
@@ -44,24 +44,36 @@ export const DEFAULT_RAG_TOP_K = 10;
 export const DEFAULT_MAX_QUERY_TOKENS = 1024;
 
 /**
+ * Minimum positive value for maxQueryTokens.
+ * CJK characters need ~2 tokens each, so at least 2 tokens are required
+ * to represent a single character query.
+ */
+const MIN_POSITIVE_MAX_QUERY_TOKENS = 2;
+
+/**
  * Resolve the effective maxQueryTokens value from env var, param, and default.
  *
  * Priority: RAG_MAX_QUERY_TOKENS env > param > DEFAULT_MAX_QUERY_TOKENS.
- * Only `0` is treated as "unlimited". Negative values and NaN are ignored
- * (fall through to the next source).
+ * `0` means "unlimited". Negative values and NaN fall through to the next source.
+ * Positive values below MIN_POSITIVE_MAX_QUERY_TOKENS are clamped up.
  */
 export function resolveMaxQueryTokens(paramValue?: number): number {
   const envRaw = process.env.RAG_MAX_QUERY_TOKENS;
   if (envRaw !== undefined) {
     const parsed = Number(envRaw);
     if (!Number.isNaN(parsed) && parsed >= 0) {
-      return parsed;
+      return clampMaxQueryTokens(parsed);
     }
   }
   if (paramValue !== undefined && paramValue >= 0) {
-    return paramValue;
+    return clampMaxQueryTokens(paramValue);
   }
   return DEFAULT_MAX_QUERY_TOKENS;
+}
+
+function clampMaxQueryTokens(value: number): number {
+  if (value === 0) return 0; // unlimited
+  return Math.max(value, MIN_POSITIVE_MAX_QUERY_TOKENS);
 }
 
 /**

--- a/packages/pinecone-context-engine/src/shared.ts
+++ b/packages/pinecone-context-engine/src/shared.ts
@@ -185,37 +185,33 @@ export function buildQueryWithTruncation(
     };
   }
 
-  // Iterate from newest turn, accumulating within budget
+  // Iterate from newest turn, accumulating within budget.
+  // Use estimateTokens on the joined candidate text to avoid
+  // over-counting from per-turn Math.ceil rounding and separator approximation.
   const selected: string[] = [];
-  let usedTokens = 0;
 
   for (let i = texts.length - 1; i >= 0; i--) {
     const text = texts[i];
-    const textTokens = estimateTokens(text);
 
     if (i === texts.length - 1) {
       // Most recent message — always include, truncate text if needed
-      if (textTokens > maxTokens) {
+      if (estimateTokens(text) > maxTokens) {
         selected.push(truncateTextToTokenBudget(text, maxTokens));
-        usedTokens = maxTokens;
       } else {
         selected.push(text);
-        usedTokens = textTokens;
       }
       continue;
     }
 
-    // Account for newline separator (+1 token approximation)
-    const separatorTokens = 1;
-    if (usedTokens + textTokens + separatorTokens > maxTokens) {
+    // Check if adding this turn would exceed the budget
+    const candidate = [text, ...selected].join("\n");
+    if (estimateTokens(candidate) > maxTokens) {
       break;
     }
-    selected.push(text);
-    usedTokens += textTokens + separatorTokens;
+    selected.unshift(text);
   }
 
-  // Reverse to restore chronological order
-  selected.reverse();
+  // selected is already in chronological order (unshift for older, push for newest)
 
   const truncatedQuery = selected.join("\n");
   return {

--- a/packages/pinecone-context-engine/src/types.ts
+++ b/packages/pinecone-context-engine/src/types.ts
@@ -21,7 +21,7 @@ export interface PineconeContextEngineParams {
   memoryHint?: string;
   /** Token threshold below which a query is considered "thin". Default: 20 */
   minQueryTokens?: number;
-  /** Maximum tokens for query text sent to Embedding API. 0 = unlimited. Default: 1024 */
+  /** Maximum tokens for the final query text sent to Embedding API (including memoryHint). 0 = unlimited. Default: 1024 */
   maxQueryTokens?: number;
 
   // --- RAG mode params ---

--- a/packages/pinecone-context-engine/src/types.ts
+++ b/packages/pinecone-context-engine/src/types.ts
@@ -21,6 +21,8 @@ export interface PineconeContextEngineParams {
   memoryHint?: string;
   /** Token threshold below which a query is considered "thin". Default: 20 */
   minQueryTokens?: number;
+  /** Maximum tokens for query text sent to Embedding API. 0 = unlimited. Default: 1024 */
+  maxQueryTokens?: number;
 
   // --- RAG mode params ---
   /** RAG モード有効化。Default: false (env: RAG_ENABLED) */


### PR DESCRIPTION
## Summary

- `assemble()` の検索クエリテキストを最大 1,024 トークンに制限し、Embedding API への過大な入力による外れ値レイテンシ（56,713 tokens → 1,446ms）を防止
- セッション履歴を新しいターンから逆順に走査し、直近のメッセージを優先的に保持する truncation ロジック
- `RAG_MAX_QUERY_TOKENS` 環境変数で制限値をオーバーライド可能（`0` で無制限 = rollback）
- memoryHint を含む最終クエリが maxQueryTokens を超えない上限保証（`capQuery()`）

## Changes

| ファイル | 変更内容 |
|---------|---------|
| `shared.ts` | `DEFAULT_MAX_QUERY_TOKENS` 定数、`buildQueryWithTruncation()` 関数、`resolveMaxQueryTokens()` ヘルパーを追加 |
| `types.ts` | `maxQueryTokens` パラメータを `PineconeContextEngineParams` に追加 |
| `pinecone-context-engine.ts` | `assembleClassic` / `assembleRag` に truncation を統合、`capQuery()` で最終クエリ上限保証 |
| `pinecone-context-engine-parallel.ts` | parallel 経路にも truncation + `capQuery()` を適用 |
| `openclaw-pinecone-plugin` | `configSchema` / `PluginConfig` / factory に `maxQueryTokens` を追加 |
| テストファイル | truncation / 環境変数 / 負値ガード / memoryHint 上限保証 / CJK 推定のテストを追加 |

## Design decisions

- **memoryHint + base query の合計で maxQueryTokens を保証**: `capQuery()` が最終クエリを検証し、超過時は memoryHint を除外
- **環境変数優先**: `RAG_MAX_QUERY_TOKENS` env > `maxQueryTokens` param > `DEFAULT_MAX_QUERY_TOKENS (1024)`
- **負値ガード**: `resolveMaxQueryTokens()` で負値・NaN をデフォルト値にフォールバック（`0` のみ無制限）

## Rollback

`RAG_MAX_QUERY_TOKENS=0` を環境変数に設定し、インスタンス再起動で truncation 無効化（現行動作に復帰）。

## Test plan

- [x] `query_tokens < maxQueryTokens` → truncation なし
- [x] `query_tokens > maxQueryTokens` → truncation 発生、最新ターン保持
- [x] `maxQueryTokens = 0` → 無制限
- [x] 1 ターンのみ＋上限超過 → テキスト末尾切り詰め
- [x] `RAG_MAX_QUERY_TOKENS` 環境変数の優先
- [x] 負値・NaN のフォールバック
- [x] truncation + memoryHint 併用（上限保証）
- [x] memoryHint 超過時に memoryHint を除外
- [x] 日本語テキストの CJK 1.5 tokens/char 推定
- [x] Parallel 経路の truncation
- [x] 全テスト pass、`npm run lint` クリーン

Closes estack-inc/easy-flow#246