### PR TITLE
feat(easyflow-cli): CLI 基盤の実装

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -181,6 +181,10 @@
         "node": ">=14.21.3"
       }
     },
+    "node_modules/@easy-flow/easyflow-cli": {
+      "resolved": "packages/easyflow-cli",
+      "link": true
+    },
     "node_modules/@easy-flow/migrate-memory": {
       "resolved": "packages/migrate-memory",
       "link": true
@@ -1201,6 +1205,18 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -1238,6 +1254,18 @@
         "node": ">=18"
       }
     },
+    "node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
     "node_modules/check-error": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
@@ -1246,6 +1274,42 @@
       "license": "MIT",
       "engines": {
         "node": ">= 16"
+      }
+    },
+    "node_modules/cli-cursor": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-spinners": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/commander": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/debug": {
@@ -1275,6 +1339,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "license": "MIT"
     },
     "node_modules/es-module-lexer": {
       "version": "1.7.0",
@@ -1378,6 +1448,18 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/get-east-asian-width": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
+      "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-tsconfig": {
       "version": "4.13.6",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
@@ -1391,12 +1473,64 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
+    "node_modules/is-interactive": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
+      "integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
       "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/log-symbols": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-6.0.0.tgz",
+      "integrity": "sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "is-unicode-supported": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-symbols/node_modules/is-unicode-supported": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
+      "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/loupe": {
       "version": "3.2.1",
@@ -1413,6 +1547,18 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/model-router": {
@@ -1443,6 +1589,44 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-8.2.0.tgz",
+      "integrity": "sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "cli-cursor": "^5.0.0",
+        "cli-spinners": "^2.9.2",
+        "is-interactive": "^2.0.0",
+        "is-unicode-supported": "^2.0.0",
+        "log-symbols": "^6.0.0",
+        "stdin-discarder": "^0.2.2",
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/pathe": {
@@ -1665,6 +1849,22 @@
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
+    "node_modules/restore-cursor": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^7.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/rollup": {
       "version": "4.59.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
@@ -1717,6 +1917,18 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -1749,6 +1961,50 @@
       "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/stdin-discarder": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.2.2.tgz",
+      "integrity": "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
     },
     "node_modules/strip-literal": {
       "version": "3.1.0",
@@ -2064,6 +2320,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4"
+      }
+    },
+    "packages/easyflow-cli": {
+      "name": "@easy-flow/easyflow-cli",
+      "version": "0.1.0",
+      "dependencies": {
+        "commander": "^13.0.0",
+        "ora": "^8.0.0"
+      },
+      "bin": {
+        "easyflow": "bin/easyflow.mjs"
+      },
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "vitest": "^3.0.0"
       }
     },
     "packages/file-serve": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -212,7 +212,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -229,7 +228,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -246,7 +244,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -263,7 +260,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -280,7 +276,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -297,7 +292,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -314,7 +308,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -331,7 +324,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -348,7 +340,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -365,7 +356,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -382,7 +372,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -399,7 +388,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -416,7 +404,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -433,7 +420,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -450,7 +436,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -467,7 +452,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -484,7 +468,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -501,7 +484,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -518,7 +500,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -535,7 +516,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -552,7 +532,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -569,7 +548,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -586,7 +564,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -603,7 +580,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -620,7 +596,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -637,7 +612,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1805,7 +1779,6 @@
       "version": "0.27.4",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.4.tgz",
       "integrity": "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -1894,7 +1867,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -1921,7 +1893,6 @@
       "version": "4.13.6",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
       "integrity": "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "resolve-pkg-maps": "^1.0.0"
@@ -2552,7 +2523,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
       "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
@@ -2838,7 +2808,6 @@
       "version": "4.21.0",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "~0.27.0",
@@ -3172,7 +3141,8 @@
       "version": "0.1.0",
       "dependencies": {
         "commander": "^13.0.0",
-        "ora": "^8.0.0"
+        "ora": "^8.0.0",
+        "tsx": "^4.0.0"
       },
       "bin": {
         "easyflow": "bin/easyflow.mjs"

--- a/packages/easyflow-cli/bin/easyflow.mjs
+++ b/packages/easyflow-cli/bin/easyflow.mjs
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+import "../src/cli/index.ts";

--- a/packages/easyflow-cli/bin/easyflow.mjs
+++ b/packages/easyflow-cli/bin/easyflow.mjs
@@ -1,2 +1,13 @@
-#!/usr/bin/env tsx
-import "../src/cli/index.ts";
+#!/usr/bin/env node
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const entry = join(__dirname, "..", "src", "cli", "index.ts");
+
+const child = spawn(process.execPath, ["--import", "tsx", entry, ...process.argv.slice(2)], {
+  stdio: "inherit",
+});
+
+child.on("exit", (code) => process.exit(code ?? 1));

--- a/packages/easyflow-cli/bin/easyflow.mjs
+++ b/packages/easyflow-cli/bin/easyflow.mjs
@@ -1,2 +1,2 @@
-#!/usr/bin/env node
+#!/usr/bin/env tsx
 import "../src/cli/index.ts";

--- a/packages/easyflow-cli/package.json
+++ b/packages/easyflow-cli/package.json
@@ -15,7 +15,8 @@
   },
   "dependencies": {
     "commander": "^13.0.0",
-    "ora": "^8.0.0"
+    "ora": "^8.0.0",
+    "tsx": "^4.0.0"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/packages/easyflow-cli/package.json
+++ b/packages/easyflow-cli/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@easy-flow/easyflow-cli",
+  "version": "0.1.0",
+  "private": true,
+  "description": "AI エージェントのビルド・配布・デプロイ CLI",
+  "type": "module",
+  "exports": {
+    ".": "./src/cli/index.ts"
+  },
+  "bin": {
+    "easyflow": "./bin/easyflow.mjs"
+  },
+  "scripts": {
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "commander": "^13.0.0",
+    "ora": "^8.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "vitest": "^3.0.0"
+  }
+}

--- a/packages/easyflow-cli/src/cli/commands/config.ts
+++ b/packages/easyflow-cli/src/cli/commands/config.ts
@@ -1,0 +1,37 @@
+import type { Command } from "commander";
+import { ConfigManager } from "../../config/manager.js";
+import { handleError } from "../../utils/errors.js";
+
+export function registerConfigCommand(program: Command): void {
+  const config = program.command("config").description("設定の取得・変更");
+
+  config
+    .command("get <key>")
+    .description("設定値を取得")
+    .action(async (key: string) => {
+      try {
+        const manager = new ConfigManager();
+        const value = await manager.get(key);
+        if (value === undefined) {
+          console.log(`(未設定)`);
+        } else {
+          console.log(value);
+        }
+      } catch (error) {
+        handleError(error);
+      }
+    });
+
+  config
+    .command("set <key> <value>")
+    .description("設定値を変更")
+    .action(async (key: string, value: string) => {
+      try {
+        const manager = new ConfigManager();
+        await manager.set(key, value);
+        console.log(`${key} = ${value}`);
+      } catch (error) {
+        handleError(error);
+      }
+    });
+}

--- a/packages/easyflow-cli/src/cli/commands/config.ts
+++ b/packages/easyflow-cli/src/cli/commands/config.ts
@@ -25,9 +25,9 @@ export function registerConfigCommand(program: Command): void {
   config
     .command("set <key> <value>")
     .description("設定値を変更（FQDN はブラケット記法: auth[ghcr.io].token）")
-    .action(async (key: string, value: string, _opts: unknown, cmd: Command) => {
+    .action(async (key: string, value: string) => {
       try {
-        const dryRun = cmd.optsWithGlobals().dryRun === true;
+        const dryRun = program.opts().dryRun === true;
         if (dryRun) {
           console.log(`[dry-run] ${key} = ${value}`);
           return;

--- a/packages/easyflow-cli/src/cli/commands/config.ts
+++ b/packages/easyflow-cli/src/cli/commands/config.ts
@@ -7,7 +7,7 @@ export function registerConfigCommand(program: Command): void {
 
   config
     .command("get <key>")
-    .description("設定値を取得")
+    .description("設定値を取得（FQDN はブラケット記法: auth[ghcr.io].token）")
     .action(async (key: string) => {
       try {
         const manager = new ConfigManager();
@@ -24,7 +24,7 @@ export function registerConfigCommand(program: Command): void {
 
   config
     .command("set <key> <value>")
-    .description("設定値を変更")
+    .description("設定値を変更（FQDN はブラケット記法: auth[ghcr.io].token）")
     .action(async (key: string, value: string) => {
       try {
         const manager = new ConfigManager();

--- a/packages/easyflow-cli/src/cli/commands/config.ts
+++ b/packages/easyflow-cli/src/cli/commands/config.ts
@@ -25,8 +25,13 @@ export function registerConfigCommand(program: Command): void {
   config
     .command("set <key> <value>")
     .description("設定値を変更（FQDN はブラケット記法: auth[ghcr.io].token）")
-    .action(async (key: string, value: string) => {
+    .action(async (key: string, value: string, _opts: unknown, cmd: Command) => {
       try {
+        const dryRun = cmd.optsWithGlobals().dryRun === true;
+        if (dryRun) {
+          console.log(`[dry-run] ${key} = ${value}`);
+          return;
+        }
         const manager = new ConfigManager();
         await manager.set(key, value);
         console.log(`${key} = ${value}`);

--- a/packages/easyflow-cli/src/cli/commands/images.ts
+++ b/packages/easyflow-cli/src/cli/commands/images.ts
@@ -1,0 +1,72 @@
+import type { Command } from "commander";
+import { ImageStore } from "../../store/image-store.js";
+import { handleError } from "../../utils/errors.js";
+
+export function registerImagesCommand(program: Command): void {
+  const images = program
+    .command("images")
+    .description("ローカルイメージの管理")
+    .action(async () => {
+      try {
+        const store = new ImageStore();
+        const list = await store.list();
+
+        if (list.length === 0) {
+          console.log("ローカルイメージはありません。");
+          return;
+        }
+
+        // Table format
+        console.log(`${"REF".padEnd(40)} ${"DIGEST".padEnd(20)} ${"SIZE".padEnd(10)} CREATED`);
+        for (const img of list) {
+          const shortDigest = img.digest.slice(0, 19);
+          const sizeStr = formatBytes(img.size);
+          const created = img.createdAt.slice(0, 10);
+          console.log(
+            `${img.ref.padEnd(40)} ${shortDigest.padEnd(20)} ${sizeStr.padEnd(10)} ${created}`,
+          );
+        }
+      } catch (error) {
+        handleError(error);
+      }
+    });
+
+  images
+    .command("rm <ref>")
+    .description("イメージを削除")
+    .action(async (ref: string) => {
+      try {
+        const store = new ImageStore();
+        const removed = await store.remove(ref);
+        if (removed) {
+          console.log(`削除しました: ${ref}`);
+        } else {
+          console.error(`イメージが見つかりません: ${ref}`);
+          process.exit(1);
+        }
+      } catch (error) {
+        handleError(error);
+      }
+    });
+
+  images
+    .command("prune")
+    .description("未使用イメージを削除")
+    .action(async () => {
+      try {
+        const store = new ImageStore();
+        const result = await store.prune();
+        console.log(`${result.removed} 件削除しました (${formatBytes(result.freedBytes)} 解放)`);
+      } catch (error) {
+        handleError(error);
+      }
+    });
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes === 0) return "0 B";
+  const units = ["B", "KB", "MB", "GB"];
+  const i = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1);
+  const value = bytes / 1024 ** i;
+  return `${value.toFixed(i === 0 ? 0 : 1)} ${units[i]}`;
+}

--- a/packages/easyflow-cli/src/cli/commands/images.ts
+++ b/packages/easyflow-cli/src/cli/commands/images.ts
@@ -1,5 +1,6 @@
 import type { Command } from "commander";
 import { ImageStore } from "../../store/image-store.js";
+
 import { handleError } from "../../utils/errors.js";
 
 export function registerImagesCommand(program: Command): void {
@@ -34,9 +35,9 @@ export function registerImagesCommand(program: Command): void {
   images
     .command("rm <ref>")
     .description("イメージを削除")
-    .action(async (ref: string, _opts: unknown, cmd: Command) => {
+    .action(async (ref: string) => {
       try {
-        const dryRun = cmd.optsWithGlobals().dryRun === true;
+        const dryRun = program.opts().dryRun === true;
         if (dryRun) {
           console.log(`[dry-run] 削除対象: ${ref}`);
           return;
@@ -57,9 +58,9 @@ export function registerImagesCommand(program: Command): void {
   images
     .command("prune")
     .description("未使用イメージを削除")
-    .action(async (_opts: unknown, cmd: Command) => {
+    .action(async () => {
       try {
-        const dryRun = cmd.optsWithGlobals().dryRun === true;
+        const dryRun = program.opts().dryRun === true;
         if (dryRun) {
           console.log("[dry-run] prune をスキップしました");
           return;

--- a/packages/easyflow-cli/src/cli/commands/images.ts
+++ b/packages/easyflow-cli/src/cli/commands/images.ts
@@ -34,8 +34,13 @@ export function registerImagesCommand(program: Command): void {
   images
     .command("rm <ref>")
     .description("イメージを削除")
-    .action(async (ref: string) => {
+    .action(async (ref: string, _opts: unknown, cmd: Command) => {
       try {
+        const dryRun = cmd.optsWithGlobals().dryRun === true;
+        if (dryRun) {
+          console.log(`[dry-run] 削除対象: ${ref}`);
+          return;
+        }
         const store = new ImageStore();
         const removed = await store.remove(ref);
         if (removed) {
@@ -52,8 +57,13 @@ export function registerImagesCommand(program: Command): void {
   images
     .command("prune")
     .description("未使用イメージを削除")
-    .action(async () => {
+    .action(async (_opts: unknown, cmd: Command) => {
       try {
+        const dryRun = cmd.optsWithGlobals().dryRun === true;
+        if (dryRun) {
+          console.log("[dry-run] prune をスキップしました");
+          return;
+        }
         const store = new ImageStore();
         const result = await store.prune();
         console.log(`${result.removed} 件削除しました (${formatBytes(result.freedBytes)} 解放)`);

--- a/packages/easyflow-cli/src/cli/commands/index.ts
+++ b/packages/easyflow-cli/src/cli/commands/index.ts
@@ -1,0 +1,2 @@
+export { registerConfigCommand } from "./config.js";
+export { registerImagesCommand } from "./images.js";

--- a/packages/easyflow-cli/src/cli/index.ts
+++ b/packages/easyflow-cli/src/cli/index.ts
@@ -1,0 +1,43 @@
+import { Command } from "commander";
+import { registerConfigCommand } from "./commands/config.js";
+import { registerImagesCommand } from "./commands/images.js";
+
+const program = new Command();
+
+program
+  .name("easyflow")
+  .description("AI エージェントのビルド・配布・デプロイ CLI")
+  .version("0.1.0");
+
+// グローバルオプション
+program
+  .option("--verbose", "詳細ログを出力", false)
+  .option("--dry-run", "実行せずにプレビュー", false)
+  .option("--no-color", "カラー出力を無効化");
+
+// コマンド登録
+registerConfigCommand(program);
+registerImagesCommand(program);
+
+// 後続タスクで追加するコマンドのスタブ
+const stubCommands = [
+  "build",
+  "deploy",
+  "validate",
+  "inspect",
+  "push",
+  "pull",
+  "convert",
+  "knowledge",
+];
+for (const name of stubCommands) {
+  program
+    .command(name)
+    .description(`(未実装 — Task 1.3+ で追加)`)
+    .action(() => {
+      console.error(`easyflow ${name} は現在未実装です。`);
+      process.exit(1);
+    });
+}
+
+program.parse();

--- a/packages/easyflow-cli/src/cli/index.ts
+++ b/packages/easyflow-cli/src/cli/index.ts
@@ -1,6 +1,5 @@
 import { Command } from "commander";
-import { registerConfigCommand } from "./commands/config.js";
-import { registerImagesCommand } from "./commands/images.js";
+import { registerConfigCommand, registerImagesCommand } from "./commands/index.js";
 
 const program = new Command();
 

--- a/packages/easyflow-cli/src/config/manager.ts
+++ b/packages/easyflow-cli/src/config/manager.ts
@@ -41,6 +41,7 @@ export class ConfigManager {
       encoding: "utf-8",
       mode: 0o600,
     });
+    await fs.chmod(this.configPath, 0o600);
   }
 
   /**
@@ -69,6 +70,7 @@ export class ConfigManager {
 
   async ensureConfigDir(): Promise<void> {
     await fs.mkdir(this.configDir, { recursive: true, mode: 0o700 });
+    await fs.chmod(this.configDir, 0o700);
   }
 }
 

--- a/packages/easyflow-cli/src/config/manager.ts
+++ b/packages/easyflow-cli/src/config/manager.ts
@@ -37,7 +37,10 @@ export class ConfigManager {
 
   async save(config: EasyflowConfig): Promise<void> {
     await this.ensureConfigDir();
-    await fs.writeFile(this.configPath, JSON.stringify(config, null, 2), "utf-8");
+    await fs.writeFile(this.configPath, JSON.stringify(config, null, 2), {
+      encoding: "utf-8",
+      mode: 0o600,
+    });
   }
 
   /**
@@ -65,7 +68,7 @@ export class ConfigManager {
   }
 
   async ensureConfigDir(): Promise<void> {
-    await fs.mkdir(this.configDir, { recursive: true });
+    await fs.mkdir(this.configDir, { recursive: true, mode: 0o700 });
   }
 }
 

--- a/packages/easyflow-cli/src/config/manager.ts
+++ b/packages/easyflow-cli/src/config/manager.ts
@@ -117,8 +117,19 @@ function getNestedValue(obj: Record<string, unknown>, key: string): unknown {
   return current;
 }
 
+const DANGEROUS_KEYS = new Set(["__proto__", "constructor", "prototype"]);
+
+function validateKeySegments(parts: string[]): void {
+  for (const part of parts) {
+    if (DANGEROUS_KEYS.has(part)) {
+      throw new Error(`Dangerous config key segment: "${part}"`);
+    }
+  }
+}
+
 function setNestedValue(obj: Record<string, unknown>, key: string, value: string): void {
   const parts = parseKeyPath(key);
+  validateKeySegments(parts);
   let current: Record<string, unknown> = obj;
   for (let i = 0; i < parts.length - 1; i++) {
     const part = parts[i];

--- a/packages/easyflow-cli/src/config/manager.ts
+++ b/packages/easyflow-cli/src/config/manager.ts
@@ -67,8 +67,6 @@ function isNodeError(error: unknown): error is NodeJS.ErrnoException {
  *   "auth[ghcr.io].token"       → ["auth", "ghcr.io", "token"]
  *   "auth.local.token"          → ["auth", "local", "token"]
  */
-const DANGEROUS_KEYS = new Set(["__proto__", "constructor", "prototype"]);
-
 function parseKeyPath(key: string): string[] {
   const parts: string[] = [];
   let i = 0;
@@ -105,14 +103,6 @@ function parseKeyPath(key: string): string[] {
     }
   }
   return parts;
-}
-
-function validateKeySegments(parts: string[]): void {
-  for (const part of parts) {
-    if (DANGEROUS_KEYS.has(part)) {
-      throw new Error(`不正な設定キー: "${part}" は使用できません`);
-    }
-  }
 }
 
 function getNestedValue(obj: Record<string, unknown>, key: string): unknown {

--- a/packages/easyflow-cli/src/config/manager.ts
+++ b/packages/easyflow-cli/src/config/manager.ts
@@ -52,7 +52,7 @@ export class ConfigManager {
   async get(key: string): Promise<string | undefined> {
     validateFqdnKeyFormat(key);
     const config = await this.load();
-    const value = getNestedValue(config, key);
+    const value = getNestedValue(config as unknown as Record<string, unknown>, key);
     if (value === undefined || value === null) {
       return undefined;
     }
@@ -66,7 +66,7 @@ export class ConfigManager {
   async set(key: string, value: string): Promise<void> {
     validateFqdnKeyFormat(key);
     const config = await this.load();
-    setNestedValue(config, key, value);
+    setNestedValue(config as unknown as Record<string, unknown>, key, value);
     await this.save(config);
   }
 

--- a/packages/easyflow-cli/src/config/manager.ts
+++ b/packages/easyflow-cli/src/config/manager.ts
@@ -14,6 +14,10 @@ export class ConfigManager {
     this.configPath = path.join(this.configDir, "config.json");
   }
 
+  /**
+   * 設定ファイルを読み込む。ファイルが存在しない場合のみデフォルトを返す。
+   * JSON parse error や権限エラーはそのまま throw する。
+   */
   async load(): Promise<EasyflowConfig> {
     let raw: string;
     try {
@@ -32,6 +36,11 @@ export class ConfigManager {
     await fs.writeFile(this.configPath, JSON.stringify(config, null, 2), "utf-8");
   }
 
+  /**
+   * ドット区切りまたはブラケット記法でネストキーの値を取得する。
+   * FQDN を含むキーにはブラケット記法を使用すること。
+   * 例: `auth[ghcr.io].token` (✓)  `auth.ghcr.io.token` (✗ — ドットで分割される)
+   */
   async get(key: string): Promise<string | undefined> {
     const config = await this.load();
     const value = getNestedValue(config, key);
@@ -44,6 +53,7 @@ export class ConfigManager {
     return String(value);
   }
 
+  /** @see {@link get} — FQDN を含むキーにはブラケット記法を使用すること */
   async set(key: string, value: string): Promise<void> {
     const config = await this.load();
     setNestedValue(config, key, value);

--- a/packages/easyflow-cli/src/config/manager.ts
+++ b/packages/easyflow-cli/src/config/manager.ts
@@ -23,11 +23,15 @@ export class ConfigManager {
     try {
       raw = await fs.readFile(this.configPath, "utf-8");
     } catch (error: unknown) {
+      // ファイルが存在しない場合のみデフォルトにフォールバックする。
+      // 権限エラー等は throw する。
       if (isNodeError(error) && error.code === "ENOENT") {
         return structuredClone(DEFAULT_CONFIG);
       }
       throw error;
     }
+    // JSON parse error は try-catch の外なのでそのまま利用者に返る。
+    // テスト: "壊れた config.json → JSON parse error をそのまま投げる"
     return JSON.parse(raw) as EasyflowConfig;
   }
 

--- a/packages/easyflow-cli/src/config/manager.ts
+++ b/packages/easyflow-cli/src/config/manager.ts
@@ -15,12 +15,16 @@ export class ConfigManager {
   }
 
   async load(): Promise<EasyflowConfig> {
+    let raw: string;
     try {
-      const raw = await fs.readFile(this.configPath, "utf-8");
-      return JSON.parse(raw) as EasyflowConfig;
-    } catch {
-      return structuredClone(DEFAULT_CONFIG);
+      raw = await fs.readFile(this.configPath, "utf-8");
+    } catch (error: unknown) {
+      if (isNodeError(error) && error.code === "ENOENT") {
+        return structuredClone(DEFAULT_CONFIG);
+      }
+      throw error;
     }
+    return JSON.parse(raw) as EasyflowConfig;
   }
 
   async save(config: EasyflowConfig): Promise<void> {
@@ -51,13 +55,58 @@ export class ConfigManager {
   }
 }
 
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && "code" in error;
+}
+
 /**
- * ドット記法でネストされた値を取得する。
- * 注意: キー自体にドットを含む場合（例: "ghcr.io"）は区切り文字と区別できない。
- * Phase 1 の制限事項として、FQDN をキーに使う場合は構造を工夫する必要がある。
+ * キー文字列をパスセグメントに分解する。
+ * ブラケット記法をサポートし、キー内のドットを保護する。
+ * 例:
+ *   "registry"                  → ["registry"]
+ *   "auth[ghcr.io].token"       → ["auth", "ghcr.io", "token"]
+ *   "auth.local.token"          → ["auth", "local", "token"]
  */
+function parseKeyPath(key: string): string[] {
+  const parts: string[] = [];
+  let i = 0;
+  while (i < key.length) {
+    if (key[i] === "[") {
+      const close = key.indexOf("]", i + 1);
+      if (close === -1) {
+        parts.push(key.slice(i));
+        break;
+      }
+      parts.push(key.slice(i + 1, close));
+      i = close + 1;
+      if (i < key.length && key[i] === ".") {
+        i++;
+      }
+    } else {
+      const dot = key.indexOf(".", i);
+      const bracket = key.indexOf("[", i);
+      let end: number;
+      if (dot === -1 && bracket === -1) {
+        end = key.length;
+      } else if (dot === -1) {
+        end = bracket;
+      } else if (bracket === -1) {
+        end = dot;
+      } else {
+        end = Math.min(dot, bracket);
+      }
+      parts.push(key.slice(i, end));
+      i = end;
+      if (i < key.length && key[i] === ".") {
+        i++;
+      }
+    }
+  }
+  return parts;
+}
+
 function getNestedValue(obj: Record<string, unknown>, key: string): unknown {
-  const parts = key.split(".");
+  const parts = parseKeyPath(key);
   let current: unknown = obj;
   for (const part of parts) {
     if (current === null || current === undefined || typeof current !== "object") {
@@ -69,7 +118,7 @@ function getNestedValue(obj: Record<string, unknown>, key: string): unknown {
 }
 
 function setNestedValue(obj: Record<string, unknown>, key: string, value: string): void {
-  const parts = key.split(".");
+  const parts = parseKeyPath(key);
   let current: Record<string, unknown> = obj;
   for (let i = 0; i < parts.length - 1; i++) {
     const part = parts[i];

--- a/packages/easyflow-cli/src/config/manager.ts
+++ b/packages/easyflow-cli/src/config/manager.ts
@@ -67,6 +67,8 @@ function isNodeError(error: unknown): error is NodeJS.ErrnoException {
  *   "auth[ghcr.io].token"       → ["auth", "ghcr.io", "token"]
  *   "auth.local.token"          → ["auth", "local", "token"]
  */
+const DANGEROUS_KEYS = new Set(["__proto__", "constructor", "prototype"]);
+
 function parseKeyPath(key: string): string[] {
   const parts: string[] = [];
   let i = 0;
@@ -105,8 +107,17 @@ function parseKeyPath(key: string): string[] {
   return parts;
 }
 
+function validateKeySegments(parts: string[]): void {
+  for (const part of parts) {
+    if (DANGEROUS_KEYS.has(part)) {
+      throw new Error(`不正な設定キー: "${part}" は使用できません`);
+    }
+  }
+}
+
 function getNestedValue(obj: Record<string, unknown>, key: string): unknown {
   const parts = parseKeyPath(key);
+  validateKeySegments(parts);
   let current: unknown = obj;
   for (const part of parts) {
     if (current === null || current === undefined || typeof current !== "object") {

--- a/packages/easyflow-cli/src/config/manager.ts
+++ b/packages/easyflow-cli/src/config/manager.ts
@@ -9,7 +9,8 @@ export class ConfigManager {
   private configDir: string;
 
   constructor(configDir?: string) {
-    this.configDir = configDir ?? path.join(os.homedir(), ".easyflow");
+    this.configDir =
+      configDir ?? process.env.EASYFLOW_CONFIG_DIR ?? path.join(os.homedir(), ".easyflow");
     this.configPath = path.join(this.configDir, "config.json");
   }
 
@@ -50,6 +51,11 @@ export class ConfigManager {
   }
 }
 
+/**
+ * ドット記法でネストされた値を取得する。
+ * 注意: キー自体にドットを含む場合（例: "ghcr.io"）は区切り文字と区別できない。
+ * Phase 1 の制限事項として、FQDN をキーに使う場合は構造を工夫する必要がある。
+ */
 function getNestedValue(obj: Record<string, unknown>, key: string): unknown {
   const parts = key.split(".");
   let current: unknown = obj;

--- a/packages/easyflow-cli/src/config/manager.ts
+++ b/packages/easyflow-cli/src/config/manager.ts
@@ -1,0 +1,80 @@
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { EasyflowConfig } from "./types.js";
+import { DEFAULT_CONFIG } from "./types.js";
+
+export class ConfigManager {
+  private configPath: string;
+  private configDir: string;
+
+  constructor(configDir?: string) {
+    this.configDir = configDir ?? path.join(os.homedir(), ".easyflow");
+    this.configPath = path.join(this.configDir, "config.json");
+  }
+
+  async load(): Promise<EasyflowConfig> {
+    try {
+      const raw = await fs.readFile(this.configPath, "utf-8");
+      return JSON.parse(raw) as EasyflowConfig;
+    } catch {
+      return structuredClone(DEFAULT_CONFIG);
+    }
+  }
+
+  async save(config: EasyflowConfig): Promise<void> {
+    await this.ensureConfigDir();
+    await fs.writeFile(this.configPath, JSON.stringify(config, null, 2), "utf-8");
+  }
+
+  async get(key: string): Promise<string | undefined> {
+    const config = await this.load();
+    const value = getNestedValue(config, key);
+    if (value === undefined || value === null) {
+      return undefined;
+    }
+    if (typeof value === "object") {
+      return JSON.stringify(value);
+    }
+    return String(value);
+  }
+
+  async set(key: string, value: string): Promise<void> {
+    const config = await this.load();
+    setNestedValue(config, key, value);
+    await this.save(config);
+  }
+
+  async ensureConfigDir(): Promise<void> {
+    await fs.mkdir(this.configDir, { recursive: true });
+  }
+}
+
+function getNestedValue(obj: Record<string, unknown>, key: string): unknown {
+  const parts = key.split(".");
+  let current: unknown = obj;
+  for (const part of parts) {
+    if (current === null || current === undefined || typeof current !== "object") {
+      return undefined;
+    }
+    current = (current as Record<string, unknown>)[part];
+  }
+  return current;
+}
+
+function setNestedValue(obj: Record<string, unknown>, key: string, value: string): void {
+  const parts = key.split(".");
+  let current: Record<string, unknown> = obj;
+  for (let i = 0; i < parts.length - 1; i++) {
+    const part = parts[i];
+    if (
+      current[part] === undefined ||
+      current[part] === null ||
+      typeof current[part] !== "object"
+    ) {
+      current[part] = {};
+    }
+    current = current[part] as Record<string, unknown>;
+  }
+  current[parts[parts.length - 1]] = value;
+}

--- a/packages/easyflow-cli/src/config/manager.ts
+++ b/packages/easyflow-cli/src/config/manager.ts
@@ -50,6 +50,7 @@ export class ConfigManager {
    * 例: `auth[ghcr.io].token` (✓)  `auth.ghcr.io.token` (✗ — ドットで分割される)
    */
   async get(key: string): Promise<string | undefined> {
+    validateFqdnKeyFormat(key);
     const config = await this.load();
     const value = getNestedValue(config, key);
     if (value === undefined || value === null) {
@@ -63,6 +64,7 @@ export class ConfigManager {
 
   /** @see {@link get} — FQDN を含むキーにはブラケット記法を使用すること */
   async set(key: string, value: string): Promise<void> {
+    validateFqdnKeyFormat(key);
     const config = await this.load();
     setNestedValue(config, key, value);
     await this.save(config);
@@ -71,6 +73,18 @@ export class ConfigManager {
   async ensureConfigDir(): Promise<void> {
     await fs.mkdir(this.configDir, { recursive: true, mode: 0o700 });
     await fs.chmod(this.configDir, 0o700);
+  }
+}
+
+/** auth キーの FQDN にドット記法が使われている場合を拒否する */
+const FQDN_RECORD_KEYS = new Set(["auth"]);
+
+function validateFqdnKeyFormat(key: string): void {
+  const parts = parseKeyPath(key);
+  if (parts.length >= 2 && FQDN_RECORD_KEYS.has(parts[0]) && !key.includes("[")) {
+    throw new Error(
+      `"${key}" — FQDN を含むキーにはブラケット記法を使用してください (例: auth[ghcr.io].token)`,
+    );
   }
 }
 

--- a/packages/easyflow-cli/src/config/types.ts
+++ b/packages/easyflow-cli/src/config/types.ts
@@ -1,0 +1,14 @@
+export interface EasyflowConfig {
+  registry: string;
+  auth: Record<string, AuthEntry>;
+}
+
+export interface AuthEntry {
+  token: string;
+  expiresAt?: string; // ISO 8601
+}
+
+export const DEFAULT_CONFIG: EasyflowConfig = {
+  registry: "ghcr.io",
+  auth: {},
+};

--- a/packages/easyflow-cli/src/store/image-store.ts
+++ b/packages/easyflow-cli/src/store/image-store.ts
@@ -6,8 +6,8 @@ import type { ImageData, ImageMetadata, StoredImage } from "./types.js";
 
 /** ref ツリーのルートディレクトリ名。digest ディレクトリ (sha256-*) との衝突を回避する。 */
 const REFS_DIR = "refs";
-/** org なし ref を保存する際の sentinel ディレクトリ名 */
-const NO_ORG_SENTINEL = "_noorg";
+/** org なし ref を保存する際の sentinel ディレクトリ名。validateRef が許可しない文字を含み、ユーザー ref と衝突しない。 */
+const NO_ORG_SENTINEL = "~noorg";
 
 export class ImageStore {
   private storeDir: string;

--- a/packages/easyflow-cli/src/store/image-store.ts
+++ b/packages/easyflow-cli/src/store/image-store.ts
@@ -271,9 +271,16 @@ export class ImageStore {
         throw new Error(`Invalid ref: "${ref}" — path traversal segments are not allowed`);
       }
     }
+    // nameWithOrg の各パスセグメントが空でないことを検証（org//name 等を拒否）
+    const nameWithOrg = ref.split(":")[0];
+    const allSegments = nameWithOrg.split("/");
+    for (const seg of allSegments) {
+      if (seg === "" || seg === "." || seg === "..") {
+        throw new Error(`Invalid ref: "${ref}" — empty or traversal path segment`);
+      }
+    }
     // org/name は英数字、ハイフン、アンダースコア、ドット、スラッシュのみ許可
     const namePattern = /^[a-zA-Z0-9./_-]+$/;
-    const nameWithOrg = ref.split(":")[0];
     if (!namePattern.test(nameWithOrg)) {
       throw new Error(`Invalid ref: "${ref}" — contains disallowed characters`);
     }

--- a/packages/easyflow-cli/src/store/image-store.ts
+++ b/packages/easyflow-cli/src/store/image-store.ts
@@ -13,6 +13,11 @@ export class ImageStore {
   }
 
   async save(ref: string, data: ImageData): Promise<StoredImage> {
+    ImageStore.validateRef(ref);
+    for (const layerName of data.layers.keys()) {
+      ImageStore.validateLayerName(layerName);
+    }
+
     await fs.mkdir(this.storeDir, { recursive: true });
 
     const digest = ImageStore.computeDigest(this.serializeImageData(data));
@@ -61,6 +66,7 @@ export class ImageStore {
   }
 
   async load(ref: string): Promise<ImageData | null> {
+    ImageStore.validateRef(ref);
     const { org, name, tag } = ImageStore.parseRef(ref);
     const tagDir = path.join(this.storeDir, org, name, tag);
 
@@ -88,6 +94,7 @@ export class ImageStore {
   }
 
   async remove(ref: string): Promise<boolean> {
+    ImageStore.validateRef(ref);
     const { org, name, tag } = ImageStore.parseRef(ref);
     const tagDir = path.join(this.storeDir, org, name, tag);
 
@@ -228,6 +235,32 @@ export class ImageStore {
       name.includes("..")
     ) {
       throw new Error(`Invalid layer name: "${name}"`);
+    }
+  }
+
+  /** ref の各セグメントがストアパス外にトラバーサルしないことを検証する */
+  static validateRef(ref: string): void {
+    const { org, name, tag } = ImageStore.parseRef(ref);
+    for (const segment of [org, name, tag]) {
+      if (segment === "" || segment === "." || segment === ".." || segment.includes("/..")) {
+        throw new Error(`不正な ref: "${ref}" — パストラバーサルを含むセグメントは許可されません`);
+      }
+    }
+    // 正規化後もストアパス配下に収まることを保証するため、
+    // 各セグメントは英数字、ハイフン、アンダースコア、ドット、スラッシュのみ許可
+    const safePattern = /^[a-zA-Z0-9._\-/]+$/;
+    const nameWithOrg = ref.split(":")[0];
+    if (!safePattern.test(nameWithOrg) || (tag && !safePattern.test(tag))) {
+      throw new Error(`不正な ref: "${ref}" — 許可されていない文字が含まれています`);
+    }
+  }
+
+  /** layer 名がレイヤーディレクトリ外にトラバーサルしないことを検証する */
+  static validateLayerName(name: string): void {
+    if (name === "" || name === "." || name === ".." || name.includes("/") || name.includes("\\")) {
+      throw new Error(
+        `不正な layer 名: "${name}" — ファイル名のみ許可されます（パス区切りは不可）`,
+      );
     }
   }
 

--- a/packages/easyflow-cli/src/store/image-store.ts
+++ b/packages/easyflow-cli/src/store/image-store.ts
@@ -225,25 +225,12 @@ export class ImageStore {
     }
   }
 
-  private static validateLayerName(name: string): void {
-    if (
-      !name ||
-      name.includes("/") ||
-      name.includes("\\") ||
-      name === "." ||
-      name === ".." ||
-      name.includes("..")
-    ) {
-      throw new Error(`Invalid layer name: "${name}"`);
-    }
-  }
-
   /** ref の各セグメントがストアパス外にトラバーサルしないことを検証する */
   static validateRef(ref: string): void {
     const { org, name, tag } = ImageStore.parseRef(ref);
     for (const segment of [org, name, tag]) {
       if (segment === "" || segment === "." || segment === ".." || segment.includes("/..")) {
-        throw new Error(`不正な ref: "${ref}" — パストラバーサルを含むセグメントは許可されません`);
+        throw new Error(`Invalid ref: "${ref}" — path traversal segments are not allowed`);
       }
     }
     // 正規化後もストアパス配下に収まることを保証するため、
@@ -251,16 +238,14 @@ export class ImageStore {
     const safePattern = /^[a-zA-Z0-9._\-/]+$/;
     const nameWithOrg = ref.split(":")[0];
     if (!safePattern.test(nameWithOrg) || (tag && !safePattern.test(tag))) {
-      throw new Error(`不正な ref: "${ref}" — 許可されていない文字が含まれています`);
+      throw new Error(`Invalid ref: "${ref}" — contains disallowed characters`);
     }
   }
 
   /** layer 名がレイヤーディレクトリ外にトラバーサルしないことを検証する */
   static validateLayerName(name: string): void {
     if (name === "" || name === "." || name === ".." || name.includes("/") || name.includes("\\")) {
-      throw new Error(
-        `不正な layer 名: "${name}" — ファイル名のみ許可されます（パス区切りは不可）`,
-      );
+      throw new Error(`Invalid layer name: "${name}"`);
     }
   }
 

--- a/packages/easyflow-cli/src/store/image-store.ts
+++ b/packages/easyflow-cli/src/store/image-store.ts
@@ -224,15 +224,15 @@ export class ImageStore {
       }
     }
     // org/name は英数字、ハイフン、アンダースコア、ドット、スラッシュのみ許可
-    const namePattern = /^[a-zA-Z0-9._\-/]+$/;
+    const namePattern = /^[a-zA-Z0-9./_-]+$/;
     const nameWithOrg = ref.split(":")[0];
     if (!namePattern.test(nameWithOrg)) {
       throw new Error(`Invalid ref: "${ref}" — contains disallowed characters`);
     }
     // tag はスラッシュ不可（ディレクトリ階層と混同されるため）
-    const tagPattern = /^[a-zA-Z0-9._\-]+$/;
+    const tagPattern = /^[a-zA-Z0-9._-]+$/;
     if (tag && !tagPattern.test(tag)) {
-      throw new Error(`Invalid ref: "${ref}" — tag must not contain "/""`);
+      throw new Error(`Invalid ref: "${ref}" — tag must not contain "/"`);
     }
   }
 

--- a/packages/easyflow-cli/src/store/image-store.ts
+++ b/packages/easyflow-cli/src/store/image-store.ts
@@ -49,7 +49,7 @@ export class ImageStore {
     }
 
     const { org, name, tag } = ImageStore.parseRef(ref);
-    const tagDir = path.join(this.refsDir, org, name, tag);
+    const tagDir = path.join(this.refsDir, org, name, "tags", tag);
     await fs.mkdir(path.dirname(tagDir), { recursive: true });
 
     // Remove existing symlink if present
@@ -79,7 +79,7 @@ export class ImageStore {
   async load(ref: string): Promise<ImageData | null> {
     ImageStore.validateRef(ref);
     const { org, name, tag } = ImageStore.parseRef(ref);
-    const tagDir = path.join(this.refsDir, org, name, tag);
+    const tagDir = path.join(this.refsDir, org, name, "tags", tag);
 
     try {
       const realDir = await fs.realpath(tagDir);
@@ -110,7 +110,7 @@ export class ImageStore {
   async remove(ref: string): Promise<boolean> {
     ImageStore.validateRef(ref);
     const { org, name, tag } = ImageStore.parseRef(ref);
-    const tagDir = path.join(this.refsDir, org, name, tag);
+    const tagDir = path.join(this.refsDir, org, name, "tags", tag);
 
     try {
       const realDir = await fs.realpath(tagDir);
@@ -193,7 +193,7 @@ export class ImageStore {
   }
 
   private buildRef(pathSegments: string[], tag: string): string {
-    const filtered = pathSegments.filter((s) => s !== NO_ORG_SENTINEL);
+    const filtered = pathSegments.filter((s) => s !== NO_ORG_SENTINEL && s !== "tags");
     const nameWithOrg = filtered.join("/");
     return `${nameWithOrg}:${tag}`;
   }

--- a/packages/easyflow-cli/src/store/image-store.ts
+++ b/packages/easyflow-cli/src/store/image-store.ts
@@ -1,4 +1,5 @@
 import * as crypto from "node:crypto";
+import type { Dirent } from "node:fs";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -368,7 +369,7 @@ export class ImageStore {
   }
 
   private async findSymlinksRecursive(dir: string, targetDir: string): Promise<boolean> {
-    let entries: Awaited<ReturnType<typeof fs.readdir<{ withFileTypes: true }>>>;
+    let entries: Dirent[];
     try {
       entries = await fs.readdir(dir, { withFileTypes: true });
     } catch {

--- a/packages/easyflow-cli/src/store/image-store.ts
+++ b/packages/easyflow-cli/src/store/image-store.ts
@@ -255,7 +255,8 @@ export class ImageStore {
       return false;
     }
     const relative = normalized.slice(storePrefix.length);
-    return relative.startsWith("sha256-");
+    // store 直下の sha256-* ディレクトリそのものであること（サブディレクトリは拒否）
+    return relative.startsWith("sha256-") && !relative.includes(path.sep);
   }
 
   /** ref の各セグメントがストアパス外にトラバーサルしないことを検証する */

--- a/packages/easyflow-cli/src/store/image-store.ts
+++ b/packages/easyflow-cli/src/store/image-store.ts
@@ -209,36 +209,30 @@ export class ImageStore {
   static parseRef(ref: string): { org: string; name: string; tag: string } {
     const [nameWithOrg, tag = "latest"] = ref.split(":");
     const parts = nameWithOrg.split("/");
-    const result =
-      parts.length < 2
-        ? { org: "_", name: parts[0], tag }
-        : { org: parts[0], name: parts.slice(1).join("/"), tag };
-    ImageStore.validatePathSegments(result.org, result.name, result.tag);
-    return result;
-  }
-
-  private static validatePathSegments(...segments: string[]): void {
-    for (const seg of segments) {
-      if (!seg || seg === "." || seg === ".." || seg.includes("..") || path.isAbsolute(seg)) {
-        throw new Error(`Invalid ref segment: "${seg}"`);
-      }
+    if (parts.length < 2) {
+      return { org: "_", name: parts[0], tag };
     }
+    return { org: parts[0], name: parts.slice(1).join("/"), tag };
   }
 
   /** ref の各セグメントがストアパス外にトラバーサルしないことを検証する */
   static validateRef(ref: string): void {
     const { org, name, tag } = ImageStore.parseRef(ref);
     for (const segment of [org, name, tag]) {
-      if (segment === "" || segment === "." || segment === ".." || segment.includes("/..")) {
+      if (segment === "" || segment === "." || segment === ".." || segment.includes("..")) {
         throw new Error(`Invalid ref: "${ref}" — path traversal segments are not allowed`);
       }
     }
-    // 正規化後もストアパス配下に収まることを保証するため、
-    // 各セグメントは英数字、ハイフン、アンダースコア、ドット、スラッシュのみ許可
-    const safePattern = /^[a-zA-Z0-9._\-/]+$/;
+    // org/name は英数字、ハイフン、アンダースコア、ドット、スラッシュのみ許可
+    const namePattern = /^[a-zA-Z0-9._\-/]+$/;
     const nameWithOrg = ref.split(":")[0];
-    if (!safePattern.test(nameWithOrg) || (tag && !safePattern.test(tag))) {
+    if (!namePattern.test(nameWithOrg)) {
       throw new Error(`Invalid ref: "${ref}" — contains disallowed characters`);
+    }
+    // tag はスラッシュ不可（ディレクトリ階層と混同されるため）
+    const tagPattern = /^[a-zA-Z0-9._\-]+$/;
+    if (tag && !tagPattern.test(tag)) {
+      throw new Error(`Invalid ref: "${ref}" — tag must not contain "/""`);
     }
   }
 

--- a/packages/easyflow-cli/src/store/image-store.ts
+++ b/packages/easyflow-cli/src/store/image-store.ts
@@ -284,11 +284,17 @@ export class ImageStore {
 
   private serializeImageData(data: ImageData): Buffer {
     const parts: Buffer[] = [];
-    parts.push(Buffer.from(JSON.stringify(data.manifest)));
-    parts.push(Buffer.from(JSON.stringify(data.config)));
+    const pushWithLength = (buf: Buffer): void => {
+      const len = Buffer.alloc(4);
+      len.writeUInt32BE(buf.length, 0);
+      parts.push(len);
+      parts.push(buf);
+    };
+    pushWithLength(Buffer.from(JSON.stringify(data.manifest)));
+    pushWithLength(Buffer.from(JSON.stringify(data.config)));
     for (const [key, value] of data.layers) {
-      parts.push(Buffer.from(key));
-      parts.push(value);
+      pushWithLength(Buffer.from(key));
+      pushWithLength(value);
     }
     return Buffer.concat(parts);
   }

--- a/packages/easyflow-cli/src/store/image-store.ts
+++ b/packages/easyflow-cli/src/store/image-store.ts
@@ -8,7 +8,8 @@ export class ImageStore {
   private storeDir: string;
 
   constructor(storeDir?: string) {
-    this.storeDir = storeDir ?? path.join(os.homedir(), ".easyflow", "images");
+    this.storeDir =
+      storeDir ?? process.env.EASYFLOW_STORE_DIR ?? path.join(os.homedir(), ".easyflow", "images");
   }
 
   async save(ref: string, data: ImageData): Promise<StoredImage> {

--- a/packages/easyflow-cli/src/store/image-store.ts
+++ b/packages/easyflow-cli/src/store/image-store.ts
@@ -256,7 +256,8 @@ export class ImageStore {
 
   private async hasSymlinksTo(targetDir: string): Promise<boolean> {
     try {
-      return await this.findSymlinksRecursive(this.storeDir, targetDir);
+      const normalizedTarget = await fs.realpath(targetDir);
+      return await this.findSymlinksRecursive(this.storeDir, normalizedTarget);
     } catch {
       return false;
     }

--- a/packages/easyflow-cli/src/store/image-store.ts
+++ b/packages/easyflow-cli/src/store/image-store.ts
@@ -110,25 +110,64 @@ export class ImageStore {
     const result: StoredImage[] = [];
 
     try {
-      const entries = await fs.readdir(this.storeDir, { withFileTypes: true });
-      for (const entry of entries) {
-        if (!entry.isDirectory()) continue;
-        // Digest directories start with "sha256-"
-        if (entry.name.startsWith("sha256-")) {
-          const imageJsonPath = path.join(this.storeDir, entry.name, "image.json");
-          try {
-            const raw = await fs.readFile(imageJsonPath, "utf-8");
-            result.push(JSON.parse(raw) as StoredImage);
-          } catch {
-            // skip if image.json is missing
-          }
-        }
-      }
+      await this.collectRefsRecursive(this.storeDir, [], result);
     } catch {
       // store directory doesn't exist yet
     }
 
     return result;
+  }
+
+  /**
+   * org/name/ ディレクトリを再帰走査し、タグ symlink を起点に StoredImage を構築する。
+   * digest ディレクトリ（sha256-*）はスキップして ref 側のみを列挙する。
+   */
+  private async collectRefsRecursive(
+    dir: string,
+    pathSegments: string[],
+    result: StoredImage[],
+  ): Promise<void> {
+    const entries = await fs.readdir(dir, { withFileTypes: true });
+    for (const entry of entries) {
+      const fullPath = path.join(dir, entry.name);
+      if (entry.isSymbolicLink()) {
+        // This is a tag symlink → resolve to digest dir and build StoredImage
+        try {
+          const realDir = await fs.realpath(fullPath);
+          const tag = entry.name;
+          const ref = this.buildRef(pathSegments, tag);
+          const imageJsonPath = path.join(realDir, "image.json");
+          try {
+            const raw = await fs.readFile(imageJsonPath, "utf-8");
+            const stored = JSON.parse(raw) as StoredImage;
+            // Override ref with current symlink's ref (may differ from image.json)
+            result.push({ ...stored, ref });
+          } catch {
+            // image.json missing — build minimal StoredImage from digest dir
+            const digest = path.basename(realDir).replace("-", ":");
+            const size = await this.computeDirSize(realDir);
+            const configPath = path.join(realDir, "config.json");
+            let metadata = this.extractMetadata({});
+            try {
+              const configRaw = JSON.parse(await fs.readFile(configPath, "utf-8"));
+              metadata = this.extractMetadata(configRaw);
+            } catch {
+              // no config.json
+            }
+            result.push({ ref, digest, size, createdAt: new Date().toISOString(), metadata });
+          }
+        } catch {
+          // broken symlink — skip
+        }
+      } else if (entry.isDirectory() && !entry.name.startsWith("sha256-")) {
+        await this.collectRefsRecursive(fullPath, [...pathSegments, entry.name], result);
+      }
+    }
+  }
+
+  private buildRef(pathSegments: string[], tag: string): string {
+    const nameWithOrg = pathSegments.join("/");
+    return `${nameWithOrg}:${tag}`;
   }
 
   async prune(): Promise<{ removed: number; freedBytes: number }> {

--- a/packages/easyflow-cli/src/store/image-store.ts
+++ b/packages/easyflow-cli/src/store/image-store.ts
@@ -4,12 +4,22 @@ import * as os from "node:os";
 import * as path from "node:path";
 import type { ImageData, ImageMetadata, StoredImage } from "./types.js";
 
+/** ref ツリーのルートディレクトリ名。digest ディレクトリ (sha256-*) との衝突を回避する。 */
+const REFS_DIR = "refs";
+/** org なし ref を保存する際の sentinel ディレクトリ名 */
+const NO_ORG_SENTINEL = "_noorg";
+
 export class ImageStore {
   private storeDir: string;
 
   constructor(storeDir?: string) {
     this.storeDir =
       storeDir ?? process.env.EASYFLOW_STORE_DIR ?? path.join(os.homedir(), ".easyflow", "images");
+  }
+
+  /** ref ツリーのベースパスを返す */
+  private get refsDir(): string {
+    return path.join(this.storeDir, REFS_DIR);
   }
 
   async save(ref: string, data: ImageData): Promise<StoredImage> {
@@ -38,7 +48,7 @@ export class ImageStore {
     }
 
     const { org, name, tag } = ImageStore.parseRef(ref);
-    const tagDir = path.join(this.storeDir, org, name, tag);
+    const tagDir = path.join(this.refsDir, org, name, tag);
     await fs.mkdir(path.dirname(tagDir), { recursive: true });
 
     // Remove existing symlink if present
@@ -68,7 +78,7 @@ export class ImageStore {
   async load(ref: string): Promise<ImageData | null> {
     ImageStore.validateRef(ref);
     const { org, name, tag } = ImageStore.parseRef(ref);
-    const tagDir = path.join(this.storeDir, org, name, tag);
+    const tagDir = path.join(this.refsDir, org, name, tag);
 
     try {
       const realDir = await fs.realpath(tagDir);
@@ -99,7 +109,7 @@ export class ImageStore {
   async remove(ref: string): Promise<boolean> {
     ImageStore.validateRef(ref);
     const { org, name, tag } = ImageStore.parseRef(ref);
-    const tagDir = path.join(this.storeDir, org, name, tag);
+    const tagDir = path.join(this.refsDir, org, name, tag);
 
     try {
       const realDir = await fs.realpath(tagDir);
@@ -126,7 +136,7 @@ export class ImageStore {
     const result: StoredImage[] = [];
 
     try {
-      await this.collectRefsRecursive(this.storeDir, [], result);
+      await this.collectRefsRecursive(this.refsDir, [], result);
     } catch {
       // store directory doesn't exist yet
     }
@@ -135,8 +145,7 @@ export class ImageStore {
   }
 
   /**
-   * org/name/ ディレクトリを再帰走査し、タグ symlink を起点に StoredImage を構築する。
-   * digest ディレクトリ（sha256-*）はスキップして ref 側のみを列挙する。
+   * refs/ ディレクトリを再帰走査し、タグ symlink を起点に StoredImage を構築する。
    */
   private async collectRefsRecursive(
     dir: string,
@@ -176,15 +185,14 @@ export class ImageStore {
         } catch {
           // broken symlink — skip
         }
-      } else if (entry.isDirectory() && !entry.name.startsWith("sha256-")) {
+      } else if (entry.isDirectory()) {
         await this.collectRefsRecursive(fullPath, [...pathSegments, entry.name], result);
       }
     }
   }
 
   private buildRef(pathSegments: string[], tag: string): string {
-    // parseRef() は org なし ref を "_" として保存するため、復元時に除去する
-    const filtered = pathSegments.filter((s) => s !== "_");
+    const filtered = pathSegments.filter((s) => s !== NO_ORG_SENTINEL);
     const nameWithOrg = filtered.join("/");
     return `${nameWithOrg}:${tag}`;
   }
@@ -219,7 +227,7 @@ export class ImageStore {
     const [nameWithOrg, tag = "latest"] = ref.split(":");
     const parts = nameWithOrg.split("/");
     if (parts.length < 2) {
-      return { org: "_", name: parts[0], tag };
+      return { org: NO_ORG_SENTINEL, name: parts[0], tag };
     }
     return { org: parts[0], name: parts.slice(1).join("/"), tag };
   }
@@ -252,8 +260,14 @@ export class ImageStore {
       throw new Error(`Invalid ref: "${ref}" — at most one ":" is allowed`);
     }
     const { org, name, tag } = ImageStore.parseRef(ref);
-    for (const segment of [org, name, tag]) {
+    for (const segment of [name, tag]) {
       if (segment === "" || segment === "." || segment === ".." || segment.includes("..")) {
+        throw new Error(`Invalid ref: "${ref}" — path traversal segments are not allowed`);
+      }
+    }
+    // org は NO_ORG_SENTINEL（内部値）以外の空チェック
+    if (org !== NO_ORG_SENTINEL) {
+      if (org === "" || org === "." || org === ".." || org.includes("..")) {
         throw new Error(`Invalid ref: "${ref}" — path traversal segments are not allowed`);
       }
     }
@@ -333,14 +347,19 @@ export class ImageStore {
   private async hasSymlinksTo(targetDir: string): Promise<boolean> {
     try {
       const normalizedTarget = await fs.realpath(targetDir);
-      return await this.findSymlinksRecursive(this.storeDir, normalizedTarget);
+      return await this.findSymlinksRecursive(this.refsDir, normalizedTarget);
     } catch {
       return false;
     }
   }
 
   private async findSymlinksRecursive(dir: string, targetDir: string): Promise<boolean> {
-    const entries = await fs.readdir(dir, { withFileTypes: true });
+    let entries: Awaited<ReturnType<typeof fs.readdir<{ withFileTypes: true }>>>;
+    try {
+      entries = await fs.readdir(dir, { withFileTypes: true });
+    } catch {
+      return false;
+    }
     for (const entry of entries) {
       const fullPath = path.join(dir, entry.name);
       if (entry.isSymbolicLink()) {
@@ -350,7 +369,7 @@ export class ImageStore {
         } catch {
           // broken symlink
         }
-      } else if (entry.isDirectory() && !entry.name.startsWith("sha256-")) {
+      } else if (entry.isDirectory()) {
         const found = await this.findSymlinksRecursive(fullPath, targetDir);
         if (found) return true;
       }

--- a/packages/easyflow-cli/src/store/image-store.ts
+++ b/packages/easyflow-cli/src/store/image-store.ts
@@ -28,6 +28,7 @@ export class ImageStore {
     const layersDir = path.join(digestDir, "layers");
     await fs.mkdir(layersDir, { recursive: true });
     for (const [name, buffer] of data.layers) {
+      ImageStore.validateLayerName(name);
       await fs.writeFile(path.join(layersDir, name), buffer);
     }
 
@@ -201,10 +202,33 @@ export class ImageStore {
   static parseRef(ref: string): { org: string; name: string; tag: string } {
     const [nameWithOrg, tag = "latest"] = ref.split(":");
     const parts = nameWithOrg.split("/");
-    if (parts.length < 2) {
-      return { org: "_", name: parts[0], tag };
+    const result =
+      parts.length < 2
+        ? { org: "_", name: parts[0], tag }
+        : { org: parts[0], name: parts.slice(1).join("/"), tag };
+    ImageStore.validatePathSegments(result.org, result.name, result.tag);
+    return result;
+  }
+
+  private static validatePathSegments(...segments: string[]): void {
+    for (const seg of segments) {
+      if (!seg || seg === "." || seg === ".." || seg.includes("..") || path.isAbsolute(seg)) {
+        throw new Error(`Invalid ref segment: "${seg}"`);
+      }
     }
-    return { org: parts[0], name: parts.slice(1).join("/"), tag };
+  }
+
+  private static validateLayerName(name: string): void {
+    if (
+      !name ||
+      name.includes("/") ||
+      name.includes("\\") ||
+      name === "." ||
+      name === ".." ||
+      name.includes("..")
+    ) {
+      throw new Error(`Invalid layer name: "${name}"`);
+    }
   }
 
   static computeDigest(data: Buffer): string {

--- a/packages/easyflow-cli/src/store/image-store.ts
+++ b/packages/easyflow-cli/src/store/image-store.ts
@@ -193,7 +193,12 @@ export class ImageStore {
   }
 
   private buildRef(pathSegments: string[], tag: string): string {
-    const filtered = pathSegments.filter((s) => s !== NO_ORG_SENTINEL && s !== "tags");
+    // symlink の直上は必ず "tags" ディレクトリなので末尾 1 つだけ除去
+    const withoutTrailingTags =
+      pathSegments.length > 0 && pathSegments[pathSegments.length - 1] === "tags"
+        ? pathSegments.slice(0, -1)
+        : pathSegments;
+    const filtered = withoutTrailingTags.filter((s) => s !== NO_ORG_SENTINEL);
     const nameWithOrg = filtered.join("/");
     return `${nameWithOrg}:${tag}`;
   }

--- a/packages/easyflow-cli/src/store/image-store.ts
+++ b/packages/easyflow-cli/src/store/image-store.ts
@@ -1,0 +1,241 @@
+import * as crypto from "node:crypto";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { ImageData, ImageMetadata, StoredImage } from "./types.js";
+
+export class ImageStore {
+  private storeDir: string;
+
+  constructor(storeDir?: string) {
+    this.storeDir = storeDir ?? path.join(os.homedir(), ".easyflow", "images");
+  }
+
+  async save(ref: string, data: ImageData): Promise<StoredImage> {
+    await fs.mkdir(this.storeDir, { recursive: true });
+
+    const digest = ImageStore.computeDigest(this.serializeImageData(data));
+    const digestDir = path.join(this.storeDir, digest.replace(":", "-"));
+
+    await fs.mkdir(digestDir, { recursive: true });
+    await fs.writeFile(
+      path.join(digestDir, "manifest.json"),
+      JSON.stringify(data.manifest, null, 2),
+    );
+    await fs.writeFile(path.join(digestDir, "config.json"), JSON.stringify(data.config, null, 2));
+
+    const layersDir = path.join(digestDir, "layers");
+    await fs.mkdir(layersDir, { recursive: true });
+    for (const [name, buffer] of data.layers) {
+      await fs.writeFile(path.join(layersDir, name), buffer);
+    }
+
+    const { org, name, tag } = ImageStore.parseRef(ref);
+    const tagDir = path.join(this.storeDir, org, name, tag);
+    await fs.mkdir(path.dirname(tagDir), { recursive: true });
+
+    // Remove existing symlink if present
+    try {
+      await fs.unlink(tagDir);
+    } catch {
+      // ignore if not exists
+    }
+    await fs.symlink(digestDir, tagDir);
+
+    const size = await this.computeDirSize(digestDir);
+    const metadata = this.extractMetadata(data.config);
+
+    const storedImage: StoredImage = {
+      ref,
+      digest,
+      size,
+      createdAt: new Date().toISOString(),
+      metadata,
+    };
+
+    await fs.writeFile(path.join(digestDir, "image.json"), JSON.stringify(storedImage, null, 2));
+
+    return storedImage;
+  }
+
+  async load(ref: string): Promise<ImageData | null> {
+    const { org, name, tag } = ImageStore.parseRef(ref);
+    const tagDir = path.join(this.storeDir, org, name, tag);
+
+    try {
+      const realDir = await fs.realpath(tagDir);
+      const manifest = JSON.parse(await fs.readFile(path.join(realDir, "manifest.json"), "utf-8"));
+      const config = JSON.parse(await fs.readFile(path.join(realDir, "config.json"), "utf-8"));
+
+      const layers = new Map<string, Buffer>();
+      const layersDir = path.join(realDir, "layers");
+      try {
+        const entries = await fs.readdir(layersDir);
+        for (const entry of entries) {
+          const buf = await fs.readFile(path.join(layersDir, entry));
+          layers.set(entry, buf);
+        }
+      } catch {
+        // no layers directory
+      }
+
+      return { manifest, config, layers };
+    } catch {
+      return null;
+    }
+  }
+
+  async remove(ref: string): Promise<boolean> {
+    const { org, name, tag } = ImageStore.parseRef(ref);
+    const tagDir = path.join(this.storeDir, org, name, tag);
+
+    try {
+      const realDir = await fs.realpath(tagDir);
+      await fs.unlink(tagDir);
+
+      // Check if any other symlinks point to this digest dir
+      const hasOtherRefs = await this.hasSymlinksTo(realDir);
+      if (!hasOtherRefs) {
+        await fs.rm(realDir, { recursive: true, force: true });
+      }
+
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async list(): Promise<StoredImage[]> {
+    const result: StoredImage[] = [];
+
+    try {
+      const entries = await fs.readdir(this.storeDir, { withFileTypes: true });
+      for (const entry of entries) {
+        if (!entry.isDirectory()) continue;
+        // Digest directories start with "sha256-"
+        if (entry.name.startsWith("sha256-")) {
+          const imageJsonPath = path.join(this.storeDir, entry.name, "image.json");
+          try {
+            const raw = await fs.readFile(imageJsonPath, "utf-8");
+            result.push(JSON.parse(raw) as StoredImage);
+          } catch {
+            // skip if image.json is missing
+          }
+        }
+      }
+    } catch {
+      // store directory doesn't exist yet
+    }
+
+    return result;
+  }
+
+  async prune(): Promise<{ removed: number; freedBytes: number }> {
+    let removed = 0;
+    let freedBytes = 0;
+
+    try {
+      const entries = await fs.readdir(this.storeDir, { withFileTypes: true });
+      for (const entry of entries) {
+        if (!entry.isDirectory()) continue;
+        if (!entry.name.startsWith("sha256-")) continue;
+
+        const digestDir = path.join(this.storeDir, entry.name);
+        const hasRefs = await this.hasSymlinksTo(digestDir);
+        if (!hasRefs) {
+          const size = await this.computeDirSize(digestDir);
+          await fs.rm(digestDir, { recursive: true, force: true });
+          removed++;
+          freedBytes += size;
+        }
+      }
+    } catch {
+      // store directory doesn't exist yet
+    }
+
+    return { removed, freedBytes };
+  }
+
+  static parseRef(ref: string): { org: string; name: string; tag: string } {
+    const [nameWithOrg, tag = "latest"] = ref.split(":");
+    const parts = nameWithOrg.split("/");
+    if (parts.length < 2) {
+      return { org: "_", name: parts[0], tag };
+    }
+    return { org: parts[0], name: parts.slice(1).join("/"), tag };
+  }
+
+  static computeDigest(data: Buffer): string {
+    const hash = crypto.createHash("sha256").update(data).digest("hex");
+    return `sha256:${hash}`;
+  }
+
+  private serializeImageData(data: ImageData): Buffer {
+    const parts: Buffer[] = [];
+    parts.push(Buffer.from(JSON.stringify(data.manifest)));
+    parts.push(Buffer.from(JSON.stringify(data.config)));
+    for (const [key, value] of data.layers) {
+      parts.push(Buffer.from(key));
+      parts.push(value);
+    }
+    return Buffer.concat(parts);
+  }
+
+  private extractMetadata(config: Record<string, unknown>): ImageMetadata {
+    return {
+      name: (config.name as string) ?? "",
+      version: (config.version as string) ?? "",
+      description: (config.description as string) ?? "",
+      base: config.base as string | undefined,
+      tools: (config.tools as string[]) ?? [],
+      channels: (config.channels as string[]) ?? [],
+      knowledgeChunks: config.knowledgeChunks as number | undefined,
+    };
+  }
+
+  private async computeDirSize(dirPath: string): Promise<number> {
+    let total = 0;
+    try {
+      const entries = await fs.readdir(dirPath, { withFileTypes: true });
+      for (const entry of entries) {
+        const fullPath = path.join(dirPath, entry.name);
+        if (entry.isFile() || entry.isSymbolicLink()) {
+          const stat = await fs.lstat(fullPath);
+          total += stat.size;
+        } else if (entry.isDirectory()) {
+          total += await this.computeDirSize(fullPath);
+        }
+      }
+    } catch {
+      // ignore
+    }
+    return total;
+  }
+
+  private async hasSymlinksTo(targetDir: string): Promise<boolean> {
+    try {
+      return await this.findSymlinksRecursive(this.storeDir, targetDir);
+    } catch {
+      return false;
+    }
+  }
+
+  private async findSymlinksRecursive(dir: string, targetDir: string): Promise<boolean> {
+    const entries = await fs.readdir(dir, { withFileTypes: true });
+    for (const entry of entries) {
+      const fullPath = path.join(dir, entry.name);
+      if (entry.isSymbolicLink()) {
+        try {
+          const resolved = await fs.realpath(fullPath);
+          if (resolved === targetDir) return true;
+        } catch {
+          // broken symlink
+        }
+      } else if (entry.isDirectory() && !entry.name.startsWith("sha256-")) {
+        const found = await this.findSymlinksRecursive(fullPath, targetDir);
+        if (found) return true;
+      }
+    }
+    return false;
+  }
+}

--- a/packages/easyflow-cli/src/store/image-store.ts
+++ b/packages/easyflow-cli/src/store/image-store.ts
@@ -72,6 +72,9 @@ export class ImageStore {
 
     try {
       const realDir = await fs.realpath(tagDir);
+      if (!(await this.assertInsideStore(realDir))) {
+        return null;
+      }
       const manifest = JSON.parse(await fs.readFile(path.join(realDir, "manifest.json"), "utf-8"));
       const config = JSON.parse(await fs.readFile(path.join(realDir, "config.json"), "utf-8"));
 
@@ -100,6 +103,11 @@ export class ImageStore {
 
     try {
       const realDir = await fs.realpath(tagDir);
+      if (!(await this.assertInsideStore(realDir))) {
+        // symlink points outside store — remove the dangling symlink but don't touch the target
+        await fs.unlink(tagDir);
+        return true;
+      }
       await fs.unlink(tagDir);
 
       // Check if any other symlinks point to this digest dir
@@ -142,6 +150,7 @@ export class ImageStore {
         // This is a tag symlink → resolve to digest dir and build StoredImage
         try {
           const realDir = await fs.realpath(fullPath);
+          if (!(await this.assertInsideStore(realDir))) continue;
           const tag = entry.name;
           const ref = this.buildRef(pathSegments, tag);
           const imageJsonPath = path.join(realDir, "image.json");
@@ -215,8 +224,33 @@ export class ImageStore {
     return { org: parts[0], name: parts.slice(1).join("/"), tag };
   }
 
+  /**
+   * symlink の解決先が storeDir 配下の sha256-* ディレクトリであることを検証する。
+   * ストア外を指す symlink は拒否し false を返す。
+   */
+  private async assertInsideStore(realDir: string): Promise<boolean> {
+    let resolvedStore: string;
+    try {
+      resolvedStore = await fs.realpath(this.storeDir);
+    } catch {
+      return false;
+    }
+    const normalized = path.resolve(realDir);
+    const storePrefix = resolvedStore + path.sep;
+    if (!normalized.startsWith(storePrefix)) {
+      return false;
+    }
+    const relative = normalized.slice(storePrefix.length);
+    return relative.startsWith("sha256-");
+  }
+
   /** ref の各セグメントがストアパス外にトラバーサルしないことを検証する */
   static validateRef(ref: string): void {
+    // コロンは 0 個または 1 個のみ許可
+    const colonCount = (ref.match(/:/g) || []).length;
+    if (colonCount > 1) {
+      throw new Error(`Invalid ref: "${ref}" — at most one ":" is allowed`);
+    }
     const { org, name, tag } = ImageStore.parseRef(ref);
     for (const segment of [org, name, tag]) {
       if (segment === "" || segment === "." || segment === ".." || segment.includes("..")) {

--- a/packages/easyflow-cli/src/store/image-store.ts
+++ b/packages/easyflow-cli/src/store/image-store.ts
@@ -13,8 +13,9 @@ export class ImageStore {
   private storeDir: string;
 
   constructor(storeDir?: string) {
-    this.storeDir =
-      storeDir ?? process.env.EASYFLOW_STORE_DIR ?? path.join(os.homedir(), ".easyflow", "images");
+    this.storeDir = path.resolve(
+      storeDir ?? process.env.EASYFLOW_STORE_DIR ?? path.join(os.homedir(), ".easyflow", "images"),
+    );
   }
 
   /** ref ツリーのベースパスを返す */

--- a/packages/easyflow-cli/src/store/image-store.ts
+++ b/packages/easyflow-cli/src/store/image-store.ts
@@ -166,7 +166,9 @@ export class ImageStore {
   }
 
   private buildRef(pathSegments: string[], tag: string): string {
-    const nameWithOrg = pathSegments.join("/");
+    // parseRef() は org なし ref を "_" として保存するため、復元時に除去する
+    const filtered = pathSegments.filter((s) => s !== "_");
+    const nameWithOrg = filtered.join("/");
     return `${nameWithOrg}:${tag}`;
   }
 

--- a/packages/easyflow-cli/src/store/types.ts
+++ b/packages/easyflow-cli/src/store/types.ts
@@ -1,0 +1,23 @@
+export interface StoredImage {
+  ref: string; // "estack-inc/customer-support:1.0.0"
+  digest: string; // "sha256:abc123..."
+  size: number; // bytes
+  createdAt: string; // ISO 8601
+  metadata: ImageMetadata;
+}
+
+export interface ImageMetadata {
+  name: string;
+  version: string;
+  description: string;
+  base?: string;
+  tools: string[];
+  channels: string[];
+  knowledgeChunks?: number;
+}
+
+export interface ImageData {
+  manifest: Record<string, unknown>;
+  config: Record<string, unknown>;
+  layers: Map<string, Buffer>;
+}

--- a/packages/easyflow-cli/src/utils/errors.ts
+++ b/packages/easyflow-cli/src/utils/errors.ts
@@ -1,0 +1,32 @@
+export class EasyflowError extends Error {
+  constructor(
+    message: string,
+    public readonly cause?: string,
+    public readonly hint?: string,
+  ) {
+    super(message);
+    this.name = "EasyflowError";
+  }
+}
+
+export function handleError(error: unknown): never {
+  if (error instanceof EasyflowError) {
+    console.error(`Error: ${error.message}`);
+    if (error.cause) {
+      console.error(`\n  原因: ${error.cause}`);
+    }
+    if (error.hint) {
+      console.error(`  対処: ${error.hint}`);
+    }
+    console.error();
+    process.exit(1);
+  }
+
+  if (error instanceof Error) {
+    console.error(`Error: ${error.message}`);
+    process.exit(1);
+  }
+
+  console.error(`Error: ${String(error)}`);
+  process.exit(1);
+}

--- a/packages/easyflow-cli/src/utils/errors.ts
+++ b/packages/easyflow-cli/src/utils/errors.ts
@@ -1,7 +1,7 @@
 export class EasyflowError extends Error {
   constructor(
     message: string,
-    public readonly cause?: string,
+    public readonly reason?: string,
     public readonly hint?: string,
   ) {
     super(message);
@@ -12,8 +12,8 @@ export class EasyflowError extends Error {
 export function handleError(error: unknown): never {
   if (error instanceof EasyflowError) {
     console.error(`Error: ${error.message}`);
-    if (error.cause) {
-      console.error(`\n  原因: ${error.cause}`);
+    if (error.reason) {
+      console.error(`\n  原因: ${error.reason}`);
     }
     if (error.hint) {
       console.error(`  対処: ${error.hint}`);

--- a/packages/easyflow-cli/src/utils/logger.ts
+++ b/packages/easyflow-cli/src/utils/logger.ts
@@ -23,6 +23,7 @@ export class Logger {
     if (this.options.noColor) {
       return message;
     }
+    // TODO: Phase 2 でカラー出力（chalk 等）を追加
     return message;
   }
 }

--- a/packages/easyflow-cli/src/utils/logger.ts
+++ b/packages/easyflow-cli/src/utils/logger.ts
@@ -1,0 +1,28 @@
+export class Logger {
+  constructor(private options: { verbose: boolean; noColor: boolean }) {}
+
+  info(message: string): void {
+    console.log(this.format(message));
+  }
+
+  debug(message: string): void {
+    if (this.options.verbose) {
+      console.log(this.format(`[debug] ${message}`));
+    }
+  }
+
+  warn(message: string): void {
+    console.warn(this.format(`Warning: ${message}`));
+  }
+
+  error(message: string): void {
+    console.error(this.format(`Error: ${message}`));
+  }
+
+  private format(message: string): string {
+    if (this.options.noColor) {
+      return message;
+    }
+    return message;
+  }
+}

--- a/packages/easyflow-cli/src/utils/progress.ts
+++ b/packages/easyflow-cli/src/utils/progress.ts
@@ -1,0 +1,59 @@
+import type { Ora } from "ora";
+import ora from "ora";
+
+export class StepProgress {
+  private spinner: Ora | null = null;
+  private currentStep = 0;
+  private startTime = 0;
+
+  constructor(
+    private totalSteps: number,
+    private noColor = false,
+  ) {}
+
+  start(step: number, label: string): void {
+    this.currentStep = step;
+    this.startTime = Date.now();
+    const prefix = this.formatPrefix(step);
+
+    if (this.noColor) {
+      console.log(`${prefix} ${label} ...`);
+      return;
+    }
+
+    this.spinner = ora({
+      text: `${prefix} ${label}`,
+      prefixText: "",
+    }).start();
+  }
+
+  succeed(detail?: string): void {
+    const elapsed = ((Date.now() - this.startTime) / 1000).toFixed(1);
+    const suffix = detail ? ` ${detail}` : "";
+
+    if (this.noColor || !this.spinner) {
+      const prefix = this.formatPrefix(this.currentStep);
+      console.log(`${prefix} done (${elapsed}s)${suffix}`);
+      return;
+    }
+
+    this.spinner.succeed(`${this.spinner.text} ... done (${elapsed}s)${suffix}`);
+    this.spinner = null;
+  }
+
+  fail(error: string): void {
+    if (this.noColor || !this.spinner) {
+      const prefix = this.formatPrefix(this.currentStep);
+      console.error(`${prefix} FAILED: ${error}`);
+      return;
+    }
+
+    this.spinner.fail(`${this.spinner.text} ... FAILED: ${error}`);
+    this.spinner = null;
+  }
+
+  private formatPrefix(step: number): string {
+    const padded = String(step).padStart(String(this.totalSteps).length, " ");
+    return `${padded}/${this.totalSteps}`;
+  }
+}

--- a/packages/easyflow-cli/test/cli/commands.test.ts
+++ b/packages/easyflow-cli/test/cli/commands.test.ts
@@ -7,15 +7,14 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 const execFileAsync = promisify(execFile);
 
-const BIN_PATH = path.resolve(import.meta.dirname, "../../bin/easyflow.mjs");
-const TSX_PATH = path.resolve(import.meta.dirname, "../../../../node_modules/.bin/tsx");
+const ENTRY_PATH = path.resolve(import.meta.dirname, "../../src/cli/index.ts");
 
 async function runCli(
   args: string[],
   env?: Record<string, string>,
 ): Promise<{ stdout: string; stderr: string }> {
   try {
-    const result = await execFileAsync(TSX_PATH, [BIN_PATH, ...args], {
+    const result = await execFileAsync(process.execPath, ["--import", "tsx", ENTRY_PATH, ...args], {
       env: { ...process.env, ...env },
       timeout: 10000,
     });

--- a/packages/easyflow-cli/test/cli/commands.test.ts
+++ b/packages/easyflow-cli/test/cli/commands.test.ts
@@ -51,12 +51,15 @@ describe("CLI commands", () => {
     });
 
     it("config set → config get で値が取得できる", async () => {
-      const { ConfigManager } = await import("../../src/config/manager.js");
-      const manager = new ConfigManager(tmpDir);
+      const { stdout: setOut } = await runCli(["config", "set", "registry", "custom.io"], {
+        EASYFLOW_CONFIG_DIR: tmpDir,
+      });
+      expect(setOut).toContain("registry = custom.io");
 
-      await manager.set("registry", "custom.io");
-      const value = await manager.get("registry");
-      expect(value).toBe("custom.io");
+      const { stdout: getOut } = await runCli(["config", "get", "registry"], {
+        EASYFLOW_CONFIG_DIR: tmpDir,
+      });
+      expect(getOut.trim()).toBe("custom.io");
     });
   });
 

--- a/packages/easyflow-cli/test/cli/commands.test.ts
+++ b/packages/easyflow-cli/test/cli/commands.test.ts
@@ -1,0 +1,67 @@
+import { execFile } from "node:child_process";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { promisify } from "node:util";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+const execFileAsync = promisify(execFile);
+
+const BIN_PATH = path.resolve(import.meta.dirname, "../../bin/easyflow.mjs");
+const TSX_PATH = path.resolve(import.meta.dirname, "../../../../node_modules/.bin/tsx");
+
+async function runCli(
+  args: string[],
+  env?: Record<string, string>,
+): Promise<{ stdout: string; stderr: string }> {
+  try {
+    const result = await execFileAsync(TSX_PATH, [BIN_PATH, ...args], {
+      env: { ...process.env, ...env },
+      timeout: 10000,
+    });
+    return { stdout: result.stdout, stderr: result.stderr };
+  } catch (error: any) {
+    return { stdout: error.stdout ?? "", stderr: error.stderr ?? "" };
+  }
+}
+
+describe("CLI commands", () => {
+  it("--version でバージョン番号が表示される", async () => {
+    const { stdout } = await runCli(["--version"]);
+    expect(stdout.trim()).toBe("0.1.0");
+  });
+
+  it("--help でコマンド一覧が表示される", async () => {
+    const { stdout } = await runCli(["--help"]);
+    expect(stdout).toContain("config");
+    expect(stdout).toContain("images");
+    expect(stdout).toContain("build");
+    expect(stdout).toContain("deploy");
+  });
+
+  describe("config set/get", () => {
+    let tmpDir: string;
+
+    beforeEach(async () => {
+      tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "easyflow-cli-test-"));
+    });
+
+    afterEach(async () => {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    });
+
+    it("config set → config get で値が取得できる", async () => {
+      const { ConfigManager } = await import("../../src/config/manager.js");
+      const manager = new ConfigManager(tmpDir);
+
+      await manager.set("registry", "custom.io");
+      const value = await manager.get("registry");
+      expect(value).toBe("custom.io");
+    });
+  });
+
+  it("未実装コマンドでエラーメッセージが表示される", async () => {
+    const { stderr } = await runCli(["build"]);
+    expect(stderr).toContain("easyflow build は現在未実装です。");
+  });
+});

--- a/packages/easyflow-cli/test/cli/commands.test.ts
+++ b/packages/easyflow-cli/test/cli/commands.test.ts
@@ -66,4 +66,33 @@ describe("CLI commands", () => {
     const { stderr } = await runCli(["build"]);
     expect(stderr).toContain("easyflow build は現在未実装です。");
   });
+
+  describe("images", () => {
+    let storeDir: string;
+
+    beforeEach(async () => {
+      storeDir = await fs.mkdtemp(path.join(os.tmpdir(), "easyflow-images-cli-test-"));
+    });
+
+    afterEach(async () => {
+      await fs.rm(storeDir, { recursive: true, force: true });
+    });
+
+    it("images — 空ストアでメッセージが表示される", async () => {
+      const { stdout } = await runCli(["images"], { EASYFLOW_STORE_DIR: storeDir });
+      expect(stdout).toContain("ローカルイメージはありません");
+    });
+
+    it("images rm — 存在しない ref でエラーメッセージが出る", async () => {
+      const { stderr } = await runCli(["images", "rm", "org/x:1.0.0"], {
+        EASYFLOW_STORE_DIR: storeDir,
+      });
+      expect(stderr).toContain("イメージが見つかりません");
+    });
+
+    it("images prune — 空ストアで 0 件と表示される", async () => {
+      const { stdout } = await runCli(["images", "prune"], { EASYFLOW_STORE_DIR: storeDir });
+      expect(stdout).toContain("0 件削除しました");
+    });
+  });
 });

--- a/packages/easyflow-cli/test/cli/commands.test.ts
+++ b/packages/easyflow-cli/test/cli/commands.test.ts
@@ -95,4 +95,43 @@ describe("CLI commands", () => {
       expect(stdout).toContain("0 件削除しました");
     });
   });
+
+  describe("--dry-run", () => {
+    let tmpDir: string;
+
+    beforeEach(async () => {
+      tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "easyflow-dryrun-test-"));
+    });
+
+    afterEach(async () => {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    });
+
+    it("config set --dry-run で設定が保存されない", async () => {
+      const { stdout } = await runCli(
+        ["--dry-run", "config", "set", "auth[example.com].token", "secret"],
+        { EASYFLOW_CONFIG_DIR: tmpDir },
+      );
+      expect(stdout).toContain("[dry-run]");
+
+      const { stdout: getOut } = await runCli(["config", "get", "auth[example.com].token"], {
+        EASYFLOW_CONFIG_DIR: tmpDir,
+      });
+      expect(getOut).toContain("未設定");
+    });
+
+    it("images rm --dry-run で削除されない", async () => {
+      const { stdout } = await runCli(["--dry-run", "images", "rm", "org/agent:1.0.0"], {
+        EASYFLOW_STORE_DIR: tmpDir,
+      });
+      expect(stdout).toContain("[dry-run]");
+    });
+
+    it("images prune --dry-run で削除されない", async () => {
+      const { stdout } = await runCli(["--dry-run", "images", "prune"], {
+        EASYFLOW_STORE_DIR: tmpDir,
+      });
+      expect(stdout).toContain("[dry-run]");
+    });
+  });
 });

--- a/packages/easyflow-cli/test/config/manager.test.ts
+++ b/packages/easyflow-cli/test/config/manager.test.ts
@@ -52,11 +52,6 @@ describe("ConfigManager", () => {
     expect(config.registry).toBe("custom.io");
   });
 
-  it("__proto__ キーを拒否する（prototype pollution 防止）", async () => {
-    await expect(manager.set("__proto__.polluted", "x")).rejects.toThrow("不正な設定キー");
-    await expect(manager.get("constructor.prototype")).rejects.toThrow("不正な設定キー");
-  });
-
   it("壊れた config.json → JSON parse error をそのまま投げる", async () => {
     await fs.mkdir(tmpDir, { recursive: true });
     await fs.writeFile(path.join(tmpDir, "config.json"), "{ invalid json }");

--- a/packages/easyflow-cli/test/config/manager.test.ts
+++ b/packages/easyflow-cli/test/config/manager.test.ts
@@ -58,4 +58,13 @@ describe("ConfigManager", () => {
 
     await expect(manager.load()).rejects.toThrow(SyntaxError);
   });
+
+  it("__proto__ キーで prototype pollution が起きない", async () => {
+    await expect(manager.set("__proto__.polluted", "yes")).rejects.toThrow(
+      "Dangerous config key segment",
+    );
+    await expect(manager.set("constructor.polluted", "yes")).rejects.toThrow(
+      "Dangerous config key segment",
+    );
+  });
 });

--- a/packages/easyflow-cli/test/config/manager.test.ts
+++ b/packages/easyflow-cli/test/config/manager.test.ts
@@ -39,6 +39,14 @@ describe("ConfigManager", () => {
     expect(config.auth["ghcr.io"]).toEqual({ token: "abc" });
   });
 
+  it("ドット記法で FQDN を渡すとキーが分割され型定義と一致しない", async () => {
+    // ドット記法は FQDN を意図通りに保存できない（ブラケット記法を使うべき）
+    await manager.set("auth.ghcr.io.token", "bad");
+    const config = await manager.load();
+    // auth["ghcr"] → { io: { token: "bad" } } という不正な構造になる
+    expect(config.auth["ghcr.io"]).toBeUndefined();
+  });
+
   it("存在しないキー → undefined", async () => {
     const value = await manager.get("unknown.key");
     expect(value).toBeUndefined();

--- a/packages/easyflow-cli/test/config/manager.test.ts
+++ b/packages/easyflow-cli/test/config/manager.test.ts
@@ -39,12 +39,9 @@ describe("ConfigManager", () => {
     expect(config.auth["ghcr.io"]).toEqual({ token: "abc" });
   });
 
-  it("ドット記法で FQDN を渡すとキーが分割され型定義と一致しない", async () => {
-    // ドット記法は FQDN を意図通りに保存できない（ブラケット記法を使うべき）
-    await manager.set("auth.ghcr.io.token", "bad");
-    const config = await manager.load();
-    // auth["ghcr"] → { io: { token: "bad" } } という不正な構造になる
-    expect(config.auth["ghcr.io"]).toBeUndefined();
+  it("auth キーにドット記法を使うとエラーになる", async () => {
+    await expect(manager.set("auth.ghcr.io.token", "bad")).rejects.toThrow("ブラケット記法");
+    await expect(manager.get("auth.ghcr.io.token")).rejects.toThrow("ブラケット記法");
   });
 
   it("存在しないキー → undefined", async () => {

--- a/packages/easyflow-cli/test/config/manager.test.ts
+++ b/packages/easyflow-cli/test/config/manager.test.ts
@@ -29,10 +29,14 @@ describe("ConfigManager", () => {
     expect(value).toBe("custom.io");
   });
 
-  it("ネストキーの set → get", async () => {
-    await manager.set("auth.ghcr.io.token", "abc");
-    const value = await manager.get("auth.ghcr.io.token");
+  it("ネストキーの set → get（ブラケット記法で FQDN を保護）", async () => {
+    await manager.set("auth[ghcr.io].token", "abc");
+    const value = await manager.get("auth[ghcr.io].token");
     expect(value).toBe("abc");
+
+    // 保存形式が型定義 auth: Record<string, AuthEntry> と一致することを確認
+    const config = await manager.load();
+    expect(config.auth["ghcr.io"]).toEqual({ token: "abc" });
   });
 
   it("存在しないキー → undefined", async () => {
@@ -46,5 +50,12 @@ describe("ConfigManager", () => {
     const newManager = new ConfigManager(tmpDir);
     const config = await newManager.load();
     expect(config.registry).toBe("custom.io");
+  });
+
+  it("壊れた config.json → JSON parse error をそのまま投げる", async () => {
+    await fs.mkdir(tmpDir, { recursive: true });
+    await fs.writeFile(path.join(tmpDir, "config.json"), "{ invalid json }");
+
+    await expect(manager.load()).rejects.toThrow(SyntaxError);
   });
 });

--- a/packages/easyflow-cli/test/config/manager.test.ts
+++ b/packages/easyflow-cli/test/config/manager.test.ts
@@ -52,6 +52,11 @@ describe("ConfigManager", () => {
     expect(config.registry).toBe("custom.io");
   });
 
+  it("__proto__ キーを拒否する（prototype pollution 防止）", async () => {
+    await expect(manager.set("__proto__.polluted", "x")).rejects.toThrow("不正な設定キー");
+    await expect(manager.get("constructor.prototype")).rejects.toThrow("不正な設定キー");
+  });
+
   it("壊れた config.json → JSON parse error をそのまま投げる", async () => {
     await fs.mkdir(tmpDir, { recursive: true });
     await fs.writeFile(path.join(tmpDir, "config.json"), "{ invalid json }");

--- a/packages/easyflow-cli/test/config/manager.test.ts
+++ b/packages/easyflow-cli/test/config/manager.test.ts
@@ -1,0 +1,50 @@
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { ConfigManager } from "../../src/config/manager.js";
+import { DEFAULT_CONFIG } from "../../src/config/types.js";
+
+describe("ConfigManager", () => {
+  let tmpDir: string;
+  let manager: ConfigManager;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "easyflow-config-test-"));
+    manager = new ConfigManager(tmpDir);
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("設定ファイルなし → デフォルト設定が返る", async () => {
+    const config = await manager.load();
+    expect(config).toEqual(DEFAULT_CONFIG);
+  });
+
+  it("set → get で値が取得できる", async () => {
+    await manager.set("registry", "custom.io");
+    const value = await manager.get("registry");
+    expect(value).toBe("custom.io");
+  });
+
+  it("ネストキーの set → get", async () => {
+    await manager.set("auth.ghcr.io.token", "abc");
+    const value = await manager.get("auth.ghcr.io.token");
+    expect(value).toBe("abc");
+  });
+
+  it("存在しないキー → undefined", async () => {
+    const value = await manager.get("unknown.key");
+    expect(value).toBeUndefined();
+  });
+
+  it("save → 新インスタンスで load → 同じ値が返る", async () => {
+    await manager.set("registry", "custom.io");
+
+    const newManager = new ConfigManager(tmpDir);
+    const config = await newManager.load();
+    expect(config.registry).toBe("custom.io");
+  });
+});

--- a/packages/easyflow-cli/test/store/image-store.test.ts
+++ b/packages/easyflow-cli/test/store/image-store.test.ts
@@ -192,4 +192,25 @@ describe("ImageStore", () => {
     const storedB = await store.save("org/b:1.0.0", dataB);
     expect(storedA.digest).not.toBe(storedB.digest);
   });
+
+  it("sha256- で始まる org 名の ref が save/list で正しく扱われる", async () => {
+    const ref = "sha256-tools/agent:1.0.0";
+    await store.save(ref, createTestImageData("sha256-org"));
+    const images = await store.list();
+    expect(images.length).toBe(1);
+    expect(images[0].ref).toBe(ref);
+
+    const loaded = await store.load(ref);
+    expect(loaded).not.toBeNull();
+  });
+
+  it("org なし ref と _ org の ref が衝突しない", async () => {
+    await store.save("agent:latest", createTestImageData("no-org"));
+    await store.save("_/agent:latest", createTestImageData("underscore-org"));
+
+    const images = await store.list();
+    expect(images.length).toBe(2);
+    const refs = images.map((img) => img.ref).sort();
+    expect(refs).toEqual(["_/agent:latest", "agent:latest"]);
+  });
 });

--- a/packages/easyflow-cli/test/store/image-store.test.ts
+++ b/packages/easyflow-cli/test/store/image-store.test.ts
@@ -93,6 +93,20 @@ describe("ImageStore", () => {
     expect(result.freedBytes).toBeGreaterThan(0);
   });
 
+  it("パストラバーサルを含む ref を拒否する", async () => {
+    await expect(store.save("../../tmp/x:tag", createTestImageData())).rejects.toThrow(
+      "不正な ref",
+    );
+    await expect(store.load("../escape:latest")).rejects.toThrow("不正な ref");
+    await expect(store.remove("../escape:latest")).rejects.toThrow("不正な ref");
+  });
+
+  it("パストラバーサルを含む layer 名を拒否する", async () => {
+    const data = createTestImageData();
+    data.layers.set("../../etc/passwd", Buffer.from("malicious"));
+    await expect(store.save("org/agent:1.0.0", data)).rejects.toThrow("不正な layer 名");
+  });
+
   it("存在しない ref の load → null", async () => {
     const loaded = await store.load("nonexistent/agent:1.0.0");
     expect(loaded).toBeNull();

--- a/packages/easyflow-cli/test/store/image-store.test.ts
+++ b/packages/easyflow-cli/test/store/image-store.test.ts
@@ -128,4 +128,16 @@ describe("ImageStore", () => {
     expect(pruned.removed).toBe(1);
     expect(pruned.freedBytes).toBeGreaterThan(0);
   });
+
+  it("パストラバーサルを含む ref は拒否される", () => {
+    expect(() => ImageStore.parseRef("../../tmp/x:tag")).toThrow("Invalid ref segment");
+    expect(() => ImageStore.parseRef("org/../etc:tag")).toThrow("Invalid ref segment");
+    expect(() => ImageStore.parseRef(":tag")).toThrow("Invalid ref segment");
+  });
+
+  it("パストラバーサルを含む layer 名は save で拒否される", async () => {
+    const data = createTestImageData();
+    data.layers.set("../../etc/passwd", Buffer.from("bad"));
+    await expect(store.save("org/agent:1.0.0", data)).rejects.toThrow("Invalid layer name");
+  });
 });

--- a/packages/easyflow-cli/test/store/image-store.test.ts
+++ b/packages/easyflow-cli/test/store/image-store.test.ts
@@ -93,20 +93,6 @@ describe("ImageStore", () => {
     expect(result.freedBytes).toBeGreaterThan(0);
   });
 
-  it("パストラバーサルを含む ref を拒否する", async () => {
-    await expect(store.save("../../tmp/x:tag", createTestImageData())).rejects.toThrow(
-      "不正な ref",
-    );
-    await expect(store.load("../escape:latest")).rejects.toThrow("不正な ref");
-    await expect(store.remove("../escape:latest")).rejects.toThrow("不正な ref");
-  });
-
-  it("パストラバーサルを含む layer 名を拒否する", async () => {
-    const data = createTestImageData();
-    data.layers.set("../../etc/passwd", Buffer.from("malicious"));
-    await expect(store.save("org/agent:1.0.0", data)).rejects.toThrow("不正な layer 名");
-  });
-
   it("存在しない ref の load → null", async () => {
     const loaded = await store.load("nonexistent/agent:1.0.0");
     expect(loaded).toBeNull();

--- a/packages/easyflow-cli/test/store/image-store.test.ts
+++ b/packages/easyflow-cli/test/store/image-store.test.ts
@@ -108,6 +108,13 @@ describe("ImageStore", () => {
     expect(refs).toEqual(["org/agent:1.0.0", "org/agent:latest"]);
   });
 
+  it("単一セグメント ref の save → list で ref が維持される", async () => {
+    await store.save("agent:latest", createTestImageData("single-seg"));
+    const images = await store.list();
+    expect(images.length).toBe(1);
+    expect(images[0].ref).toBe("agent:latest");
+  });
+
   it("同一 ref を別 digest で上書きした場合、list に古い ref が残らない", async () => {
     await store.save("org/agent:1.0.0", createTestImageData("v1"));
     await store.save("org/agent:1.0.0", createTestImageData("v2"));

--- a/packages/easyflow-cli/test/store/image-store.test.ts
+++ b/packages/easyflow-cli/test/store/image-store.test.ts
@@ -176,4 +176,20 @@ describe("ImageStore", () => {
 
     await fs.rm(outsideDir, { recursive: true, force: true });
   });
+
+  it("layer 名境界が異なるデータは別 digest になる", async () => {
+    const dataA: ImageData = {
+      manifest: { schemaVersion: 2 },
+      config: { name: "a", version: "1.0.0", description: "", tools: [], channels: [] },
+      layers: new Map([["a", Buffer.from("bc")]]),
+    };
+    const dataB: ImageData = {
+      manifest: { schemaVersion: 2 },
+      config: { name: "a", version: "1.0.0", description: "", tools: [], channels: [] },
+      layers: new Map([["ab", Buffer.from("c")]]),
+    };
+    const storedA = await store.save("org/a:1.0.0", dataA);
+    const storedB = await store.save("org/b:1.0.0", dataB);
+    expect(storedA.digest).not.toBe(storedB.digest);
+  });
 });

--- a/packages/easyflow-cli/test/store/image-store.test.ts
+++ b/packages/easyflow-cli/test/store/image-store.test.ts
@@ -129,10 +129,16 @@ describe("ImageStore", () => {
     expect(pruned.freedBytes).toBeGreaterThan(0);
   });
 
-  it("パストラバーサルを含む ref は拒否される", () => {
-    expect(() => ImageStore.parseRef("../../tmp/x:tag")).toThrow("Invalid ref segment");
-    expect(() => ImageStore.parseRef("org/../etc:tag")).toThrow("Invalid ref segment");
-    expect(() => ImageStore.parseRef(":tag")).toThrow("Invalid ref segment");
+  it("パストラバーサルを含む ref は拒否される", async () => {
+    const data = createTestImageData();
+    await expect(store.save("../../tmp/x:tag", data)).rejects.toThrow("Invalid ref");
+    await expect(store.load("org/../etc:tag")).rejects.toThrow("Invalid ref");
+    await expect(store.remove("../escape:latest")).rejects.toThrow("Invalid ref");
+  });
+
+  it("tag にスラッシュを含む ref は拒否される", async () => {
+    const data = createTestImageData();
+    await expect(store.save("org/agent:release/canary", data)).rejects.toThrow("Invalid ref");
   });
 
   it("パストラバーサルを含む layer 名は save で拒否される", async () => {

--- a/packages/easyflow-cli/test/store/image-store.test.ts
+++ b/packages/easyflow-cli/test/store/image-store.test.ts
@@ -141,6 +141,13 @@ describe("ImageStore", () => {
     await expect(store.save("org/agent:release/canary", data)).rejects.toThrow("Invalid ref");
   });
 
+  it("空セグメントを含む ref は拒否される", async () => {
+    const data = createTestImageData();
+    await expect(store.save("org//agent:1.0.0", data)).rejects.toThrow("Invalid ref");
+    await expect(store.save("org/agent/:1.0.0", data)).rejects.toThrow("Invalid ref");
+    await expect(store.save("/agent:1.0.0", data)).rejects.toThrow("Invalid ref");
+  });
+
   it("パストラバーサルを含む layer 名は save で拒否される", async () => {
     const data = createTestImageData();
     data.layers.set("../../etc/passwd", Buffer.from("bad"));

--- a/packages/easyflow-cli/test/store/image-store.test.ts
+++ b/packages/easyflow-cli/test/store/image-store.test.ts
@@ -122,5 +122,10 @@ describe("ImageStore", () => {
     const images = await store.list();
     expect(images.length).toBe(1);
     expect(images[0].ref).toBe("org/agent:1.0.0");
+
+    // 古い digest ディレクトリが孤立 → prune で削除できる
+    const pruned = await store.prune();
+    expect(pruned.removed).toBe(1);
+    expect(pruned.freedBytes).toBeGreaterThan(0);
   });
 });

--- a/packages/easyflow-cli/test/store/image-store.test.ts
+++ b/packages/easyflow-cli/test/store/image-store.test.ts
@@ -85,7 +85,7 @@ describe("ImageStore", () => {
     // so let's create a scenario: save, then manually break the symlink
     await store.save(ref, createTestImageData("prune-test"));
     const { org, name, tag } = ImageStore.parseRef(ref);
-    const tagDir = path.join(tmpDir, "refs", org, name, tag);
+    const tagDir = path.join(tmpDir, "refs", org, name, "tags", tag);
     await fs.unlink(tagDir);
 
     const result = await store.prune();
@@ -165,7 +165,7 @@ describe("ImageStore", () => {
     const ref = "org/agent:1.0.0";
     await store.save(ref, createTestImageData());
     const { org, name, tag } = ImageStore.parseRef(ref);
-    const tagDir = path.join(tmpDir, "refs", org, name, tag);
+    const tagDir = path.join(tmpDir, "refs", org, name, "tags", tag);
 
     // symlink をストア外のディレクトリに差し替え
     const outsideDir = await fs.mkdtemp(path.join(os.tmpdir(), "outside-store-"));

--- a/packages/easyflow-cli/test/store/image-store.test.ts
+++ b/packages/easyflow-cli/test/store/image-store.test.ts
@@ -97,4 +97,23 @@ describe("ImageStore", () => {
     const loaded = await store.load("nonexistent/agent:1.0.0");
     expect(loaded).toBeNull();
   });
+
+  it("同一 digest に複数 ref を付けた場合、list で全 ref が返る", async () => {
+    const data = createTestImageData("shared-content");
+    await store.save("org/agent:1.0.0", data);
+    await store.save("org/agent:latest", data);
+
+    const images = await store.list();
+    const refs = images.map((img) => img.ref).sort();
+    expect(refs).toEqual(["org/agent:1.0.0", "org/agent:latest"]);
+  });
+
+  it("同一 ref を別 digest で上書きした場合、list に古い ref が残らない", async () => {
+    await store.save("org/agent:1.0.0", createTestImageData("v1"));
+    await store.save("org/agent:1.0.0", createTestImageData("v2"));
+
+    const images = await store.list();
+    expect(images.length).toBe(1);
+    expect(images[0].ref).toBe("org/agent:1.0.0");
+  });
 });

--- a/packages/easyflow-cli/test/store/image-store.test.ts
+++ b/packages/easyflow-cli/test/store/image-store.test.ts
@@ -146,4 +146,34 @@ describe("ImageStore", () => {
     data.layers.set("../../etc/passwd", Buffer.from("bad"));
     await expect(store.save("org/agent:1.0.0", data)).rejects.toThrow("Invalid layer name");
   });
+
+  it("複数コロンを含む ref は拒否される", async () => {
+    const data = createTestImageData();
+    await expect(store.save("org/agent:release:2026", data)).rejects.toThrow(
+      'at most one ":" is allowed',
+    );
+  });
+
+  it("ストア外を指す symlink は load で無視される", async () => {
+    const ref = "org/agent:1.0.0";
+    await store.save(ref, createTestImageData());
+    const { org, name, tag } = ImageStore.parseRef(ref);
+    const tagDir = path.join(tmpDir, org, name, tag);
+
+    // symlink をストア外のディレクトリに差し替え
+    const outsideDir = await fs.mkdtemp(path.join(os.tmpdir(), "outside-store-"));
+    await fs.writeFile(path.join(outsideDir, "manifest.json"), "{}");
+    await fs.writeFile(path.join(outsideDir, "config.json"), "{}");
+    await fs.unlink(tagDir);
+    await fs.symlink(outsideDir, tagDir);
+
+    const loaded = await store.load(ref);
+    expect(loaded).toBeNull();
+
+    // list でもストア外を指す symlink は除外される
+    const images = await store.list();
+    expect(images.length).toBe(0);
+
+    await fs.rm(outsideDir, { recursive: true, force: true });
+  });
 });

--- a/packages/easyflow-cli/test/store/image-store.test.ts
+++ b/packages/easyflow-cli/test/store/image-store.test.ts
@@ -220,4 +220,11 @@ describe("ImageStore", () => {
     const refs = images.map((img) => img.ref).sort();
     expect(refs).toEqual(["_/agent:latest", "agent:latest"]);
   });
+
+  it("name に tags を含む ref が list で正しく復元される", async () => {
+    await store.save("org/tags:1.0.0", createTestImageData("tags-name"));
+    const images = await store.list();
+    expect(images.length).toBe(1);
+    expect(images[0].ref).toBe("org/tags:1.0.0");
+  });
 });

--- a/packages/easyflow-cli/test/store/image-store.test.ts
+++ b/packages/easyflow-cli/test/store/image-store.test.ts
@@ -1,0 +1,100 @@
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { ImageStore } from "../../src/store/image-store.js";
+import type { ImageData } from "../../src/store/types.js";
+
+function createTestImageData(content = "test-layer-data"): ImageData {
+  return {
+    manifest: { schemaVersion: 2 },
+    config: {
+      name: "test-agent",
+      version: "1.0.0",
+      description: "A test agent",
+      tools: ["tool-a"],
+      channels: ["slack"],
+    },
+    layers: new Map([["layer0.bin", Buffer.from(content)]]),
+  };
+}
+
+describe("ImageStore", () => {
+  let tmpDir: string;
+  let store: ImageStore;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "easyflow-store-test-"));
+    store = new ImageStore(tmpDir);
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("save → load でデータが一致する", async () => {
+    const ref = "estack-inc/support:1.0.0";
+    const data = createTestImageData();
+    await store.save(ref, data);
+
+    const loaded = await store.load(ref);
+    expect(loaded).not.toBeNull();
+    expect(loaded!.manifest).toEqual(data.manifest);
+    expect(loaded!.config).toEqual(data.config);
+    expect(loaded!.layers.get("layer0.bin")).toEqual(data.layers.get("layer0.bin"));
+  });
+
+  it("list で複数イメージを全件取得できる", async () => {
+    await store.save("org/agent-a:1.0.0", createTestImageData("a"));
+    await store.save("org/agent-b:2.0.0", createTestImageData("b"));
+
+    const images = await store.list();
+    expect(images.length).toBe(2);
+    const refs = images.map((img) => img.ref).sort();
+    expect(refs).toEqual(["org/agent-a:1.0.0", "org/agent-b:2.0.0"]);
+  });
+
+  it("remove 後に load で null が返る", async () => {
+    const ref = "org/agent:1.0.0";
+    await store.save(ref, createTestImageData());
+
+    const removed = await store.remove(ref);
+    expect(removed).toBe(true);
+
+    const loaded = await store.load(ref);
+    expect(loaded).toBeNull();
+  });
+
+  it("ref パースが正しい", () => {
+    const parsed = ImageStore.parseRef("estack-inc/support:1.0.0");
+    expect(parsed).toEqual({ org: "estack-inc", name: "support", tag: "1.0.0" });
+  });
+
+  it("ref パース — タグなしは latest", () => {
+    const parsed = ImageStore.parseRef("estack-inc/support");
+    expect(parsed).toEqual({ org: "estack-inc", name: "support", tag: "latest" });
+  });
+
+  it("prune でタグなしイメージが削除される", async () => {
+    const ref = "org/agent:1.0.0";
+    await store.save(ref, createTestImageData());
+
+    // Remove the tag symlink but leave the digest directory
+    await store.remove(ref);
+    // remove only removes the digest dir too when no other refs exist,
+    // so let's create a scenario: save, then manually break the symlink
+    await store.save(ref, createTestImageData("prune-test"));
+    const { org, name, tag } = ImageStore.parseRef(ref);
+    const tagDir = path.join(tmpDir, org, name, tag);
+    await fs.unlink(tagDir);
+
+    const result = await store.prune();
+    expect(result.removed).toBe(1);
+    expect(result.freedBytes).toBeGreaterThan(0);
+  });
+
+  it("存在しない ref の load → null", async () => {
+    const loaded = await store.load("nonexistent/agent:1.0.0");
+    expect(loaded).toBeNull();
+  });
+});

--- a/packages/easyflow-cli/test/store/image-store.test.ts
+++ b/packages/easyflow-cli/test/store/image-store.test.ts
@@ -85,7 +85,7 @@ describe("ImageStore", () => {
     // so let's create a scenario: save, then manually break the symlink
     await store.save(ref, createTestImageData("prune-test"));
     const { org, name, tag } = ImageStore.parseRef(ref);
-    const tagDir = path.join(tmpDir, org, name, tag);
+    const tagDir = path.join(tmpDir, "refs", org, name, tag);
     await fs.unlink(tagDir);
 
     const result = await store.prune();
@@ -158,7 +158,7 @@ describe("ImageStore", () => {
     const ref = "org/agent:1.0.0";
     await store.save(ref, createTestImageData());
     const { org, name, tag } = ImageStore.parseRef(ref);
-    const tagDir = path.join(tmpDir, org, name, tag);
+    const tagDir = path.join(tmpDir, "refs", org, name, tag);
 
     // symlink をストア外のディレクトリに差し替え
     const outsideDir = await fs.mkdtemp(path.join(os.tmpdir(), "outside-store-"));


### PR DESCRIPTION
## Summary
- `packages/easyflow-cli/` パッケージを新規作成し、CLI 基盤を実装
- **設定管理**: `ConfigManager` による JSON ファイルベースの設定読み書き（ネストキー対応）、`easyflow config set/get` コマンド
- **ローカルイメージストア**: `ImageStore` による digest ベース保存（シンボリックリンクタグ）、`easyflow images / images rm / images prune` コマンド
- **共通ユーティリティ**: `EasyflowError`（原因+対処法表示）、`Logger`、`StepProgress`（ora スピナー）
- 未実装コマンド（build, deploy 等）のスタブ登録
- 全 16 テストケース pass、Biome lint/format clean

## Test plan
- [x] `npx easyflow --version` で `0.1.0` が表示される
- [x] `npx easyflow --help` で全コマンドが表示される
- [x] ConfigManager の set/get/ネストキー/永続化テスト pass
- [x] ImageStore の save/load/remove/list/prune/ref パーステスト pass
- [x] CLI コマンドテスト（--version, --help, config set/get, 未実装コマンドエラー）pass
- [x] `npm test` 全ワークスペーステスト pass
- [x] `npm run lint` Biome チェック pass