### PR TITLE
fix(codex-review): VERDICT 抽出失敗の修正 (AI_REVIEWER_TOKEN 廃止 + tail -1)

### DIFF
--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -4,7 +4,6 @@
 #
 # 必要な Secrets:
 #   OPENAI_API_KEY      — OpenAI API キー
-#   AI_REVIEWER_TOKEN   — GitHub PAT（PR レビュー投稿用、省略時 GITHUB_TOKEN）
 #   SLACK_WEBHOOK_URL   — Slack 通知用 Webhook URL（省略時は通知スキップ）
 
 name: Codex Code Review
@@ -257,13 +256,13 @@ jobs:
             - 全ての問題を 1 回のレビューで網羅的に検出する。小出しにしない
             - GitHub への直接投稿（gh pr comment, gh pr review）は行わない
         env:
-          GH_TOKEN: ${{ secrets.AI_REVIEWER_TOKEN || secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Post review comment
         id: post_review
         if: steps.check_files.outputs.skip != 'true' && success()
         env:
-          GH_TOKEN: ${{ secrets.AI_REVIEWER_TOKEN || secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
         run: |
@@ -280,20 +279,22 @@ jobs:
           steps.codex_review.conclusion == 'success' &&
           steps.post_review.conclusion == 'success'
         env:
-          GH_TOKEN: ${{ secrets.AI_REVIEWER_TOKEN || secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
         run: |
           VERDICT=""
 
           # Layer 1: VERDICT トークン
-          VERDICT=$(sed -n 's/^<!-- VERDICT:\([A-Z_]*\) -->/\1/p' /tmp/review-result.md | head -1)
+          # 注: Codex が finding 説明などで先頭に VERDICT 例を echo するケースがあるため、
+          # 先頭一致ではなく「最終出現」を採用する（真の verdict は出力末尾にある）
+          VERDICT=$(sed -n 's/^<!-- VERDICT:\([A-Z_]*\) -->/\1/p' /tmp/review-result.md | tail -1)
 
           # Layer 2: "### レビュー結果:" ヘッダの絵文字・キーワード
           if [ -z "$VERDICT" ]; then
             echo "::warning::No VERDICT token in file, trying header fallback"
-            # grep が no-match を返してもステップを落とさないため || true を付与
-            HEADER_LINE=$(grep -m1 -E '^### (判定|レビュー結果):' /tmp/review-result.md || true)
+            # Layer 1 と同様、最終出現のヘッダを採用（先頭一致だとテンプレ例を拾う懸念あり）
+            HEADER_LINE=$(grep -E '^### (判定|レビュー結果):' /tmp/review-result.md | tail -1 || true)
             if [ -n "$HEADER_LINE" ]; then
               HEADER=$(echo "$HEADER_LINE" | sed 's/.*: //' | cut -c1-50)
               echo "Fallback header line: $HEADER"


### PR DESCRIPTION
## 概要

Issue #152 の実装 PR。portal [#19](https://github.com/estack-inc/easy-flow-portal/pull/19) での検証結果を踏まえ、以下 2 点を適用します。

## 変更内容

### 1. `AI_REVIEWER_TOKEN` 廃止 → `GITHUB_TOKEN` 統一

- `Run Codex Review` / `Post review comment` / `Submit review verdict` の 3 ステップすべての `GH_TOKEN` を `GITHUB_TOKEN` 単独に統一
- 必須 Secrets コメントから `AI_REVIEWER_TOKEN` を削除
- **副作用**: formal Approve / Request-Changes の名義が `github-actions[bot]` に変わります（従来は PAT 所有者名義）

### 2. VERDICT 抽出の `head -1` → `tail -1` 化

portal #19 で Codex の自己レビューが誤判定された事象への追随修正。

Codex は finding 説明などで出力本文内に `<!-- VERDICT:APPROVED -->` などの例を echo することがあり、`head -1` だと先頭のテンプレ例を拾って真の verdict（通常は出力末尾）を上書きしてしまう問題があります。

Layer 1 / Layer 2 をいずれも **最終出現（`tail -1`）採用** に変更しました。

## テスト方針

- 本 PR の CI で新 workflow が走ることで自動検証されます
- Codex が self-review で `APPROVED` を返し、github-actions[bot] が正しく Approve できれば成功

## 関連

- Parent Issue: #152
- portal 先行実装: estack-inc/easy-flow-portal#19