### PR TITLE
fix: codex-review の VERDICT 抽出を三重防御化

### DIFF
--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -100,6 +100,10 @@ jobs:
             ${{ github.event.pull_request.base.ref }} \
             +refs/pull/${{ github.event.pull_request.number }}/head
 
+      - name: Install bubblewrap
+        if: steps.check_files.outputs.skip != 'true'
+        run: sudo apt-get update && sudo apt-get install -y bubblewrap
+
       - name: Run Codex Review
         id: codex_review
         if: steps.check_files.outputs.skip != 'true'
@@ -237,6 +241,15 @@ jobs:
             VERDICT 行は `<!-- VERDICT:APPROVED -->` または `<!-- VERDICT:CHANGES_REQUESTED -->` のいずれか。
             この行は出力の最終行に必ず含めること。
 
+            ## 最終メッセージ要件（必須）
+
+            以下を **両方** 満たしてください:
+            1. OUTPUT block 全文（`### 変更の概要` から `<!-- VERDICT:... -->` まで）を `/tmp/review-result.md` に書き込む
+            2. **最終チャットメッセージ（あなたの最後の発話）にも全く同じ OUTPUT block を含める**
+
+            ファイル書き込みだけでは不十分です。最終チャットメッセージは output-file のフォールバックとして利用されるため、VERDICT トークンを必ず含めてください。
+            GitHub への直接投稿は引き続き禁止です。
+
             ## レビュー方針
             - 確信がない指摘は避け、確実な問題のみ指摘する
             - 修正漏れの検出を最優先で行う
@@ -271,34 +284,59 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
         run: |
-          # Primary: parse machine-readable VERDICT comment
+          VERDICT=""
+
+          # Layer 1: VERDICT トークン
           VERDICT=$(sed -n 's/^<!-- VERDICT:\([A-Z_]*\) -->/\1/p' /tmp/review-result.md | head -1)
 
-          # Fallback: parse header line
+          # Layer 2: "### レビュー結果:" ヘッダの絵文字・キーワード
           if [ -z "$VERDICT" ]; then
-            HEADER=$(grep -E '^### (判定|レビュー結果):' /tmp/review-result.md | head -1 | \
-              sed 's/.*: //' | cut -c1-50)
-            echo "Fallback header: $HEADER"
-            if echo "$HEADER" | grep -qiE 'CHANGES_REQUESTED|Changes Requested|要修正'; then
-              VERDICT="CHANGES_REQUESTED"
-            elif echo "$HEADER" | grep -qiE 'APPROVED|APPROVE|Approved|✅'; then
+            echo "::warning::No VERDICT token in file, trying header fallback"
+            # grep が no-match を返してもステップを落とさないため || true を付与
+            HEADER_LINE=$(grep -m1 -E '^### (判定|レビュー結果):' /tmp/review-result.md || true)
+            if [ -n "$HEADER_LINE" ]; then
+              HEADER=$(echo "$HEADER_LINE" | sed 's/.*: //' | cut -c1-50)
+              echo "Fallback header line: $HEADER"
+              if echo "$HEADER" | grep -qiE 'CHANGES_REQUESTED|Changes Requested|要修正|❌'; then
+                VERDICT="CHANGES_REQUESTED"
+              elif echo "$HEADER" | grep -qiE 'APPROVED|APPROVE|Approved|✅'; then
+                VERDICT="APPROVED"
+              fi
+            else
+              echo "No header found in review output"
+            fi
+          fi
+
+          # Layer 3: Codex 最終メッセージの自然文（"判定は `APPROVED` です" など）
+          if [ -z "$VERDICT" ]; then
+            echo "::warning::No header found, trying natural-language fallback"
+            if grep -qE '判定は[^A-Z]*`?APPROVED`?' /tmp/review-result.md; then
               VERDICT="APPROVED"
+            elif grep -qE '判定は[^A-Z]*`?CHANGES_REQUESTED`?' /tmp/review-result.md; then
+              VERDICT="CHANGES_REQUESTED"
             fi
           fi
 
           echo "Verdict: $VERDICT"
-          if [ "$VERDICT" = "CHANGES_REQUESTED" ]; then
-            echo "Submitting CHANGES_REQUESTED review"
-            gh pr review "$PR_NUMBER" --repo "$REPO" --request-changes \
-              --body "🤖 AIレビュー判定: CHANGES_REQUESTED — 詳細はレビューコメントを確認してください。"
-          elif [ "$VERDICT" = "APPROVED" ]; then
-            echo "Submitting APPROVED review"
-            gh pr review "$PR_NUMBER" --repo "$REPO" --approve \
-              --body "🤖 AIレビュー判定: APPROVED ✅"
-          else
-            echo "Could not determine verdict"
-            echo "Skipping review submission"
-          fi
+
+          case "$VERDICT" in
+            CHANGES_REQUESTED)
+              gh pr review "$PR_NUMBER" --repo "$REPO" --request-changes \
+                --body "🤖 AIレビュー判定: CHANGES_REQUESTED ❌" \
+                || echo "::warning::Could not submit review"
+              ;;
+            APPROVED)
+              gh pr review "$PR_NUMBER" --repo "$REPO" --approve \
+                --body "🤖 AIレビュー判定: APPROVED ✅" \
+                || echo "::warning::Could not submit review"
+              ;;
+            *)
+              # Layer 4: silent skip 廃止。コメント形式レビューで可視化
+              gh pr review "$PR_NUMBER" --repo "$REPO" --comment \
+                --body "🤖 AIレビュー判定: **判定不能** — Codex 出力から VERDICT を抽出できませんでした。レビューコメント本文を確認してください。" \
+                || echo "::warning::Could not submit fallback comment"
+              ;;
+          esac
 
       - name: Notify Slack on Failure
         if: failure() && steps.check_files.outputs.skip != 'true'


### PR DESCRIPTION
## Summary

Codex Review ワークフローの VERDICT 抽出失敗による silent skip を解消するため、**案 A' + 案 A + 案 B の三重防御**を適用します。

## 背景

`/tmp/review-result.md` に書かれているはずの VERDICT が読み取れず、`Submit review verdict` ステップが silent skip する事象が親リポジトリ (easy-flow) を含む複数 PR で発生。観測事実と仮説、対応の詳細は指示書を参照:

- 指示書: [docs/operations/codex-review-verdict-extraction-fix.md](https://github.com/estack-inc/easy-flow/blob/main/docs/operations/codex-review-verdict-extraction-fix.md)
- 親 Issue: estack-inc/easy-flow#268
- 子 Issue: #152

## 変更内容

### 案 A': bubblewrap 明示インストール
`ubuntu-latest` にはデフォルトで bubblewrap が入っておらず vendored 版が使われる。vendored 版とホストカーネルの互換性差異が原因の可能性を排除するため、OS パッケージ版を明示インストール。

### 案 A: プロンプト強化
Codex に「最終チャットメッセージにも OUTPUT block 全文を含める」よう指示を追加。output-file への書き込みが欠落してもチャット本文から復元可能にする。

### 案 B: Submit verdict の 4 層フォールバック

| Layer | 抽出源 | 目的 |
|-------|--------|------|
| 1 | `<!-- VERDICT:... -->` トークン | 最も確実 |
| 2 | `### レビュー結果:` ヘッダ | 既存フォールバック（pipefail 非致命化） |
| 3 | 自然文「判定は APPROVED です」等 | 最終メッセージ文中の復元 |
| 4 | コメント形式レビュー投稿 | silent skip 廃止、判定不能を可視化 |

## 検証

- **easy-flow#286** (マージ済 afb1d2b): Phase 1 で三重防御を適用、Codex 再レビューで Approved を確認
- **openclaw-templates#219** (マージ済 8da31ed): Layer 2 pipefail 修正の横展開で Approved を確認

## Test plan

- [ ] CI が通過する
- [ ] Codex レビューで ✅ Approved または適切な判定が出る
- [ ] `Submit review verdict` が silent skip せず Layer 1-4 のいずれかで判定を出す