### PR TITLE
fix: 会話メモリの品質改善（ノイズ除去 + テキスト抽出修正）

### DIFF
--- a/packages/pinecone-context-engine/src/extract-message-text.test.ts
+++ b/packages/pinecone-context-engine/src/extract-message-text.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import { extractMessageText } from "./shared.js";
+
+describe("extractMessageText", () => {
+  it("returns string content as-is", () => {
+    expect(extractMessageText("hello world")).toBe("hello world");
+  });
+
+  it("returns empty string for empty string", () => {
+    expect(extractMessageText("")).toBe("");
+  });
+
+  it("returns empty string for empty array", () => {
+    expect(extractMessageText([])).toBe("");
+  });
+
+  it("extracts text from array with type:text entries", () => {
+    const content = [
+      { type: "text", text: "first message" },
+      { type: "text", text: "second message" },
+    ];
+    expect(extractMessageText(content)).toBe("first message\nsecond message");
+  });
+
+  it("filters out toolCall entries", () => {
+    const content = [
+      { type: "text", text: "user question" },
+      { type: "toolCall", toolCallId: "tc1", toolName: "read", args: {} },
+      { type: "text", text: "follow up" },
+    ];
+    expect(extractMessageText(content)).toBe("user question\nfollow up");
+  });
+
+  it("filters out toolResult entries", () => {
+    const content = [
+      { type: "toolResult", toolCallId: "tc1", result: "some result" },
+      { type: "text", text: "actual message" },
+    ];
+    expect(extractMessageText(content)).toBe("actual message");
+  });
+
+  it("filters out thinking entries", () => {
+    const content = [
+      { type: "thinking", text: "internal reasoning" },
+      { type: "text", text: "visible response" },
+    ];
+    expect(extractMessageText(content)).toBe("visible response");
+  });
+
+  it("returns empty string for array with only non-text types", () => {
+    const content = [
+      { type: "toolCall", toolCallId: "tc1", toolName: "read", args: {} },
+      { type: "toolResult", toolCallId: "tc1", result: "result" },
+    ];
+    expect(extractMessageText(content)).toBe("");
+  });
+
+  it("handles mixed content with single text entry", () => {
+    const content = [
+      { type: "toolCall", toolCallId: "tc1", toolName: "bash", args: {} },
+      { type: "toolResult", toolCallId: "tc1", result: "ok" },
+      { type: "text", text: "done with task" },
+    ];
+    expect(extractMessageText(content)).toBe("done with task");
+  });
+
+  it("returns empty string for non-array non-string content", () => {
+    // @ts-expect-error testing invalid input
+    expect(extractMessageText(42)).toBe("");
+    // @ts-expect-error testing invalid input
+    expect(extractMessageText(null)).toBe("");
+    // @ts-expect-error testing invalid input
+    expect(extractMessageText(undefined)).toBe("");
+  });
+
+  it("handles array entries missing text field gracefully", () => {
+    const content = [
+      { type: "text" }, // missing text field
+      { type: "text", text: "valid" },
+    ];
+    expect(extractMessageText(content)).toBe("valid");
+  });
+});

--- a/packages/pinecone-context-engine/src/pinecone-context-engine-parallel.ts
+++ b/packages/pinecone-context-engine/src/pinecone-context-engine-parallel.ts
@@ -23,6 +23,7 @@ import {
   DEFAULT_SKIP_PATTERNS,
   DEFAULT_TOKEN_BUDGET,
   DEFAULT_TOP_K,
+  extractMessageText,
   readOldTurns,
   resolveMaxQueryTokens,
   withRetry,
@@ -113,8 +114,7 @@ export class PineconeContextEngineParallel implements ContextEngine {
         return { ingested: false };
       }
 
-      const text =
-        typeof message.content === "string" ? message.content : JSON.stringify(message.content);
+      const text = extractMessageText(message.content);
 
       if (!text || text.length === 0) {
         return { ingested: false };
@@ -266,7 +266,7 @@ export class PineconeContextEngineParallel implements ContextEngine {
 
       // Upsert all old turns to Pinecone (idempotent)
       const allChunks = oldMessages.flatMap((msg) => {
-        const text = typeof msg.content === "string" ? msg.content : JSON.stringify(msg.content);
+        const text = extractMessageText(msg.content);
 
         if (!text || text.length === 0) {
           return [];

--- a/packages/pinecone-context-engine/src/pinecone-context-engine.ts
+++ b/packages/pinecone-context-engine/src/pinecone-context-engine.ts
@@ -28,6 +28,7 @@ import {
   DEFAULT_SKIP_PATTERNS,
   DEFAULT_TOKEN_BUDGET,
   DEFAULT_TOP_K,
+  extractMessageText,
   readAgentsCore,
   readOldTurns,
   resolveMaxQueryTokens,
@@ -112,8 +113,7 @@ export class PineconeContextEngine implements ContextEngine {
         return { ingested: false };
       }
 
-      const text =
-        typeof message.content === "string" ? message.content : JSON.stringify(message.content);
+      const text = extractMessageText(message.content);
 
       if (!text || text.length === 0) {
         return { ingested: false };
@@ -407,7 +407,7 @@ export class PineconeContextEngine implements ContextEngine {
       // Upsert all old turns to Pinecone (idempotent)
       // Use content hash (same as ingest()) to avoid duplicate entries
       const allChunks = oldMessages.flatMap((msg) => {
-        const text = typeof msg.content === "string" ? msg.content : JSON.stringify(msg.content);
+        const text = extractMessageText(msg.content);
 
         if (!text || text.length === 0) {
           return [];

--- a/packages/pinecone-context-engine/src/shared.ts
+++ b/packages/pinecone-context-engine/src/shared.ts
@@ -2,6 +2,39 @@ import type { QueryResult } from "@easy-flow/pinecone-client";
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import { estimateTokens } from "./token-estimator.js";
 
+/**
+ * Extract text from an AgentMessage content field.
+ *
+ * - If `content` is a string, return it as-is.
+ * - If `content` is an array, extract `text` fields from `type: "text"` entries,
+ *   filtering out `toolCall`, `toolResult`, `thinking`, and other non-text types.
+ * - Returns empty string for `[]`, non-text-only arrays, or unrecognized formats.
+ */
+export function extractMessageText(content: AgentMessage["content"]): string {
+  if (typeof content === "string") {
+    return content;
+  }
+
+  if (!Array.isArray(content)) {
+    return "";
+  }
+
+  const texts: string[] = [];
+  for (const part of content) {
+    if (
+      typeof part === "object" &&
+      part !== null &&
+      "type" in part &&
+      part.type === "text" &&
+      "text" in part &&
+      typeof part.text === "string"
+    ) {
+      texts.push(part.text);
+    }
+  }
+  return texts.join("\n");
+}
+
 export const DEFAULT_SKIP_PATTERNS = [
   "記憶しないで",
   "覚えなくていい",
@@ -11,6 +44,10 @@ export const DEFAULT_SKIP_PATTERNS = [
   "dont remember",
   "don't remember",
   "skip ingest",
+  // System noise patterns
+  "NO_REPLY",
+  "HEARTBEAT_OK",
+  "変更なしスキップ",
 ];
 
 export const RECENT_TURNS_FOR_QUERY = 3;
@@ -139,9 +176,7 @@ export async function withRetry<T>(fn: () => Promise<T>): Promise<T> {
 
 export function buildQueryFromRecentTurns(messages: AgentMessage[]): string {
   const recent = messages.slice(-RECENT_TURNS_FOR_QUERY);
-  const texts = recent
-    .map((m) => (typeof m.content === "string" ? m.content : JSON.stringify(m.content)))
-    .filter((t) => t.length > 0);
+  const texts = recent.map((m) => extractMessageText(m.content)).filter((t) => t.length > 0);
   return texts.join("\n");
 }
 
@@ -167,9 +202,7 @@ export function buildQueryWithTruncation(
   maxTokens: number,
 ): TruncationResult {
   const recent = messages.slice(-RECENT_TURNS_FOR_QUERY);
-  const texts = recent
-    .map((m) => (typeof m.content === "string" ? m.content : JSON.stringify(m.content)))
-    .filter((t) => t.length > 0);
+  const texts = recent.map((m) => extractMessageText(m.content)).filter((t) => t.length > 0);
   const fullQuery = texts.join("\n");
   const originalTokens = estimateTokens(fullQuery);
 


### PR DESCRIPTION
## Summary

- `extractMessageText()` ヘルパーを `shared.ts` に追加。`content` が配列の場合、`type:"text"` エントリのみ抽出し、`toolCall` / `toolResult` / `thinking` をフィルタリング
- `DEFAULT_SKIP_PATTERNS` にシステムノイズ（`NO_REPLY`, `HEARTBEAT_OK`, `変更なしスキップ`）を追加
- `ingest()` / `compact()` / `buildQueryFromRecentTurns()` / `buildQueryWithTruncation()` の全 5 箇所で `JSON.stringify(msg.content)` → `extractMessageText()` に統一

## Background

pgvector の会話メモリ分析で以下の品質問題を検出:
- **51%** のベクトルが JSON 配列をそのまま stringify して保存（テキスト未抽出）
- **177 件** のシステムノイズ（NO_REPLY: 68, HEARTBEAT_OK: 53, 空配列: 56）
- `toolCall` / `toolResult` の内容が混入

## Test plan

- [x] `extractMessageText` 11 テストケース追加（文字列/配列/toolCall除外/空配列/不正入力）
- [x] 既存テスト 644 件全パス
- [x] biome lint クリーン

Closes estack-inc/easy-flow#144