### PR TITLE
feat: ingest-document コマンドで任意ドキュメントを RAG 事前登録

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -663,6 +663,190 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@napi-rs/canvas": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.80.tgz",
+      "integrity": "sha512-DxuT1ClnIPts1kQx8FBmkk4BQDTfI5kIzywAaMjQSXfNnra5UFU9PwurXrl+Je3bJ6BGsp/zmshVVFbCmyI+ww==",
+      "license": "MIT",
+      "workspaces": [
+        "e2e/*"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas-android-arm64": "0.1.80",
+        "@napi-rs/canvas-darwin-arm64": "0.1.80",
+        "@napi-rs/canvas-darwin-x64": "0.1.80",
+        "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.80",
+        "@napi-rs/canvas-linux-arm64-gnu": "0.1.80",
+        "@napi-rs/canvas-linux-arm64-musl": "0.1.80",
+        "@napi-rs/canvas-linux-riscv64-gnu": "0.1.80",
+        "@napi-rs/canvas-linux-x64-gnu": "0.1.80",
+        "@napi-rs/canvas-linux-x64-musl": "0.1.80",
+        "@napi-rs/canvas-win32-x64-msvc": "0.1.80"
+      }
+    },
+    "node_modules/@napi-rs/canvas-android-arm64": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.80.tgz",
+      "integrity": "sha512-sk7xhN/MoXeuExlggf91pNziBxLPVUqF2CAVnB57KLG/pz7+U5TKG8eXdc3pm0d7Od0WreB6ZKLj37sX9muGOQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-arm64": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.80.tgz",
+      "integrity": "sha512-O64APRTXRUiAz0P8gErkfEr3lipLJgM6pjATwavZ22ebhjYl/SUbpgM0xcWPQBNMP1n29afAC/Us5PX1vg+JNQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-x64": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.80.tgz",
+      "integrity": "sha512-FqqSU7qFce0Cp3pwnTjVkKjjOtxMqRe6lmINxpIZYaZNnVI0H5FtsaraZJ36SiTHNjZlUB69/HhxNDT1Aaa9vA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.80.tgz",
+      "integrity": "sha512-eyWz0ddBDQc7/JbAtY4OtZ5SpK8tR4JsCYEZjCE3dI8pqoWUC8oMwYSBGCYfsx2w47cQgQCgMVRVTFiiO38hHQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-gnu": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.80.tgz",
+      "integrity": "sha512-qwA63t8A86bnxhuA/GwOkK3jvb+XTQaTiVML0vAWoHyoZYTjNs7BzoOONDgTnNtr8/yHrq64XXzUoLqDzU+Uuw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-musl": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.80.tgz",
+      "integrity": "sha512-1XbCOz/ymhj24lFaIXtWnwv/6eFHXDrjP0jYkc6iHQ9q8oXKzUX1Lc6bu+wuGiLhGh2GS/2JlfORC5ZcXimRcg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.80.tgz",
+      "integrity": "sha512-XTzR125w5ZMs0lJcxRlS1K3P5RaZ9RmUsPtd1uGt+EfDyYMu4c6SEROYsxyatbbu/2+lPe7MPHOO/0a0x7L/gw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-gnu": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.80.tgz",
+      "integrity": "sha512-BeXAmhKg1kX3UCrJsYbdQd3hIMDH/K6HnP/pG2LuITaXhXBiNdh//TVVVVCBbJzVQaV5gK/4ZOCMrQW9mvuTqA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-musl": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.80.tgz",
+      "integrity": "sha512-x0XvZWdHbkgdgucJsRxprX/4o4sEed7qo9rCQA9ugiS9qE2QvP0RIiEugtZhfLH3cyI+jIRFJHV4Fuz+1BHHMg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-x64-msvc": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.80.tgz",
+      "integrity": "sha512-Z8jPsM6df5V8B1HrCHB05+bDiCxjE9QA//3YrkKIdVDEwn5RKaqOxCJDRJkl48cJbylcrJbW4HxZbTte8juuPg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@openclaw/workflow-controller": {
       "resolved": "packages/workflow-controller",
       "link": true
@@ -1061,6 +1245,16 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@types/pdf-parse": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@types/pdf-parse/-/pdf-parse-1.1.5.tgz",
+      "integrity": "sha512-kBfrSXsloMnUJOKi25s3+hRmkycHfLK6A09eRGqF/N8BkQoPUmaCr+q8Cli5FnfohEz/rsv82zAiPz/LXtOGhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/pg": {
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.20.0.tgz",
@@ -1201,6 +1395,33 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.8.12",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.12.tgz",
+      "integrity": "sha512-9k/gHF6n/pAi/9tqr3m3aqkuiNosYTurLLUtc7xQ9sxB/wm7WPygCv8GYa6mS0fLJEHhqMC1ATYhz++U/lRHqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/adler-32": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
+      "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -1211,6 +1432,38 @@
         "node": ">=12"
       }
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bluebird": {
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
+      "integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==",
+      "license": "MIT"
+    },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "license": "ISC"
+    },
     "node_modules/cac": {
       "version": "6.7.14",
       "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
@@ -1219,6 +1472,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/cfb": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.2.2.tgz",
+      "integrity": "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "crc-32": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/chai": {
@@ -1248,6 +1514,103 @@
         "node": ">= 16"
       }
     },
+    "node_modules/cheerio": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.2.0.tgz",
+      "integrity": "sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==",
+      "license": "MIT",
+      "dependencies": {
+        "cheerio-select": "^2.1.0",
+        "dom-serializer": "^2.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "encoding-sniffer": "^0.2.1",
+        "htmlparser2": "^10.1.0",
+        "parse5": "^7.3.0",
+        "parse5-htmlparser2-tree-adapter": "^7.1.0",
+        "parse5-parser-stream": "^7.1.2",
+        "undici": "^7.19.0",
+        "whatwg-mimetype": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.1"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+      }
+    },
+    "node_modules/cheerio-select": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
+      "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-select": "^5.1.0",
+        "css-what": "^6.1.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/codepage": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.15.0.tgz",
+      "integrity": "sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -1274,6 +1637,101 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/dingbat-to-unicode": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dingbat-to-unicode/-/dingbat-to-unicode-1.0.1.tgz",
+      "integrity": "sha512-98l0sW87ZT58pU4i61wa2OHwxbiYSbuxsCBozaVnYX2iCnr3bLM3fIes1/ej7h1YdOKuKt/MLs706TVnALA65w==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/duck": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/duck/-/duck-0.1.12.tgz",
+      "integrity": "sha512-wkctla1O6VfP89gQ+J/yDesM0S7B7XLXjKGzXxMDVFg7uEn706niAtyYovKbyq1oT9YwDcly721/iUWoc8MVRg==",
+      "license": "BSD",
+      "dependencies": {
+        "underscore": "^1.13.1"
+      }
+    },
+    "node_modules/encoding-sniffer": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
+      "integrity": "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "^0.6.3",
+        "whatwg-encoding": "^3.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-module-lexer": {
@@ -1363,6 +1821,15 @@
         }
       }
     },
+    "node_modules/frac": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/frac/-/frac-1.1.2.tgz",
+      "integrity": "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -1391,12 +1858,105 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
+    "node_modules/htmlparser2": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
     "node_modules/js-tokens": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
       "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
+    },
+    "node_modules/lop": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/lop/-/lop-0.4.2.tgz",
+      "integrity": "sha512-RefILVDQ4DKoRZsJ4Pj22TxE3omDO47yFpkIBoDKzkqPRISs5U1cnAdg/5583YPkWPaLIYHOKRMQSvjFsO26cw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "duck": "^0.1.12",
+        "option": "~0.2.1",
+        "underscore": "^1.13.1"
+      }
     },
     "node_modules/loupe": {
       "version": "3.2.1",
@@ -1413,6 +1973,30 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mammoth": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/mammoth/-/mammoth-1.12.0.tgz",
+      "integrity": "sha512-cwnK1RIcRdDMi2HRx2EXGYlxqIEh0Oo3bLhorgnsVJi2UkbX1+jKxuBNR9PC5+JaX7EkmJxFPmo6mjLpqShI2w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@xmldom/xmldom": "^0.8.6",
+        "argparse": "~1.0.3",
+        "base64-js": "^1.5.1",
+        "bluebird": "~3.4.0",
+        "dingbat-to-unicode": "^1.0.1",
+        "jszip": "^3.7.1",
+        "lop": "^0.4.2",
+        "path-is-absolute": "^1.0.0",
+        "underscore": "^1.13.1",
+        "xmlbuilder": "^10.0.0"
+      },
+      "bin": {
+        "mammoth": "bin/mammoth"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/model-router": {
@@ -1445,6 +2029,88 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
+    "node_modules/option": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/option/-/option-0.2.4.tgz",
+      "integrity": "sha512-pkEqbDyl8ou5cpq+VsnQbe/WlEy5qS7xPzMS1U55OCG9KPvwFD46zDbxQIj3egJSFc3D+XhYOPUzz49zQAVy7A==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz",
+      "integrity": "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==",
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "^5.0.3",
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-parser-stream": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
+      "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
+      "license": "MIT",
+      "dependencies": {
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/pathe": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
@@ -1460,6 +2126,38 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14.16"
+      }
+    },
+    "node_modules/pdf-parse": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/pdf-parse/-/pdf-parse-2.4.5.tgz",
+      "integrity": "sha512-mHU89HGh7v+4u2ubfnevJ03lmPgQ5WU4CxAVmTSh/sxVTEDYd1er/dKS/A6vg77NX47KTEoihq8jZBLr8Cxuwg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@napi-rs/canvas": "0.1.80",
+        "pdfjs-dist": "5.4.296"
+      },
+      "bin": {
+        "pdf-parse": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.16.0 <21 || >=22.3.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/mehmet-kozan"
+      }
+    },
+    "node_modules/pdfjs-dist": {
+      "version": "5.4.296",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-5.4.296.tgz",
+      "integrity": "sha512-DlOzet0HO7OEnmUmB6wWGJrrdvbyJKftI1bhMitK7O2N8W2gc757yyYBbINy9IDafXAV9wmKr9t7xsTaNKRG5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20.16.0 || >=22.3.0"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas": "^0.1.80"
       }
     },
     "node_modules/pg": {
@@ -1655,6 +2353,27 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
@@ -1710,6 +2429,24 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "license": "MIT"
+    },
     "node_modules/siginfo": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
@@ -1736,6 +2473,24 @@
         "node": ">= 10.x"
       }
     },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/ssf": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
+      "integrity": "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "frac": "~1.1.2"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
@@ -1749,6 +2504,15 @@
       "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
     },
     "node_modules/strip-literal": {
       "version": "3.1.0",
@@ -1858,6 +2622,21 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/underscore": {
+      "version": "1.13.8",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
+      "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
+      "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
@@ -1868,6 +2647,12 @@
     "node_modules/upstash-memory": {
       "resolved": "packages/openclaw-upstash-plugin",
       "link": true
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "7.3.1",
@@ -2040,6 +2825,28 @@
         }
       }
     },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -2055,6 +2862,54 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/wmf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wmf/-/wmf-1.0.2.tgz",
+      "integrity": "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/word": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/word/-/word-0.3.0.tgz",
+      "integrity": "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/xlsx": {
+      "version": "0.18.5",
+      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.18.5.tgz",
+      "integrity": "sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "cfb": "~1.2.1",
+        "codepage": "~1.15.0",
+        "crc-32": "~1.2.1",
+        "ssf": "~0.11.2",
+        "wmf": "~1.0.1",
+        "word": "~0.3.0"
+      },
+      "bin": {
+        "xlsx": "bin/xlsx.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-10.1.1.tgz",
+      "integrity": "sha512-OyzrcFLL/nb6fMGHbiRDuPup9ljBycsdCypwuyg5AAHvyWzGfChJpCXMG88AGTIMFhGZ9RccFN1e6lhg3hkwKg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/xtend": {
@@ -2121,13 +2976,19 @@
       "dependencies": {
         "@easy-flow/pgvector-client": "*",
         "@easy-flow/pinecone-client": "*",
-        "picomatch": "^4.0.3"
+        "cheerio": "^1.2.0",
+        "jszip": "^3.10.1",
+        "mammoth": "^1.12.0",
+        "pdf-parse": "^2.4.5",
+        "picomatch": "^4.0.3",
+        "xlsx": "^0.18.5"
       },
       "bin": {
         "easy-flow": "dist/cli.js"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
+        "@types/pdf-parse": "^1.1.5",
         "@types/picomatch": "^4.0.2",
         "typescript": "^5.7.0",
         "vitest": "^3.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1245,16 +1245,6 @@
         "undici-types": "~6.21.0"
       }
     },
-    "node_modules/@types/pdf-parse": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@types/pdf-parse/-/pdf-parse-1.1.5.tgz",
-      "integrity": "sha512-kBfrSXsloMnUJOKi25s3+hRmkycHfLK6A09eRGqF/N8BkQoPUmaCr+q8Cli5FnfohEz/rsv82zAiPz/LXtOGhA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/pg": {
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.20.0.tgz",
@@ -2988,7 +2978,6 @@
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
-        "@types/pdf-parse": "^1.1.5",
         "@types/picomatch": "^4.0.2",
         "typescript": "^5.7.0",
         "vitest": "^3.0.0"

--- a/packages/migrate-memory/package.json
+++ b/packages/migrate-memory/package.json
@@ -26,7 +26,6 @@
   },
   "devDependencies": {
     "@types/node": "^22.0.0",
-    "@types/pdf-parse": "^1.1.5",
     "@types/picomatch": "^4.0.2",
     "typescript": "^5.7.0",
     "vitest": "^3.0.0"

--- a/packages/migrate-memory/package.json
+++ b/packages/migrate-memory/package.json
@@ -17,10 +17,16 @@
   "dependencies": {
     "@easy-flow/pgvector-client": "*",
     "@easy-flow/pinecone-client": "*",
-    "picomatch": "^4.0.3"
+    "cheerio": "^1.2.0",
+    "jszip": "^3.10.1",
+    "mammoth": "^1.12.0",
+    "pdf-parse": "^2.4.5",
+    "picomatch": "^4.0.3",
+    "xlsx": "^0.18.5"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",
+    "@types/pdf-parse": "^1.1.5",
     "@types/picomatch": "^4.0.2",
     "typescript": "^5.7.0",
     "vitest": "^3.0.0"

--- a/packages/migrate-memory/src/cli.ts
+++ b/packages/migrate-memory/src/cli.ts
@@ -496,6 +496,7 @@ Options:
   --namespace <name>    Agent namespace (e.g. "agent:mell") [required]
   --category <name>     Document category for filtering (e.g. "manual", "faq", "policy")
   --dry-run             Show what would be ingested without writing to DB
+  --force               Skip secret detection preflight check
   --help                Show this help message
 
 Environment Variables:

--- a/packages/migrate-memory/src/cli.ts
+++ b/packages/migrate-memory/src/cli.ts
@@ -519,6 +519,7 @@ async function runIngestDocument(args: string[]): Promise<void> {
       namespace: { type: "string" },
       category: { type: "string" },
       "dry-run": { type: "boolean", default: false },
+      force: { type: "boolean", default: false },
       help: { type: "boolean", default: false },
     },
     strict: true,
@@ -545,6 +546,7 @@ async function runIngestDocument(args: string[]): Promise<void> {
   }
 
   const dryRun = values["dry-run"] as boolean;
+  const force = values.force as boolean;
   const category = values.category as string | undefined;
 
   const pgvectorClient = createClient("pgvector", dryRun);
@@ -555,6 +557,7 @@ async function runIngestDocument(args: string[]): Promise<void> {
     pgvectorClient,
     category,
     dryRun,
+    force,
   });
 
   if (errors.length > 0) {

--- a/packages/migrate-memory/src/cli.ts
+++ b/packages/migrate-memory/src/cli.ts
@@ -476,12 +476,21 @@ async function runPineconeToPgvector(args: string[]): Promise<void> {
 }
 
 function printIngestDocumentUsage(): void {
-  console.log(`Usage: easy-flow ingest-document [options] <file...>
+  console.log(`Usage: easy-flow ingest-document [options] <source...>
 
-Ingest text/markdown documents into pgvector for RAG retrieval.
+Ingest documents into pgvector for RAG retrieval.
 
 Arguments:
-  <file...>             One or more file paths to ingest (.txt, .md, .markdown, .text)
+  <source...>           One or more file paths or URLs to ingest
+
+Supported formats:
+  Text/Markdown         .txt, .md, .markdown, .text
+  Office                .docx, .xlsx, .pptx
+  PDF                   .pdf
+  URL                   http:// or https:// (HTML pages)
+  Google Docs           https://docs.google.com/document/d/...
+  Google Sheets         https://docs.google.com/spreadsheets/d/...
+  Google Slides         https://docs.google.com/presentation/d/...
 
 Options:
   --namespace <name>    Agent namespace (e.g. "agent:mell") [required]
@@ -495,7 +504,10 @@ Environment Variables:
 
 Examples:
   easy-flow ingest-document --namespace agent:mell manual.md
-  easy-flow ingest-document --namespace agent:mell --category faq faq.txt guide.md
+  easy-flow ingest-document --namespace agent:mell --category faq faq.txt guide.docx
+  easy-flow ingest-document --namespace agent:mell report.pdf slides.pptx data.xlsx
+  easy-flow ingest-document --namespace agent:mell https://example.com/page
+  easy-flow ingest-document --namespace agent:mell https://docs.google.com/document/d/xxx
   easy-flow ingest-document --namespace agent:mell --dry-run *.md`);
 }
 

--- a/packages/migrate-memory/src/cli.ts
+++ b/packages/migrate-memory/src/cli.ts
@@ -5,6 +5,7 @@ import { bulkMigrate } from "./bulk-migrator.js";
 import { bulkUpdate } from "./bulk-updater.js";
 import { type Backend, createClient } from "./create-client.js";
 import { MemoryDeleter } from "./deleter.js";
+import { ingestDocuments } from "./ingest-document.js";
 import { AgentsMigrator } from "./migrate-agents.js";
 import { Migrator } from "./migrator.js";
 import { migrateConversationMemory, pineconeHeaders } from "./pinecone-to-pgvector.js";
@@ -16,6 +17,7 @@ function printUsage(): void {
 Commands:
   migrate-memory        Migrate markdown files to vector DB
   agents                Migrate AGENTS.md to vector DB (section-based chunking)
+  ingest-document       Ingest text/markdown documents into vector DB
   memory-delete         Delete memory from vector DB
   pinecone-to-pgvector  Migrate conversation memory from Pinecone to pgvector
   bulk-migrate          Bulk migrate all EasyFlow instances
@@ -473,6 +475,77 @@ async function runPineconeToPgvector(args: string[]): Promise<void> {
   }
 }
 
+function printIngestDocumentUsage(): void {
+  console.log(`Usage: easy-flow ingest-document [options] <file...>
+
+Ingest text/markdown documents into pgvector for RAG retrieval.
+
+Arguments:
+  <file...>             One or more file paths to ingest (.txt, .md, .markdown, .text)
+
+Options:
+  --namespace <name>    Agent namespace (e.g. "agent:mell") [required]
+  --category <name>     Document category for filtering (e.g. "manual", "faq", "policy")
+  --dry-run             Show what would be ingested without writing to DB
+  --help                Show this help message
+
+Environment Variables:
+  PGVECTOR_DATABASE_URL  Required
+  GEMINI_API_KEY         Required
+
+Examples:
+  easy-flow ingest-document --namespace agent:mell manual.md
+  easy-flow ingest-document --namespace agent:mell --category faq faq.txt guide.md
+  easy-flow ingest-document --namespace agent:mell --dry-run *.md`);
+}
+
+async function runIngestDocument(args: string[]): Promise<void> {
+  const { values, positionals } = parseArgs({
+    args,
+    allowPositionals: true,
+    options: {
+      namespace: { type: "string" },
+      category: { type: "string" },
+      "dry-run": { type: "boolean", default: false },
+      help: { type: "boolean", default: false },
+    },
+    strict: true,
+  });
+
+  if (values.help) {
+    printIngestDocumentUsage();
+    process.exit(0);
+  }
+
+  const namespace = values.namespace as string | undefined;
+  if (!namespace) {
+    console.error("Error: --namespace is required (e.g. --namespace agent:mell)");
+    process.exit(1);
+  }
+
+  // Extract agentId from namespace (e.g. "agent:mell" → "mell")
+  const agentId = namespace.startsWith("agent:") ? namespace.slice(6) : namespace;
+
+  const filePaths = positionals;
+  if (filePaths.length === 0) {
+    console.error("Error: At least one file path is required");
+    process.exit(1);
+  }
+
+  const dryRun = values["dry-run"] as boolean;
+  const category = values.category as string | undefined;
+
+  const pgvectorClient = createClient("pgvector", dryRun);
+
+  await ingestDocuments({
+    filePaths,
+    agentId,
+    pgvectorClient,
+    category,
+    dryRun,
+  });
+}
+
 async function main(): Promise<void> {
   const subcommand = process.argv[2];
 
@@ -485,6 +558,8 @@ async function main(): Promise<void> {
     await runMigrate(process.argv.slice(3));
   } else if (subcommand === "agents") {
     await runAgents(process.argv.slice(3));
+  } else if (subcommand === "ingest-document") {
+    await runIngestDocument(process.argv.slice(3));
   } else if (subcommand === "memory-delete") {
     await runDelete(process.argv.slice(3));
   } else if (subcommand === "pinecone-to-pgvector") {

--- a/packages/migrate-memory/src/cli.ts
+++ b/packages/migrate-memory/src/cli.ts
@@ -549,13 +549,17 @@ async function runIngestDocument(args: string[]): Promise<void> {
 
   const pgvectorClient = createClient("pgvector", dryRun);
 
-  await ingestDocuments({
+  const { errors } = await ingestDocuments({
     filePaths,
     agentId,
     pgvectorClient,
     category,
     dryRun,
   });
+
+  if (errors.length > 0) {
+    process.exit(1);
+  }
 }
 
 async function main(): Promise<void> {

--- a/packages/migrate-memory/src/ingest-document.test.ts
+++ b/packages/migrate-memory/src/ingest-document.test.ts
@@ -103,7 +103,8 @@ describe("ingestDocument", () => {
     expect(result.sourceFile).toBe(`doc:${filePath}`);
     expect(result.agentId).toBe("test-agent");
     expect(client.deleteBySource).toHaveBeenCalledWith("test-agent", `doc:${filePath}`);
-    expect(client.upsert).toHaveBeenCalledTimes(1);
+    // 2 upsert calls: validate + final (safe replace pattern)
+    expect(client.upsert).toHaveBeenCalledTimes(2);
 
     const chunks = client.upsert.mock.calls[0][0];
     expect(chunks[0].metadata.sourceType).toBe("document");
@@ -158,7 +159,7 @@ describe("ingestDocument", () => {
     expect(client.deleteBySource).not.toHaveBeenCalled();
   });
 
-  it("should call deleteBySource before upsert to remove stale chunks", async () => {
+  it("should validate upsert before deleting old chunks (safe replace)", async () => {
     const filePath = join(tmpDir, "doc.txt");
     await writeFile(filePath, "updated content");
 
@@ -169,12 +170,49 @@ describe("ingestDocument", () => {
       pgvectorClient: client,
     });
 
-    // deleteBySource must be called before upsert
+    // Safe replace: upsert (validate) → delete → upsert (final)
+    expect(client.upsert).toHaveBeenCalledTimes(2);
     expect(client.deleteBySource).toHaveBeenCalledTimes(1);
-    expect(client.upsert).toHaveBeenCalledTimes(1);
+    const firstUpsertOrder = client.upsert.mock.invocationCallOrder[0];
     const deleteOrder = client.deleteBySource.mock.invocationCallOrder[0];
-    const upsertOrder = client.upsert.mock.invocationCallOrder[0];
-    expect(deleteOrder).toBeLessThan(upsertOrder);
+    const secondUpsertOrder = client.upsert.mock.invocationCallOrder[1];
+    expect(firstUpsertOrder).toBeLessThan(deleteOrder);
+    expect(deleteOrder).toBeLessThan(secondUpsertOrder);
+  });
+
+  it("should preserve existing data when upsert fails", async () => {
+    const filePath = join(tmpDir, "doc.txt");
+    await writeFile(filePath, "content");
+
+    const client = createMockClient();
+    client.upsert.mockRejectedValueOnce(new Error("Embedding API error"));
+
+    await expect(
+      ingestDocument({ filePath, agentId: "test-agent", pgvectorClient: client }),
+    ).rejects.toThrow("Upsert validation failed");
+
+    // deleteBySource should NOT have been called
+    expect(client.deleteBySource).not.toHaveBeenCalled();
+  });
+
+  it("should reject documents containing secrets unless force is set", async () => {
+    const filePath = join(tmpDir, "secrets.txt");
+    await writeFile(filePath, "password: my_secret_pw123\nother content");
+
+    const client = createMockClient();
+
+    await expect(
+      ingestDocument({ filePath, agentId: "test-agent", pgvectorClient: client }),
+    ).rejects.toThrow("Secret detected");
+
+    // With force, should succeed
+    const result = await ingestDocument({
+      filePath,
+      agentId: "test-agent",
+      pgvectorClient: client,
+      force: true,
+    });
+    expect(result.totalChunks).toBeGreaterThan(0);
   });
 
   it("should use absolute path as sourceFile to avoid same-name collisions", async () => {
@@ -248,7 +286,7 @@ describe("ingestDocument", () => {
     });
 
     expect(result.totalChunks).toBe(3); // ceil(2500/900) = 3
-    expect(client.upsert).toHaveBeenCalledTimes(1);
+    expect(client.upsert).toHaveBeenCalledTimes(2); // validate + final
     expect(client.upsert.mock.calls[0][0]).toHaveLength(3);
   });
 });
@@ -281,7 +319,7 @@ describe("ingestDocuments", () => {
     expect(errors).toHaveLength(0);
     expect(results[0].totalChunks).toBe(1);
     expect(results[1].totalChunks).toBe(1);
-    expect(client.upsert).toHaveBeenCalledTimes(2);
+    expect(client.upsert).toHaveBeenCalledTimes(4); // 2 per file (validate + final)
   });
 
   it("should call ensureIndex in non-dry-run mode", async () => {
@@ -337,7 +375,7 @@ describe("ingestDocuments", () => {
 
     expect(errors).toHaveLength(1);
     expect(errors[0].filePath).toBe(file1);
-    expect(errors[0].error.message).toBe("DB connection lost");
+    expect(errors[0].error.message).toContain("DB connection lost");
     expect(results).toHaveLength(1);
     expect(results[0].filePath).toBe(file2);
   });

--- a/packages/migrate-memory/src/ingest-document.test.ts
+++ b/packages/migrate-memory/src/ingest-document.test.ts
@@ -194,7 +194,7 @@ describe("ingestDocument", () => {
     expect(result2.sourceFile).toContain("sub2/manual.txt");
   });
 
-  it("should skip empty files", async () => {
+  it("should delete existing chunks and skip upsert for empty files", async () => {
     const filePath = join(tmpDir, "empty.txt");
     await writeFile(filePath, "   ");
 
@@ -207,6 +207,22 @@ describe("ingestDocument", () => {
 
     expect(result.totalChunks).toBe(0);
     expect(client.upsert).not.toHaveBeenCalled();
+    expect(client.deleteBySource).toHaveBeenCalledTimes(1);
+  });
+
+  it("should not delete in dry-run mode for empty files", async () => {
+    const filePath = join(tmpDir, "empty.txt");
+    await writeFile(filePath, "   ");
+
+    const client = createMockClient();
+    await ingestDocument({
+      filePath,
+      agentId: "test-agent",
+      pgvectorClient: client,
+      dryRun: true,
+    });
+
+    expect(client.deleteBySource).not.toHaveBeenCalled();
   });
 
   it("should create multiple chunks for large documents", async () => {

--- a/packages/migrate-memory/src/ingest-document.test.ts
+++ b/packages/migrate-memory/src/ingest-document.test.ts
@@ -28,10 +28,20 @@ describe("isSupportedExtension", () => {
     expect(isSupportedExtension("file.text")).toBe(true);
   });
 
+  it("should accept office and PDF files", () => {
+    expect(isSupportedExtension("file.pdf")).toBe(true);
+    expect(isSupportedExtension("file.docx")).toBe(true);
+    expect(isSupportedExtension("file.xlsx")).toBe(true);
+    expect(isSupportedExtension("file.pptx")).toBe(true);
+  });
+
+  it("should accept URLs", () => {
+    expect(isSupportedExtension("https://example.com")).toBe(true);
+  });
+
   it("should reject unsupported extensions", () => {
-    expect(isSupportedExtension("file.pdf")).toBe(false);
-    expect(isSupportedExtension("file.docx")).toBe(false);
     expect(isSupportedExtension("file.csv")).toBe(false);
+    expect(isSupportedExtension("file.jpg")).toBe(false);
   });
 });
 
@@ -61,9 +71,9 @@ describe("extractText", () => {
   });
 
   it("should throw for unsupported file type", async () => {
-    const filePath = join(tmpDir, "test.pdf");
-    await writeFile(filePath, "data");
-    await expect(extractText(filePath)).rejects.toThrow("Unsupported file type: .pdf");
+    const filePath = join(tmpDir, "test.csv");
+    await writeFile(filePath, "a,b,c");
+    await expect(extractText(filePath)).rejects.toThrow("Unsupported file type: .csv");
   });
 });
 

--- a/packages/migrate-memory/src/ingest-document.test.ts
+++ b/packages/migrate-memory/src/ingest-document.test.ts
@@ -90,8 +90,9 @@ describe("ingestDocument", () => {
     });
 
     expect(result.totalChunks).toBe(1);
-    expect(result.sourceFile).toBe("doc:manual.txt");
+    expect(result.sourceFile).toBe(`doc:${filePath}`);
     expect(result.agentId).toBe("test-agent");
+    expect(client.deleteBySource).toHaveBeenCalledWith("test-agent", `doc:${filePath}`);
     expect(client.upsert).toHaveBeenCalledTimes(1);
 
     const chunks = client.upsert.mock.calls[0][0];
@@ -144,6 +145,53 @@ describe("ingestDocument", () => {
 
     expect(result.totalChunks).toBe(1);
     expect(client.upsert).not.toHaveBeenCalled();
+    expect(client.deleteBySource).not.toHaveBeenCalled();
+  });
+
+  it("should call deleteBySource before upsert to remove stale chunks", async () => {
+    const filePath = join(tmpDir, "doc.txt");
+    await writeFile(filePath, "updated content");
+
+    const client = createMockClient();
+    await ingestDocument({
+      filePath,
+      agentId: "test-agent",
+      pgvectorClient: client,
+    });
+
+    // deleteBySource must be called before upsert
+    expect(client.deleteBySource).toHaveBeenCalledTimes(1);
+    expect(client.upsert).toHaveBeenCalledTimes(1);
+    const deleteOrder = client.deleteBySource.mock.invocationCallOrder[0];
+    const upsertOrder = client.upsert.mock.invocationCallOrder[0];
+    expect(deleteOrder).toBeLessThan(upsertOrder);
+  });
+
+  it("should use absolute path as sourceFile to avoid same-name collisions", async () => {
+    const file1 = join(tmpDir, "sub1", "manual.txt");
+    const file2 = join(tmpDir, "sub2", "manual.txt");
+    const { mkdir } = await import("node:fs/promises");
+    await mkdir(join(tmpDir, "sub1"), { recursive: true });
+    await mkdir(join(tmpDir, "sub2"), { recursive: true });
+    await writeFile(file1, "content from sub1");
+    await writeFile(file2, "content from sub2");
+
+    const client = createMockClient();
+    const result1 = await ingestDocument({
+      filePath: file1,
+      agentId: "test-agent",
+      pgvectorClient: client,
+    });
+    const result2 = await ingestDocument({
+      filePath: file2,
+      agentId: "test-agent",
+      pgvectorClient: client,
+    });
+
+    // Different absolute paths produce different sourceFile values
+    expect(result1.sourceFile).not.toBe(result2.sourceFile);
+    expect(result1.sourceFile).toContain("sub1/manual.txt");
+    expect(result2.sourceFile).toContain("sub2/manual.txt");
   });
 
   it("should skip empty files", async () => {

--- a/packages/migrate-memory/src/ingest-document.test.ts
+++ b/packages/migrate-memory/src/ingest-document.test.ts
@@ -159,7 +159,7 @@ describe("ingestDocument", () => {
     expect(client.deleteBySource).not.toHaveBeenCalled();
   });
 
-  it("should validate upsert before deleting old chunks (safe replace)", async () => {
+  it("should use staging pattern for safe replace", async () => {
     const filePath = join(tmpDir, "doc.txt");
     await writeFile(filePath, "updated content");
 
@@ -170,17 +170,25 @@ describe("ingestDocument", () => {
       pgvectorClient: client,
     });
 
-    // Safe replace: upsert (validate) → delete → upsert (final)
+    // Safe replace: staging upsert → delete old → production upsert → delete staging
     expect(client.upsert).toHaveBeenCalledTimes(2);
-    expect(client.deleteBySource).toHaveBeenCalledTimes(1);
+    expect(client.deleteBySource).toHaveBeenCalledTimes(2);
+
+    // First upsert uses staging sourceFile
+    const stagingChunks = client.upsert.mock.calls[0][0];
+    expect(stagingChunks[0].metadata.sourceFile).toContain(":staging:");
+
+    // Second upsert uses production sourceFile
+    const productionChunks = client.upsert.mock.calls[1][0];
+    expect(productionChunks[0].metadata.sourceFile).not.toContain(":staging:");
+
+    // Verify ordering: staging upsert before any delete
     const firstUpsertOrder = client.upsert.mock.invocationCallOrder[0];
-    const deleteOrder = client.deleteBySource.mock.invocationCallOrder[0];
-    const secondUpsertOrder = client.upsert.mock.invocationCallOrder[1];
-    expect(firstUpsertOrder).toBeLessThan(deleteOrder);
-    expect(deleteOrder).toBeLessThan(secondUpsertOrder);
+    const firstDeleteOrder = client.deleteBySource.mock.invocationCallOrder[0];
+    expect(firstUpsertOrder).toBeLessThan(firstDeleteOrder);
   });
 
-  it("should preserve existing data when upsert fails", async () => {
+  it("should preserve existing data when staging upsert fails", async () => {
     const filePath = join(tmpDir, "doc.txt");
     await writeFile(filePath, "content");
 
@@ -189,9 +197,9 @@ describe("ingestDocument", () => {
 
     await expect(
       ingestDocument({ filePath, agentId: "test-agent", pgvectorClient: client }),
-    ).rejects.toThrow("Upsert validation failed");
+    ).rejects.toThrow("Upsert failed");
 
-    // deleteBySource should NOT have been called
+    // deleteBySource should NOT have been called — existing data preserved
     expect(client.deleteBySource).not.toHaveBeenCalled();
   });
 

--- a/packages/migrate-memory/src/ingest-document.test.ts
+++ b/packages/migrate-memory/src/ingest-document.test.ts
@@ -271,13 +271,14 @@ describe("ingestDocuments", () => {
     await writeFile(file2, "# Document two\n\nContent here");
 
     const client = createMockClient();
-    const results = await ingestDocuments({
+    const { results, errors } = await ingestDocuments({
       filePaths: [file1, file2],
       agentId: "test-agent",
       pgvectorClient: client,
     });
 
     expect(results).toHaveLength(2);
+    expect(errors).toHaveLength(0);
     expect(results[0].totalChunks).toBe(1);
     expect(results[1].totalChunks).toBe(1);
     expect(client.upsert).toHaveBeenCalledTimes(2);
@@ -311,5 +312,33 @@ describe("ingestDocuments", () => {
     });
 
     expect(client.ensureIndex).not.toHaveBeenCalled();
+  });
+
+  it("should continue processing remaining files when one fails", async () => {
+    const file1 = join(tmpDir, "doc1.txt");
+    const file2 = join(tmpDir, "doc2.txt");
+    await writeFile(file1, "First document");
+    await writeFile(file2, "Second document");
+
+    const client = createMockClient();
+    // Make upsert fail on first call, succeed on second
+    let callCount = 0;
+    client.upsert.mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) throw new Error("DB connection lost");
+      return Promise.resolve();
+    });
+
+    const { results, errors } = await ingestDocuments({
+      filePaths: [file1, file2],
+      agentId: "test-agent",
+      pgvectorClient: client,
+    });
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0].filePath).toBe(file1);
+    expect(errors[0].error.message).toBe("DB connection lost");
+    expect(results).toHaveLength(1);
+    expect(results[0].filePath).toBe(file2);
   });
 });

--- a/packages/migrate-memory/src/ingest-document.test.ts
+++ b/packages/migrate-memory/src/ingest-document.test.ts
@@ -1,0 +1,241 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  extractText,
+  ingestDocument,
+  ingestDocuments,
+  isSupportedExtension,
+} from "./ingest-document.js";
+
+function createMockClient() {
+  return {
+    upsert: vi.fn<(chunks: unknown[]) => Promise<void>>().mockResolvedValue(undefined),
+    query: vi.fn().mockResolvedValue([]),
+    delete: vi.fn().mockResolvedValue(undefined),
+    deleteBySource: vi.fn().mockResolvedValue(undefined),
+    deleteNamespace: vi.fn().mockResolvedValue(undefined),
+    ensureIndex: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+describe("isSupportedExtension", () => {
+  it("should accept .txt, .md, .markdown, .text", () => {
+    expect(isSupportedExtension("file.txt")).toBe(true);
+    expect(isSupportedExtension("file.md")).toBe(true);
+    expect(isSupportedExtension("file.markdown")).toBe(true);
+    expect(isSupportedExtension("file.text")).toBe(true);
+  });
+
+  it("should reject unsupported extensions", () => {
+    expect(isSupportedExtension("file.pdf")).toBe(false);
+    expect(isSupportedExtension("file.docx")).toBe(false);
+    expect(isSupportedExtension("file.csv")).toBe(false);
+  });
+});
+
+describe("extractText", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), "ingest-test-"));
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true });
+  });
+
+  it("should read text file content", async () => {
+    const filePath = join(tmpDir, "test.txt");
+    await writeFile(filePath, "hello world");
+    const text = await extractText(filePath);
+    expect(text).toBe("hello world");
+  });
+
+  it("should read markdown file content", async () => {
+    const filePath = join(tmpDir, "test.md");
+    await writeFile(filePath, "# Title\n\nContent");
+    const text = await extractText(filePath);
+    expect(text).toBe("# Title\n\nContent");
+  });
+
+  it("should throw for unsupported file type", async () => {
+    const filePath = join(tmpDir, "test.pdf");
+    await writeFile(filePath, "data");
+    await expect(extractText(filePath)).rejects.toThrow("Unsupported file type: .pdf");
+  });
+});
+
+describe("ingestDocument", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), "ingest-test-"));
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true });
+  });
+
+  it("should chunk and upsert a text file", async () => {
+    const filePath = join(tmpDir, "manual.txt");
+    await writeFile(filePath, "This is a test document with some content.");
+
+    const client = createMockClient();
+    const result = await ingestDocument({
+      filePath,
+      agentId: "test-agent",
+      pgvectorClient: client,
+    });
+
+    expect(result.totalChunks).toBe(1);
+    expect(result.sourceFile).toBe("doc:manual.txt");
+    expect(result.agentId).toBe("test-agent");
+    expect(client.upsert).toHaveBeenCalledTimes(1);
+
+    const chunks = client.upsert.mock.calls[0][0];
+    expect(chunks[0].metadata.sourceType).toBe("document");
+    expect(chunks[0].metadata.agentId).toBe("test-agent");
+  });
+
+  it("should set category when provided", async () => {
+    const filePath = join(tmpDir, "faq.md");
+    await writeFile(filePath, "# FAQ\n\nQ: What? A: This.");
+
+    const client = createMockClient();
+    await ingestDocument({
+      filePath,
+      agentId: "test-agent",
+      pgvectorClient: client,
+      category: "faq",
+    });
+
+    const chunks = client.upsert.mock.calls[0][0];
+    expect(chunks[0].metadata.category).toBe("faq");
+  });
+
+  it("should use custom sourceFile when provided", async () => {
+    const filePath = join(tmpDir, "doc.txt");
+    await writeFile(filePath, "content");
+
+    const client = createMockClient();
+    const result = await ingestDocument({
+      filePath,
+      agentId: "test-agent",
+      pgvectorClient: client,
+      sourceFile: "doc:custom-name",
+    });
+
+    expect(result.sourceFile).toBe("doc:custom-name");
+  });
+
+  it("should not upsert in dry-run mode", async () => {
+    const filePath = join(tmpDir, "doc.txt");
+    await writeFile(filePath, "content");
+
+    const client = createMockClient();
+    const result = await ingestDocument({
+      filePath,
+      agentId: "test-agent",
+      pgvectorClient: client,
+      dryRun: true,
+    });
+
+    expect(result.totalChunks).toBe(1);
+    expect(client.upsert).not.toHaveBeenCalled();
+  });
+
+  it("should skip empty files", async () => {
+    const filePath = join(tmpDir, "empty.txt");
+    await writeFile(filePath, "   ");
+
+    const client = createMockClient();
+    const result = await ingestDocument({
+      filePath,
+      agentId: "test-agent",
+      pgvectorClient: client,
+    });
+
+    expect(result.totalChunks).toBe(0);
+    expect(client.upsert).not.toHaveBeenCalled();
+  });
+
+  it("should create multiple chunks for large documents", async () => {
+    const filePath = join(tmpDir, "large.txt");
+    // TextChunker defaults: chunkSize=1000, overlapSize=100, step=900
+    await writeFile(filePath, "x".repeat(2500));
+
+    const client = createMockClient();
+    const result = await ingestDocument({
+      filePath,
+      agentId: "test-agent",
+      pgvectorClient: client,
+    });
+
+    expect(result.totalChunks).toBe(3); // ceil(2500/900) = 3
+    expect(client.upsert).toHaveBeenCalledTimes(1);
+    expect(client.upsert.mock.calls[0][0]).toHaveLength(3);
+  });
+});
+
+describe("ingestDocuments", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), "ingest-test-"));
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true });
+  });
+
+  it("should process multiple files", async () => {
+    const file1 = join(tmpDir, "doc1.txt");
+    const file2 = join(tmpDir, "doc2.md");
+    await writeFile(file1, "Document one content");
+    await writeFile(file2, "# Document two\n\nContent here");
+
+    const client = createMockClient();
+    const results = await ingestDocuments({
+      filePaths: [file1, file2],
+      agentId: "test-agent",
+      pgvectorClient: client,
+    });
+
+    expect(results).toHaveLength(2);
+    expect(results[0].totalChunks).toBe(1);
+    expect(results[1].totalChunks).toBe(1);
+    expect(client.upsert).toHaveBeenCalledTimes(2);
+  });
+
+  it("should call ensureIndex in non-dry-run mode", async () => {
+    const file1 = join(tmpDir, "doc.txt");
+    await writeFile(file1, "content");
+
+    const client = createMockClient();
+    await ingestDocuments({
+      filePaths: [file1],
+      agentId: "test-agent",
+      pgvectorClient: client,
+      dryRun: false,
+    });
+
+    expect(client.ensureIndex).toHaveBeenCalledTimes(1);
+  });
+
+  it("should not call ensureIndex in dry-run mode", async () => {
+    const file1 = join(tmpDir, "doc.txt");
+    await writeFile(file1, "content");
+
+    const client = createMockClient();
+    await ingestDocuments({
+      filePaths: [file1],
+      agentId: "test-agent",
+      pgvectorClient: client,
+      dryRun: true,
+    });
+
+    expect(client.ensureIndex).not.toHaveBeenCalled();
+  });
+});

--- a/packages/migrate-memory/src/ingest-document.ts
+++ b/packages/migrate-memory/src/ingest-document.ts
@@ -59,7 +59,11 @@ export async function ingestDocument(opts: IngestDocumentOptions): Promise<Inges
   console.log(`   Text length: ${text.length} chars`);
 
   if (text.trim().length === 0) {
-    console.log("   ⚠️  Empty file, skipping");
+    console.log("   ⚠️  Empty file");
+    if (!dryRun) {
+      await pgvectorClient.deleteBySource(agentId, sourceFile);
+      console.log("   🗑️  Deleted existing chunks for this source");
+    }
     return { filePath, sourceFile, agentId, totalChunks: 0, category };
   }
 

--- a/packages/migrate-memory/src/ingest-document.ts
+++ b/packages/migrate-memory/src/ingest-document.ts
@@ -82,10 +82,15 @@ export async function ingestDocument(opts: IngestDocumentOptions): Promise<Inges
   return { filePath, sourceFile, agentId, totalChunks: chunks.length, category };
 }
 
+export interface IngestDocumentsResult {
+  results: IngestDocumentResult[];
+  errors: { filePath: string; error: Error }[];
+}
+
 export async function ingestDocuments(
-  opts: Omit<IngestDocumentOptions, "filePath"> & { filePaths: string[] },
-): Promise<IngestDocumentResult[]> {
-  const { filePaths, agentId, pgvectorClient, category, sourceFile, dryRun } = opts;
+  opts: Omit<IngestDocumentOptions, "filePath" | "sourceFile"> & { filePaths: string[] },
+): Promise<IngestDocumentsResult> {
+  const { filePaths, agentId, pgvectorClient, category, dryRun } = opts;
 
   console.log(`\n${"=".repeat(60)}`);
   console.log("ドキュメント事前登録");
@@ -99,24 +104,30 @@ export async function ingestDocuments(
   }
 
   const results: IngestDocumentResult[] = [];
+  const errors: { filePath: string; error: Error }[] = [];
 
   for (const filePath of filePaths) {
-    const result = await ingestDocument({
-      filePath,
-      agentId,
-      pgvectorClient,
-      category,
-      sourceFile,
-      dryRun,
-    });
-    results.push(result);
+    try {
+      const result = await ingestDocument({
+        filePath,
+        agentId,
+        pgvectorClient,
+        category,
+        dryRun,
+      });
+      results.push(result);
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      console.error(`   ❌ Failed: ${filePath} — ${error.message}`);
+      errors.push({ filePath, error });
+    }
   }
 
   // Summary
   const totalChunks = results.reduce((sum, r) => sum + r.totalChunks, 0);
   console.log(`\n${"=".repeat(60)}`);
-  console.log(`完了: ${results.length} sources, ${totalChunks} chunks`);
+  console.log(`完了: ${results.length} 成功, ${errors.length} 失敗, ${totalChunks} chunks`);
   console.log(`${"=".repeat(60)}`);
 
-  return results;
+  return { results, errors };
 }

--- a/packages/migrate-memory/src/ingest-document.ts
+++ b/packages/migrate-memory/src/ingest-document.ts
@@ -10,6 +10,7 @@
 import { resolve } from "node:path";
 import type { IPineconeClient } from "@easy-flow/pinecone-client";
 import { TextChunker } from "@easy-flow/pinecone-client";
+import { checkTextForSecrets } from "./preflight.js";
 import { extractText, isUrl } from "./text-extractor.js";
 
 export { extractText, isSupportedInput as isSupportedExtension } from "./text-extractor.js";
@@ -24,6 +25,8 @@ export interface IngestDocumentOptions {
   /** Custom source file identifier. Defaults to absolute path or URL. */
   sourceFile?: string;
   dryRun?: boolean;
+  /** Skip secret detection preflight check */
+  force?: boolean;
 }
 
 export interface IngestDocumentResult {
@@ -40,7 +43,7 @@ function defaultSourceFile(input: string): string {
 }
 
 export async function ingestDocument(opts: IngestDocumentOptions): Promise<IngestDocumentResult> {
-  const { filePath, agentId, pgvectorClient, category, dryRun } = opts;
+  const { filePath, agentId, pgvectorClient, category, dryRun, force } = opts;
   const sourceFile = opts.sourceFile ?? defaultSourceFile(filePath);
 
   console.log(`\n📄 Ingesting: ${filePath}`);
@@ -50,6 +53,16 @@ export async function ingestDocument(opts: IngestDocumentOptions): Promise<Inges
 
   const text = await extractText(filePath);
   console.log(`   Text length: ${text.length} chars`);
+
+  // Preflight: detect secrets in extracted text
+  if (!force) {
+    const secrets = checkTextForSecrets(text);
+    if (secrets.length > 0) {
+      throw new Error(
+        `Secret detected in ${filePath}: ${secrets.join(", ")}. Use --force to skip this check.`,
+      );
+    }
+  }
 
   if (text.trim().length === 0) {
     console.log("   ⚠️  Empty content");
@@ -74,6 +87,23 @@ export async function ingestDocument(opts: IngestDocumentOptions): Promise<Inges
   if (dryRun) {
     console.log("   [DRY RUN] Would delete existing + upsert chunks");
   } else {
+    // Safe atomic-like replace:
+    // 1. Validate new chunks via upsert (embedding generation + DB write)
+    // 2. Delete all chunks for this source (old + newly inserted)
+    // 3. Re-insert validated chunks (no embedding re-generation, idempotent)
+    //
+    // If step 1 fails → existing data preserved, no deletion occurred
+    // If step 2 fails → duplicates exist but no data loss
+    // Step 3 uses already-validated chunks, so failure risk is minimal (DB-only)
+    try {
+      await pgvectorClient.upsert(chunks);
+    } catch (err) {
+      // Upsert failed (e.g. embedding API error) — do NOT delete existing data
+      throw new Error(
+        `Upsert validation failed for ${filePath}, existing data preserved: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+    // Upsert succeeded → safe to replace
     await pgvectorClient.deleteBySource(agentId, sourceFile);
     await pgvectorClient.upsert(chunks);
     console.log(`   ✅ Replaced with ${chunks.length} chunks`);
@@ -90,7 +120,7 @@ export interface IngestDocumentsResult {
 export async function ingestDocuments(
   opts: Omit<IngestDocumentOptions, "filePath" | "sourceFile"> & { filePaths: string[] },
 ): Promise<IngestDocumentsResult> {
-  const { filePaths, agentId, pgvectorClient, category, dryRun } = opts;
+  const { filePaths, agentId, pgvectorClient, category, dryRun, force } = opts;
 
   console.log(`\n${"=".repeat(60)}`);
   console.log("ドキュメント事前登録");
@@ -114,6 +144,7 @@ export async function ingestDocuments(
         pgvectorClient,
         category,
         dryRun,
+        force,
       });
       results.push(result);
     } catch (err) {

--- a/packages/migrate-memory/src/ingest-document.ts
+++ b/packages/migrate-memory/src/ingest-document.ts
@@ -1,0 +1,124 @@
+/**
+ * 任意ドキュメントを pgvector に事前登録する
+ *
+ * テキスト / Markdown ファイルを読み込み、チャンク分割 → pgvector upsert する。
+ * sourceType は "document" を使用し、category でドキュメント種別を区別する。
+ * 同一ファイルの再登録時は ON CONFLICT で上書き（冪等）。
+ */
+
+import { readFile } from "node:fs/promises";
+import { basename, extname } from "node:path";
+import type { IPineconeClient } from "@easy-flow/pinecone-client";
+import { TextChunker } from "@easy-flow/pinecone-client";
+
+export interface IngestDocumentOptions {
+  filePath: string;
+  agentId: string;
+  pgvectorClient: IPineconeClient;
+  /** Optional category for filtering (e.g. "manual", "faq", "policy") */
+  category?: string;
+  /** Custom source file identifier. Defaults to filename. */
+  sourceFile?: string;
+  dryRun?: boolean;
+}
+
+export interface IngestDocumentResult {
+  filePath: string;
+  sourceFile: string;
+  agentId: string;
+  totalChunks: number;
+  category?: string;
+}
+
+const SUPPORTED_EXTENSIONS = new Set([".txt", ".md", ".markdown", ".text"]);
+
+export function isSupportedExtension(filePath: string): boolean {
+  return SUPPORTED_EXTENSIONS.has(extname(filePath).toLowerCase());
+}
+
+export async function extractText(filePath: string): Promise<string> {
+  const ext = extname(filePath).toLowerCase();
+  if (!SUPPORTED_EXTENSIONS.has(ext)) {
+    throw new Error(
+      `Unsupported file type: ${ext}. Supported: ${[...SUPPORTED_EXTENSIONS].join(", ")}`,
+    );
+  }
+  return readFile(filePath, "utf-8");
+}
+
+export async function ingestDocument(opts: IngestDocumentOptions): Promise<IngestDocumentResult> {
+  const { filePath, agentId, pgvectorClient, category, dryRun } = opts;
+  const sourceFile = opts.sourceFile ?? `doc:${basename(filePath)}`;
+
+  console.log(`\n📄 Ingesting: ${filePath}`);
+  console.log(`   Agent: ${agentId}`);
+  console.log(`   Source: ${sourceFile}`);
+  if (category) console.log(`   Category: ${category}`);
+
+  const text = await extractText(filePath);
+  console.log(`   Text length: ${text.length} chars`);
+
+  if (text.trim().length === 0) {
+    console.log("   ⚠️  Empty file, skipping");
+    return { filePath, sourceFile, agentId, totalChunks: 0, category };
+  }
+
+  const chunker = new TextChunker();
+  const chunks = chunker.chunk({
+    text,
+    agentId,
+    sourceFile,
+    sourceType: "document",
+    category,
+  });
+
+  console.log(`   Chunks: ${chunks.length}`);
+
+  if (dryRun) {
+    console.log("   [DRY RUN] Would upsert chunks");
+  } else {
+    await pgvectorClient.upsert(chunks);
+    console.log(`   ✅ Upserted ${chunks.length} chunks`);
+  }
+
+  return { filePath, sourceFile, agentId, totalChunks: chunks.length, category };
+}
+
+export async function ingestDocuments(
+  opts: Omit<IngestDocumentOptions, "filePath"> & { filePaths: string[] },
+): Promise<IngestDocumentResult[]> {
+  const { filePaths, agentId, pgvectorClient, category, sourceFile, dryRun } = opts;
+
+  console.log(`\n${"=".repeat(60)}`);
+  console.log("ドキュメント事前登録");
+  console.log(`${"=".repeat(60)}`);
+  console.log(`Agent: ${agentId}`);
+  console.log(`Files: ${filePaths.length}`);
+  console.log(`Dry run: ${dryRun ?? false}`);
+
+  if (!dryRun) {
+    await pgvectorClient.ensureIndex();
+  }
+
+  const results: IngestDocumentResult[] = [];
+
+  for (const filePath of filePaths) {
+    const result = await ingestDocument({
+      filePath,
+      agentId,
+      pgvectorClient,
+      category,
+      sourceFile,
+      dryRun,
+    });
+    results.push(result);
+  }
+
+  // Summary
+  const totalChunks = results.reduce((sum, r) => sum + r.totalChunks, 0);
+  console.log(`\n${"=".repeat(60)}`);
+  console.log(`完了: ${results.length} files, ${totalChunks} chunks`);
+  console.log(`${"=".repeat(60)}`);
+
+  return results;
+}

--- a/packages/migrate-memory/src/ingest-document.ts
+++ b/packages/migrate-memory/src/ingest-document.ts
@@ -87,25 +87,36 @@ export async function ingestDocument(opts: IngestDocumentOptions): Promise<Inges
   if (dryRun) {
     console.log("   [DRY RUN] Would delete existing + upsert chunks");
   } else {
-    // Safe atomic-like replace:
-    // 1. Validate new chunks via upsert (embedding generation + DB write)
-    // 2. Delete all chunks for this source (old + newly inserted)
-    // 3. Re-insert validated chunks (no embedding re-generation, idempotent)
+    // Safe replace using staging sourceFile:
+    // 1. Upsert new chunks with a staging sourceFile (embedding + DB write)
+    // 2. Delete old chunks (original sourceFile) — only after step 1 succeeds
+    // 3. Delete staging chunks (cleanup)
+    // 4. Upsert final chunks with real sourceFile
     //
-    // If step 1 fails → existing data preserved, no deletion occurred
-    // If step 2 fails → duplicates exist but no data loss
-    // Step 3 uses already-validated chunks, so failure risk is minimal (DB-only)
+    // If step 1 fails → no data loss (old chunks untouched, no staging residue)
+    // If step 2/3/4 fails → staging chunks exist as readable backup
+    const stagingSourceFile = `${sourceFile}:staging:${Date.now()}`;
+    const stagingChunks = chunks.map((c) => ({
+      ...c,
+      metadata: { ...c.metadata, sourceFile: stagingSourceFile },
+    }));
+
+    // Step 1: Validate embedding generation + DB write with staging name
     try {
-      await pgvectorClient.upsert(chunks);
+      await pgvectorClient.upsert(stagingChunks);
     } catch (err) {
-      // Upsert failed (e.g. embedding API error) — do NOT delete existing data
       throw new Error(
-        `Upsert validation failed for ${filePath}, existing data preserved: ${err instanceof Error ? err.message : String(err)}`,
+        `Upsert failed for ${filePath}, existing data preserved: ${err instanceof Error ? err.message : String(err)}`,
       );
     }
-    // Upsert succeeded → safe to replace
+
+    // Step 2: Delete old production chunks (safe — staging backup exists)
     await pgvectorClient.deleteBySource(agentId, sourceFile);
+
+    // Step 3-4: Promote staging → production
     await pgvectorClient.upsert(chunks);
+    await pgvectorClient.deleteBySource(agentId, stagingSourceFile);
+
     console.log(`   ✅ Replaced with ${chunks.length} chunks`);
   }
 

--- a/packages/migrate-memory/src/ingest-document.ts
+++ b/packages/migrate-memory/src/ingest-document.ts
@@ -3,11 +3,11 @@
  *
  * テキスト / Markdown ファイルを読み込み、チャンク分割 → pgvector upsert する。
  * sourceType は "document" を使用し、category でドキュメント種別を区別する。
- * 同一ファイルの再登録時は ON CONFLICT で上書き（冪等）。
+ * 同一ファイルの再登録時は deleteBySource → upsert で古いチャンクを残さない。
  */
 
 import { readFile } from "node:fs/promises";
-import { basename, extname } from "node:path";
+import { extname, resolve } from "node:path";
 import type { IPineconeClient } from "@easy-flow/pinecone-client";
 import { TextChunker } from "@easy-flow/pinecone-client";
 
@@ -48,7 +48,7 @@ export async function extractText(filePath: string): Promise<string> {
 
 export async function ingestDocument(opts: IngestDocumentOptions): Promise<IngestDocumentResult> {
   const { filePath, agentId, pgvectorClient, category, dryRun } = opts;
-  const sourceFile = opts.sourceFile ?? `doc:${basename(filePath)}`;
+  const sourceFile = opts.sourceFile ?? `doc:${resolve(filePath)}`;
 
   console.log(`\n📄 Ingesting: ${filePath}`);
   console.log(`   Agent: ${agentId}`);
@@ -75,10 +75,11 @@ export async function ingestDocument(opts: IngestDocumentOptions): Promise<Inges
   console.log(`   Chunks: ${chunks.length}`);
 
   if (dryRun) {
-    console.log("   [DRY RUN] Would upsert chunks");
+    console.log("   [DRY RUN] Would delete existing + upsert chunks");
   } else {
+    await pgvectorClient.deleteBySource(agentId, sourceFile);
     await pgvectorClient.upsert(chunks);
-    console.log(`   ✅ Upserted ${chunks.length} chunks`);
+    console.log(`   ✅ Replaced with ${chunks.length} chunks`);
   }
 
   return { filePath, sourceFile, agentId, totalChunks: chunks.length, category };

--- a/packages/migrate-memory/src/ingest-document.ts
+++ b/packages/migrate-memory/src/ingest-document.ts
@@ -1,23 +1,27 @@
 /**
  * 任意ドキュメントを pgvector に事前登録する
  *
- * テキスト / Markdown ファイルを読み込み、チャンク分割 → pgvector upsert する。
+ * テキスト / Markdown / Office / PDF / URL / Google Docs を読み込み、
+ * チャンク分割 → pgvector upsert する。
  * sourceType は "document" を使用し、category でドキュメント種別を区別する。
  * 同一ファイルの再登録時は deleteBySource → upsert で古いチャンクを残さない。
  */
 
-import { readFile } from "node:fs/promises";
-import { extname, resolve } from "node:path";
+import { resolve } from "node:path";
 import type { IPineconeClient } from "@easy-flow/pinecone-client";
 import { TextChunker } from "@easy-flow/pinecone-client";
+import { extractText, isUrl } from "./text-extractor.js";
+
+export { extractText, isSupportedInput as isSupportedExtension } from "./text-extractor.js";
 
 export interface IngestDocumentOptions {
+  /** File path or URL */
   filePath: string;
   agentId: string;
   pgvectorClient: IPineconeClient;
   /** Optional category for filtering (e.g. "manual", "faq", "policy") */
   category?: string;
-  /** Custom source file identifier. Defaults to filename. */
+  /** Custom source file identifier. Defaults to absolute path or URL. */
   sourceFile?: string;
   dryRun?: boolean;
 }
@@ -30,25 +34,14 @@ export interface IngestDocumentResult {
   category?: string;
 }
 
-const SUPPORTED_EXTENSIONS = new Set([".txt", ".md", ".markdown", ".text"]);
-
-export function isSupportedExtension(filePath: string): boolean {
-  return SUPPORTED_EXTENSIONS.has(extname(filePath).toLowerCase());
-}
-
-export async function extractText(filePath: string): Promise<string> {
-  const ext = extname(filePath).toLowerCase();
-  if (!SUPPORTED_EXTENSIONS.has(ext)) {
-    throw new Error(
-      `Unsupported file type: ${ext}. Supported: ${[...SUPPORTED_EXTENSIONS].join(", ")}`,
-    );
-  }
-  return readFile(filePath, "utf-8");
+function defaultSourceFile(input: string): string {
+  if (isUrl(input)) return `doc:${input}`;
+  return `doc:${resolve(input)}`;
 }
 
 export async function ingestDocument(opts: IngestDocumentOptions): Promise<IngestDocumentResult> {
   const { filePath, agentId, pgvectorClient, category, dryRun } = opts;
-  const sourceFile = opts.sourceFile ?? `doc:${resolve(filePath)}`;
+  const sourceFile = opts.sourceFile ?? defaultSourceFile(filePath);
 
   console.log(`\n📄 Ingesting: ${filePath}`);
   console.log(`   Agent: ${agentId}`);
@@ -59,7 +52,7 @@ export async function ingestDocument(opts: IngestDocumentOptions): Promise<Inges
   console.log(`   Text length: ${text.length} chars`);
 
   if (text.trim().length === 0) {
-    console.log("   ⚠️  Empty file");
+    console.log("   ⚠️  Empty content");
     if (!dryRun) {
       await pgvectorClient.deleteBySource(agentId, sourceFile);
       console.log("   🗑️  Deleted existing chunks for this source");
@@ -98,7 +91,7 @@ export async function ingestDocuments(
   console.log("ドキュメント事前登録");
   console.log(`${"=".repeat(60)}`);
   console.log(`Agent: ${agentId}`);
-  console.log(`Files: ${filePaths.length}`);
+  console.log(`Sources: ${filePaths.length}`);
   console.log(`Dry run: ${dryRun ?? false}`);
 
   if (!dryRun) {
@@ -122,7 +115,7 @@ export async function ingestDocuments(
   // Summary
   const totalChunks = results.reduce((sum, r) => sum + r.totalChunks, 0);
   console.log(`\n${"=".repeat(60)}`);
-  console.log(`完了: ${results.length} files, ${totalChunks} chunks`);
+  console.log(`完了: ${results.length} sources, ${totalChunks} chunks`);
   console.log(`${"=".repeat(60)}`);
 
   return results;

--- a/packages/migrate-memory/src/preflight.ts
+++ b/packages/migrate-memory/src/preflight.ts
@@ -70,6 +70,22 @@ export async function runPreflight(files: string[]): Promise<{
   return { results, hasSecrets };
 }
 
+/**
+ * Check extracted text content for secret patterns.
+ * Returns an array of detected secret names (empty if clean).
+ */
+export function checkTextForSecrets(text: string): string[] {
+  const detected: string[] = [];
+  for (const line of text.split("\n")) {
+    for (const { name, pattern } of SECRET_PATTERNS) {
+      if (pattern.test(line) && !detected.includes(name)) {
+        detected.push(name);
+      }
+    }
+  }
+  return detected;
+}
+
 export function validateExcludePatterns(patterns: string[]): string[] {
   const warnings: string[] = [];
   for (const p of patterns) {

--- a/packages/migrate-memory/src/text-extractor.test.ts
+++ b/packages/migrate-memory/src/text-extractor.test.ts
@@ -128,4 +128,108 @@ describe("extractText", () => {
 
     vi.unstubAllGlobals();
   });
+
+  it("should extract text from .docx file via mammoth", async () => {
+    vi.doMock("mammoth", () => ({
+      default: {
+        extractRawText: vi.fn().mockResolvedValue({ value: "Word document content" }),
+      },
+    }));
+    // Re-import to pick up the mock
+    const { extractText: extract } = await import("./text-extractor.js");
+    const filePath = join(tmpDir, "test.docx");
+    await writeFile(filePath, "dummy"); // mammoth is mocked so content doesn't matter
+    const text = await extract(filePath);
+    expect(text).toBe("Word document content");
+    vi.doUnmock("mammoth");
+  });
+
+  it("should extract text from .xlsx file via xlsx", async () => {
+    vi.doMock("xlsx", () => ({
+      readFile: vi.fn().mockReturnValue({
+        SheetNames: ["Sheet1"],
+        Sheets: { Sheet1: {} },
+      }),
+      utils: {
+        sheet_to_csv: vi.fn().mockReturnValue("A,B,C\n1,2,3"),
+      },
+    }));
+    const { extractText: extract } = await import("./text-extractor.js");
+    const filePath = join(tmpDir, "test.xlsx");
+    await writeFile(filePath, "dummy");
+    const text = await extract(filePath);
+    expect(text).toContain("Sheet1");
+    expect(text).toContain("A,B,C");
+    vi.doUnmock("xlsx");
+  });
+
+  it("should extract text from .pptx file via jszip", async () => {
+    const slideXml = "<a:t>Slide title</a:t><a:t>Bullet point</a:t>";
+    vi.doMock("jszip", () => ({
+      default: {
+        loadAsync: vi.fn().mockResolvedValue({
+          files: {
+            "ppt/slides/slide1.xml": {
+              async: vi.fn().mockResolvedValue(slideXml),
+            },
+          },
+        }),
+      },
+    }));
+    const { extractText: extract } = await import("./text-extractor.js");
+    const filePath = join(tmpDir, "test.pptx");
+    await writeFile(filePath, "dummy");
+    const text = await extract(filePath);
+    expect(text).toContain("Slide title");
+    expect(text).toContain("Bullet point");
+    vi.doUnmock("jszip");
+  });
+
+  it("should extract text from .pdf file via pdf-parse", async () => {
+    vi.doMock("pdf-parse", () => ({
+      PDFParse: vi.fn().mockImplementation(() => ({
+        getText: vi.fn().mockResolvedValue({ text: "PDF document text" }),
+      })),
+    }));
+    const { extractText: extract } = await import("./text-extractor.js");
+    const filePath = join(tmpDir, "test.pdf");
+    await writeFile(filePath, "dummy");
+    const text = await extract(filePath);
+    expect(text).toBe("PDF document text");
+    vi.doUnmock("pdf-parse");
+  });
+
+  it("should convert Google Sheets URL to csv export", async () => {
+    const fetchMock = vi.fn<(input: string | URL | Request) => Promise<Response>>();
+    fetchMock.mockResolvedValueOnce(
+      new Response("col1,col2\nval1,val2", { headers: { "content-type": "text/plain" } }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const text = await extractText("https://docs.google.com/spreadsheets/d/abc123/edit");
+    expect(text).toBe("col1,col2\nval1,val2");
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://docs.google.com/spreadsheets/d/abc123/export?format=csv",
+      expect.any(Object),
+    );
+
+    vi.unstubAllGlobals();
+  });
+
+  it("should convert Google Slides URL to txt export", async () => {
+    const fetchMock = vi.fn<(input: string | URL | Request) => Promise<Response>>();
+    fetchMock.mockResolvedValueOnce(
+      new Response("Slide 1 text\nSlide 2 text", { headers: { "content-type": "text/plain" } }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const text = await extractText("https://docs.google.com/presentation/d/abc123/edit");
+    expect(text).toBe("Slide 1 text\nSlide 2 text");
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://docs.google.com/presentation/d/abc123/export?format=txt",
+      expect.any(Object),
+    );
+
+    vi.unstubAllGlobals();
+  });
 });

--- a/packages/migrate-memory/src/text-extractor.test.ts
+++ b/packages/migrate-memory/src/text-extractor.test.ts
@@ -1,0 +1,131 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { extractText, isGoogleDocsUrl, isSupportedInput, isUrl } from "./text-extractor.js";
+
+describe("isUrl", () => {
+  it("should detect http URLs", () => {
+    expect(isUrl("http://example.com")).toBe(true);
+    expect(isUrl("https://example.com/page")).toBe(true);
+  });
+
+  it("should reject non-URLs", () => {
+    expect(isUrl("file.txt")).toBe(false);
+    expect(isUrl("/path/to/file.md")).toBe(false);
+  });
+});
+
+describe("isGoogleDocsUrl", () => {
+  it("should detect Google Docs URLs", () => {
+    expect(isGoogleDocsUrl("https://docs.google.com/document/d/abc123/edit")).toBe(true);
+    expect(isGoogleDocsUrl("https://docs.google.com/spreadsheets/d/abc123/edit")).toBe(true);
+    expect(isGoogleDocsUrl("https://docs.google.com/presentation/d/abc123/edit")).toBe(true);
+  });
+
+  it("should reject non-Google Docs URLs", () => {
+    expect(isGoogleDocsUrl("https://example.com")).toBe(false);
+  });
+});
+
+describe("isSupportedInput", () => {
+  it("should accept text/markdown files", () => {
+    expect(isSupportedInput("file.txt")).toBe(true);
+    expect(isSupportedInput("file.md")).toBe(true);
+  });
+
+  it("should accept office files", () => {
+    expect(isSupportedInput("file.docx")).toBe(true);
+    expect(isSupportedInput("file.xlsx")).toBe(true);
+    expect(isSupportedInput("file.pptx")).toBe(true);
+  });
+
+  it("should accept PDF", () => {
+    expect(isSupportedInput("file.pdf")).toBe(true);
+  });
+
+  it("should accept URLs", () => {
+    expect(isSupportedInput("https://example.com")).toBe(true);
+  });
+
+  it("should reject unsupported formats", () => {
+    expect(isSupportedInput("file.csv")).toBe(false);
+    expect(isSupportedInput("file.jpg")).toBe(false);
+  });
+});
+
+describe("extractText", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), "extractor-test-"));
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true });
+  });
+
+  it("should extract text from .txt file", async () => {
+    const filePath = join(tmpDir, "test.txt");
+    await writeFile(filePath, "hello world");
+    expect(await extractText(filePath)).toBe("hello world");
+  });
+
+  it("should extract text from .md file", async () => {
+    const filePath = join(tmpDir, "test.md");
+    await writeFile(filePath, "# Title\n\nContent");
+    expect(await extractText(filePath)).toBe("# Title\n\nContent");
+  });
+
+  it("should throw for unsupported file type", async () => {
+    const filePath = join(tmpDir, "test.csv");
+    await writeFile(filePath, "a,b,c");
+    await expect(extractText(filePath)).rejects.toThrow("Unsupported file type: .csv");
+  });
+
+  it("should extract text from URL", async () => {
+    const fetchMock = vi.fn<(input: string | URL | Request) => Promise<Response>>();
+    fetchMock.mockResolvedValueOnce(
+      new Response("<html><body><main><p>Page content</p></main></body></html>", {
+        headers: { "content-type": "text/html" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const text = await extractText("https://example.com/page");
+    expect(text).toContain("Page content");
+
+    vi.unstubAllGlobals();
+  });
+
+  it("should convert Google Docs URL to export URL", async () => {
+    const fetchMock = vi.fn<(input: string | URL | Request) => Promise<Response>>();
+    fetchMock.mockResolvedValueOnce(
+      new Response("Document text content", {
+        headers: { "content-type": "text/plain" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const text = await extractText("https://docs.google.com/document/d/abc123/edit");
+    expect(text).toBe("Document text content");
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://docs.google.com/document/d/abc123/export?format=txt",
+      expect.any(Object),
+    );
+
+    vi.unstubAllGlobals();
+  });
+
+  it("should throw on fetch failure", async () => {
+    const fetchMock = vi.fn<(input: string | URL | Request) => Promise<Response>>();
+    fetchMock.mockResolvedValueOnce(
+      new Response("Not Found", { status: 404, statusText: "Not Found" }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(extractText("https://example.com/missing")).rejects.toThrow("404");
+
+    vi.unstubAllGlobals();
+  });
+});

--- a/packages/migrate-memory/src/text-extractor.test.ts
+++ b/packages/migrate-memory/src/text-extractor.test.ts
@@ -129,6 +129,20 @@ describe("extractText", () => {
     vi.unstubAllGlobals();
   });
 
+  it("should reject unsupported URL content types", async () => {
+    const fetchMock = vi.fn<(input: string | URL | Request) => Promise<Response>>();
+    fetchMock.mockResolvedValueOnce(
+      new Response("binary data", { headers: { "content-type": "image/png" } }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(extractText("https://example.com/image.png")).rejects.toThrow(
+      "Unsupported content type",
+    );
+
+    vi.unstubAllGlobals();
+  });
+
   it("should extract text from .docx file via mammoth", async () => {
     vi.doMock("mammoth", () => ({
       default: {

--- a/packages/migrate-memory/src/text-extractor.test.ts
+++ b/packages/migrate-memory/src/text-extractor.test.ts
@@ -199,15 +199,17 @@ describe("extractText", () => {
     vi.doUnmock("pdf-parse");
   });
 
-  it("should convert Google Sheets URL to csv export", async () => {
+  it("should convert Google Sheets URL to csv export and preserve CSV structure", async () => {
+    const csvData = "col1,col2\nval1,val2\nval3,val4";
     const fetchMock = vi.fn<(input: string | URL | Request) => Promise<Response>>();
     fetchMock.mockResolvedValueOnce(
-      new Response("col1,col2\nval1,val2", { headers: { "content-type": "text/plain" } }),
+      new Response(csvData, { headers: { "content-type": "text/csv; charset=utf-8" } }),
     );
     vi.stubGlobal("fetch", fetchMock);
 
     const text = await extractText("https://docs.google.com/spreadsheets/d/abc123/edit");
-    expect(text).toBe("col1,col2\nval1,val2");
+    // CSV should be preserved as-is, not processed through HTML parser
+    expect(text).toBe(csvData);
     expect(fetchMock).toHaveBeenCalledWith(
       "https://docs.google.com/spreadsheets/d/abc123/export?format=csv",
       expect.any(Object),

--- a/packages/migrate-memory/src/text-extractor.ts
+++ b/packages/migrate-memory/src/text-extractor.ts
@@ -99,9 +99,11 @@ async function extractPptx(filePath: string): Promise<string> {
 
 /** PDF からテキスト抽出 */
 async function extractPdf(filePath: string): Promise<string> {
+  const { readFile } = await import("node:fs/promises");
   const { PDFParse } = await import("pdf-parse");
-  const parser = new PDFParse();
-  const result = await parser.loadPDF(filePath);
+  const data = await readFile(filePath);
+  const parser = new PDFParse({ data: new Uint8Array(data) });
+  const result = await parser.getText();
   return result.text;
 }
 

--- a/packages/migrate-memory/src/text-extractor.ts
+++ b/packages/migrate-memory/src/text-extractor.ts
@@ -128,6 +128,14 @@ async function extractUrl(url: string): Promise<string> {
     return body;
   }
 
+  // Reject non-HTML content types (e.g. image, PDF, binary)
+  const ALLOWED_HTML_TYPES = ["text/html", "application/xhtml+xml"];
+  if (!ALLOWED_HTML_TYPES.some((t) => contentType.includes(t))) {
+    throw new Error(
+      `Unsupported content type: ${contentType}. Only HTML, text/plain, and text/csv URLs are supported.`,
+    );
+  }
+
   // HTML → text extraction
   const cheerio = await import("cheerio");
   const $ = cheerio.load(body);

--- a/packages/migrate-memory/src/text-extractor.ts
+++ b/packages/migrate-memory/src/text-extractor.ts
@@ -123,8 +123,8 @@ async function extractUrl(url: string): Promise<string> {
   const contentType = res.headers.get("content-type") ?? "";
   const body = await res.text();
 
-  // Google Docs export returns plain text
-  if (contentType.includes("text/plain")) {
+  // Google Docs export returns plain text, Google Sheets returns CSV
+  if (contentType.includes("text/plain") || contentType.includes("text/csv")) {
     return body;
   }
 

--- a/packages/migrate-memory/src/text-extractor.ts
+++ b/packages/migrate-memory/src/text-extractor.ts
@@ -1,0 +1,183 @@
+/**
+ * 多形式テキスト抽出モジュール
+ *
+ * 対応形式:
+ *   - テキスト/Markdown (.txt, .md, .markdown, .text)
+ *   - Word (.docx)
+ *   - Excel (.xlsx)
+ *   - PowerPoint (.pptx)
+ *   - PDF (.pdf)
+ *   - URL (HTML ページ)
+ *   - Google Docs (公開ドキュメント URL)
+ */
+
+import { readFile } from "node:fs/promises";
+import { extname } from "node:path";
+
+const TEXT_EXTENSIONS = new Set([".txt", ".md", ".markdown", ".text"]);
+const OFFICE_EXTENSIONS = new Set([".docx", ".xlsx", ".pptx"]);
+const ALL_SUPPORTED_EXTENSIONS = new Set([...TEXT_EXTENSIONS, ...OFFICE_EXTENSIONS, ".pdf"]);
+
+const GOOGLE_DOCS_PATTERN = /^https:\/\/docs\.google\.com\/document\/d\/([^/]+)/;
+const GOOGLE_SHEETS_PATTERN = /^https:\/\/docs\.google\.com\/spreadsheets\/d\/([^/]+)/;
+const GOOGLE_SLIDES_PATTERN = /^https:\/\/docs\.google\.com\/presentation\/d\/([^/]+)/;
+
+export function isUrl(input: string): boolean {
+  return input.startsWith("http://") || input.startsWith("https://");
+}
+
+export function isGoogleDocsUrl(url: string): boolean {
+  return (
+    GOOGLE_DOCS_PATTERN.test(url) ||
+    GOOGLE_SHEETS_PATTERN.test(url) ||
+    GOOGLE_SLIDES_PATTERN.test(url)
+  );
+}
+
+export function isSupportedInput(input: string): boolean {
+  if (isUrl(input)) return true;
+  return ALL_SUPPORTED_EXTENSIONS.has(extname(input).toLowerCase());
+}
+
+/** テキスト/Markdown ファイルからテキスト抽出 */
+async function extractPlainText(filePath: string): Promise<string> {
+  return readFile(filePath, "utf-8");
+}
+
+/** Word (.docx) からテキスト抽出 */
+async function extractDocx(filePath: string): Promise<string> {
+  const mammoth = await import("mammoth");
+  const result = await mammoth.default.extractRawText({ path: filePath });
+  return result.value;
+}
+
+/** Excel (.xlsx) からテキスト抽出 */
+async function extractXlsx(filePath: string): Promise<string> {
+  const XLSX = await import("xlsx");
+  const workbook = XLSX.readFile(filePath);
+  const lines: string[] = [];
+
+  for (const sheetName of workbook.SheetNames) {
+    lines.push(`## ${sheetName}`);
+    const sheet = workbook.Sheets[sheetName];
+    const csv = XLSX.utils.sheet_to_csv(sheet);
+    lines.push(csv);
+    lines.push("");
+  }
+
+  return lines.join("\n");
+}
+
+/** PowerPoint (.pptx) からテキスト抽出 */
+async function extractPptx(filePath: string): Promise<string> {
+  const JSZip = (await import("jszip")).default;
+  const data = await readFile(filePath);
+  const zip = await JSZip.loadAsync(data);
+
+  const slideFiles = Object.keys(zip.files)
+    .filter((name) => /^ppt\/slides\/slide\d+\.xml$/.test(name))
+    .sort((a, b) => {
+      const numA = Number.parseInt(a.match(/slide(\d+)/)?.[1] ?? "0", 10);
+      const numB = Number.parseInt(b.match(/slide(\d+)/)?.[1] ?? "0", 10);
+      return numA - numB;
+    });
+
+  const texts: string[] = [];
+
+  for (const slidePath of slideFiles) {
+    const xml = await zip.files[slidePath].async("text");
+    // Extract text from <a:t> tags in the slide XML
+    const matches = xml.match(/<a:t>([^<]*)<\/a:t>/g);
+    if (matches) {
+      const slideText = matches.map((m) => m.replace(/<\/?a:t>/g, "")).join(" ");
+      texts.push(slideText);
+    }
+  }
+
+  return texts.join("\n\n");
+}
+
+/** PDF からテキスト抽出 */
+async function extractPdf(filePath: string): Promise<string> {
+  const { PDFParse } = await import("pdf-parse");
+  const parser = new PDFParse();
+  const result = await parser.loadPDF(filePath);
+  return result.text;
+}
+
+/** URL からテキスト抽出（HTML → プレーンテキスト） */
+async function extractUrl(url: string): Promise<string> {
+  // Google Docs の場合は export URL に変換
+  const fetchUrl = toGoogleExportUrl(url) ?? url;
+
+  const res = await fetch(fetchUrl, {
+    headers: { "User-Agent": "EasyFlow-RAG-Ingester/1.0" },
+  });
+
+  if (!res.ok) {
+    throw new Error(`Failed to fetch URL: ${res.status} ${res.statusText}`);
+  }
+
+  const contentType = res.headers.get("content-type") ?? "";
+  const body = await res.text();
+
+  // Google Docs export returns plain text
+  if (contentType.includes("text/plain")) {
+    return body;
+  }
+
+  // HTML → text extraction
+  const cheerio = await import("cheerio");
+  const $ = cheerio.load(body);
+
+  // Remove non-content elements
+  $("script, style, nav, header, footer, aside, noscript").remove();
+
+  // Get text from main content or body
+  const mainContent = $("main, article, [role=main]").first();
+  const text = mainContent.length > 0 ? mainContent.text() : $("body").text();
+
+  // Clean up whitespace
+  return text.replace(/\s+/g, " ").trim();
+}
+
+/** Google Docs/Sheets/Slides URL を export URL に変換 */
+function toGoogleExportUrl(url: string): string | null {
+  const docsMatch = url.match(GOOGLE_DOCS_PATTERN);
+  if (docsMatch) {
+    return `https://docs.google.com/document/d/${docsMatch[1]}/export?format=txt`;
+  }
+
+  const sheetsMatch = url.match(GOOGLE_SHEETS_PATTERN);
+  if (sheetsMatch) {
+    return `https://docs.google.com/spreadsheets/d/${sheetsMatch[1]}/export?format=csv`;
+  }
+
+  const slidesMatch = url.match(GOOGLE_SLIDES_PATTERN);
+  if (slidesMatch) {
+    return `https://docs.google.com/presentation/d/${slidesMatch[1]}/export?format=txt`;
+  }
+
+  return null;
+}
+
+/**
+ * ファイルパスまたは URL からテキストを抽出する
+ */
+export async function extractText(input: string): Promise<string> {
+  if (isUrl(input)) {
+    return extractUrl(input);
+  }
+
+  const ext = extname(input).toLowerCase();
+
+  if (TEXT_EXTENSIONS.has(ext)) return extractPlainText(input);
+  if (ext === ".docx") return extractDocx(input);
+  if (ext === ".xlsx") return extractXlsx(input);
+  if (ext === ".pptx") return extractPptx(input);
+  if (ext === ".pdf") return extractPdf(input);
+
+  throw new Error(
+    `Unsupported file type: ${ext}. Supported: ${[...ALL_SUPPORTED_EXTENSIONS].join(", ")}, URL`,
+  );
+}

--- a/packages/pinecone-client/src/types.ts
+++ b/packages/pinecone-client/src/types.ts
@@ -8,7 +8,7 @@ export interface MemoryChunk {
 export interface ChunkMetadata {
   agentId: string;
   sourceFile: string;
-  sourceType: "memory_file" | "session_turn" | "workflow_state" | "agents_rule";
+  sourceType: "memory_file" | "session_turn" | "workflow_state" | "agents_rule" | "document";
   chunkIndex: number;
   createdAt: number;
   turnId?: string;

--- a/packages/pinecone-context-engine/src/reranker.test.ts
+++ b/packages/pinecone-context-engine/src/reranker.test.ts
@@ -33,12 +33,13 @@ describe("rerankChunks", () => {
   });
 
   describe("sourceType 重み付け", () => {
-    it("agents_rule > memory_file > session_turn > workflow_state の順にスコアが高い", () => {
+    it("agents_rule > document > memory_file > session_turn > workflow_state の順にスコアが高い", () => {
       const now = Date.now();
       const chunks = [
         makeChunk({ id: "wf", sourceType: "workflow_state", score: 0.9, createdAt: now }),
         makeChunk({ id: "st", sourceType: "session_turn", score: 0.9, createdAt: now }),
         makeChunk({ id: "mf", sourceType: "memory_file", score: 0.9, createdAt: now }),
+        makeChunk({ id: "doc", sourceType: "document", score: 0.9, createdAt: now }),
         makeChunk({ id: "ar", sourceType: "agents_rule", score: 0.9, createdAt: now }),
       ];
 
@@ -48,9 +49,10 @@ describe("rerankChunks", () => {
       const ranked = rerankChunks(chunks, now);
 
       expect(ranked[0].id).toBe("ar");
-      expect(ranked[1].id).toBe("mf");
-      expect(ranked[2].id).toBe("st");
-      expect(ranked[3].id).toBe("wf");
+      expect(ranked[1].id).toBe("doc");
+      expect(ranked[2].id).toBe("mf");
+      expect(ranked[3].id).toBe("st");
+      expect(ranked[4].id).toBe("wf");
     });
   });
 

--- a/packages/pinecone-context-engine/src/reranker.ts
+++ b/packages/pinecone-context-engine/src/reranker.ts
@@ -12,6 +12,7 @@ export interface RankedChunk {
 
 const SOURCE_TYPE_WEIGHTS: Record<ChunkMetadata["sourceType"], number> = {
   agents_rule: 1.0,
+  document: 0.9,
   memory_file: 0.8,
   session_turn: 0.6,
   workflow_state: 0.5,


### PR DESCRIPTION
## Summary

- sourceType に `document` を新設（`packages/pinecone-client/src/types.ts`）
- `ingest-document` サブコマンドを `migrate-memory` CLI に追加
- テキスト / Markdown ファイルをチャンク分割 → Gemini embedding → pgvector upsert
- `--namespace`, `--category`, `--dry-run` オプション対応
- 14 件のテスト追加（extractText, isSupportedExtension, ingestDocument, ingestDocuments）

### 使用例

```bash
# 単一ファイル
easy-flow ingest-document --namespace agent:mell manual.md

# カテゴリ付き複数ファイル
easy-flow ingest-document --namespace agent:mell --category faq faq.txt guide.md

# ドライラン
easy-flow ingest-document --namespace agent:mell --dry-run *.md
```

## Test plan

- [x] `npx vitest run packages/migrate-memory/src/ingest-document.test.ts` — 14 tests passed
- [x] `npx biome check` — no errors
- [ ] CI test / codex-review

Closes #143