### PR TITLE
feat(easyflow-cli): easyflow inspect / validate コマンドの実装 (#223)

### DIFF
--- a/packages/easyflow-cli/src/cli/commands/index.ts
+++ b/packages/easyflow-cli/src/cli/commands/index.ts
@@ -2,3 +2,5 @@ export { registerBuildCommand } from "./build.js";
 export { registerConfigCommand } from "./config.js";
 export { registerConvertCommand } from "./convert.js";
 export { registerImagesCommand } from "./images.js";
+export { registerInspectCommand } from "./inspect.js";
+export { registerValidateCommand } from "./validate.js";

--- a/packages/easyflow-cli/src/cli/commands/inspect.ts
+++ b/packages/easyflow-cli/src/cli/commands/inspect.ts
@@ -1,0 +1,28 @@
+import type { Command } from "commander";
+import { formatHuman, formatJson } from "../../inspect/formatter.js";
+import { inspectImage } from "../../inspect/inspector.js";
+import { handleError } from "../../utils/errors.js";
+
+interface InspectCliOptions {
+  json: boolean;
+}
+
+export function registerInspectCommand(program: Command): void {
+  program
+    .command("inspect")
+    .description("ローカルイメージのメタデータ・レイヤー情報を表示")
+    .argument("<ref>", "イメージの ref（例: org/name:1.0）")
+    .option("--json", "JSON 形式で出力", false)
+    .action(async (ref: string, options: InspectCliOptions) => {
+      try {
+        const report = await inspectImage(ref);
+        if (options.json) {
+          console.log(formatJson(report));
+        } else {
+          console.log(formatHuman(report));
+        }
+      } catch (error) {
+        handleError(error);
+      }
+    });
+}

--- a/packages/easyflow-cli/src/cli/commands/validate.ts
+++ b/packages/easyflow-cli/src/cli/commands/validate.ts
@@ -1,0 +1,27 @@
+import type { Command } from "commander";
+import { formatHuman, formatJson } from "../../validate/formatter.js";
+import { validateAgentfile } from "../../validate/validator.js";
+
+interface ValidateCliOptions {
+  file: string;
+  json: boolean;
+}
+
+export function registerValidateCommand(program: Command): void {
+  program
+    .command("validate")
+    .description("Agentfile のスキーマ・ファイル存在・base 解決を検証")
+    .requiredOption("-f, --file <path>", "Agentfile のパス")
+    .option("--json", "JSON 形式で出力", false)
+    .action(async (options: ValidateCliOptions) => {
+      const report = await validateAgentfile(options.file);
+      if (options.json) {
+        console.log(formatJson(report));
+      } else {
+        console.log(formatHuman(report));
+      }
+      if (!report.ok) {
+        process.exit(1);
+      }
+    });
+}

--- a/packages/easyflow-cli/src/cli/index.ts
+++ b/packages/easyflow-cli/src/cli/index.ts
@@ -4,6 +4,8 @@ import {
   registerConfigCommand,
   registerConvertCommand,
   registerImagesCommand,
+  registerInspectCommand,
+  registerValidateCommand,
 } from "./commands/index.js";
 
 const program = new Command();
@@ -24,9 +26,11 @@ registerConfigCommand(program);
 registerImagesCommand(program);
 registerBuildCommand(program);
 registerConvertCommand(program);
+registerInspectCommand(program);
+registerValidateCommand(program);
 
 // 後続タスクで追加するコマンドのスタブ
-const stubCommands = ["deploy", "validate", "inspect", "push", "pull", "knowledge"];
+const stubCommands = ["deploy", "push", "pull", "knowledge"];
 for (const name of stubCommands) {
   program
     .command(name)

--- a/packages/easyflow-cli/src/inspect/formatter.ts
+++ b/packages/easyflow-cli/src/inspect/formatter.ts
@@ -1,0 +1,90 @@
+import type { InspectReport } from "./types.js";
+
+function formatBytes(bytes: number): string {
+  if (bytes === 0) return "0 B";
+  const units = ["B", "KB", "MB", "GB"];
+  const i = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1);
+  const value = bytes / 1024 ** i;
+  return `${value.toFixed(i === 0 ? 0 : 1)} ${units[i]}`;
+}
+
+/**
+ * InspectReport を人間向けテキスト形式にフォーマットする。
+ */
+export function formatHuman(report: InspectReport): string {
+  const lines: string[] = [];
+
+  lines.push("=== Image ===");
+  lines.push(`  Ref:       ${report.ref}`);
+  lines.push(`  Digest:    ${report.digest}`);
+  lines.push(`  Size:      ${formatBytes(report.size)}`);
+  lines.push(`  CreatedAt: ${report.createdAt}`);
+  lines.push("");
+
+  lines.push("=== Metadata ===");
+  lines.push(`  Name:        ${report.metadata.name}`);
+  lines.push(`  Version:     ${report.metadata.version}`);
+  lines.push(`  Description: ${report.metadata.description}`);
+  lines.push(`  Author:      ${report.metadata.author}`);
+  if (report.metadata.base) {
+    lines.push(
+      `  Base:        ${report.metadata.base.ref}${report.metadata.base.digest ? ` (${report.metadata.base.digest})` : ""}`,
+    );
+  }
+  lines.push("");
+
+  lines.push("=== Identity ===");
+  lines.push(`  Name:        ${report.identity.name}`);
+  lines.push(`  Soul:        ${report.identity.soulPreview}`);
+  lines.push(`  Policies:    ${report.identity.policyCount}`);
+  lines.push("");
+
+  lines.push("=== Knowledge ===");
+  lines.push(`  Total Chunks: ${report.knowledge.totalChunks}`);
+  lines.push(`  Total Tokens: ${report.knowledge.totalTokens}`);
+  if (report.knowledge.sources.length > 0) {
+    lines.push("  Sources:");
+    for (const src of report.knowledge.sources) {
+      lines.push(`    - ${src.path} [${src.type}] chunks=${src.chunks} tokens=${src.tokens}`);
+    }
+  } else {
+    lines.push("  Sources: (none)");
+  }
+  lines.push("");
+
+  lines.push("=== Tools ===");
+  if (report.tools.length > 0) {
+    for (const tool of report.tools) {
+      lines.push(`  - ${tool}`);
+    }
+  } else {
+    lines.push("  (none)");
+  }
+  lines.push("");
+
+  lines.push("=== Channels ===");
+  if (report.channels.length > 0) {
+    for (const ch of report.channels) {
+      lines.push(`  - ${ch}`);
+    }
+  } else {
+    lines.push("  (none)");
+  }
+  lines.push("");
+
+  lines.push("=== Layers ===");
+  for (const layer of report.layers) {
+    lines.push(
+      `  ${layer.name.padEnd(10)} ${formatBytes(layer.size).padStart(8)}  files=${layer.fileCount}  ${layer.digest}`,
+    );
+  }
+
+  return lines.join("\n");
+}
+
+/**
+ * InspectReport を JSON 形式にフォーマットする。
+ */
+export function formatJson(report: InspectReport): string {
+  return JSON.stringify(report, null, 2);
+}

--- a/packages/easyflow-cli/src/inspect/inspector.ts
+++ b/packages/easyflow-cli/src/inspect/inspector.ts
@@ -1,0 +1,128 @@
+import { ImageStore } from "../store/image-store.js";
+import { EasyflowError } from "../utils/errors.js";
+import type { InspectReport } from "./types.js";
+
+/**
+ * ImageStore からイメージ情報を取得して InspectReport を構築する。
+ */
+export async function inspectImage(ref: string, store?: ImageStore): Promise<InspectReport> {
+  const imageStore = store ?? new ImageStore();
+  const data = await imageStore.load(ref);
+
+  if (!data) {
+    throw new EasyflowError(`image not found: ${ref}`);
+  }
+
+  const { manifest, config, layers } = data;
+
+  // config.json から各フィールドを抽出
+  const cfgMetadata = (config.metadata ?? {}) as Record<string, unknown>;
+  const cfgBase = config.base as { ref?: string; digest?: string } | undefined;
+  const cfgKnowledge = (config.knowledge ?? { totalChunks: 0, totalTokens: 0, sources: [] }) as {
+    totalChunks: number;
+    totalTokens: number;
+    sources: { path: string; type: string; description?: string; chunks: number; tokens: number }[];
+  };
+  const cfgTools = (config.tools ?? []) as string[];
+  const cfgChannels = (config.channels ?? []) as string[];
+
+  // metadata セクション
+  const metadata = {
+    name: (cfgMetadata.name as string) ?? "",
+    version: (cfgMetadata.version as string) ?? "",
+    description: (cfgMetadata.description as string) ?? "",
+    author: (cfgMetadata.author as string) ?? "",
+    ...(cfgBase?.ref
+      ? { base: { ref: cfgBase.ref, ...(cfgBase.digest ? { digest: cfgBase.digest } : {}) } }
+      : {}),
+  };
+
+  // identity セクション (config.json にはソウルを持たないため description をプレビューとして使用)
+  const identityName = (cfgMetadata.name as string) ?? "";
+  const soulPreview =
+    metadata.description.length > 80
+      ? `${metadata.description.slice(0, 80)}...`
+      : metadata.description || "(no soul)";
+  const policyCount = 0; // config.json には policy 情報を含まない
+
+  // knowledge セクション
+  const knowledge = {
+    totalChunks: cfgKnowledge.totalChunks ?? 0,
+    totalTokens: cfgKnowledge.totalTokens ?? 0,
+    sources: (cfgKnowledge.sources ?? []).map((s) => ({
+      path: s.path,
+      type: s.type,
+      chunks: s.chunks,
+      tokens: s.tokens,
+    })),
+  };
+
+  // layers セクション: manifest から digest を、layers Map からサイズを取得
+  const manifestLayers = (manifest.layers ?? []) as Array<{
+    digest: string;
+    size: number;
+    annotations?: { "org.easyflow.layer.name"?: string };
+  }>;
+
+  const layerInfos = manifestLayers.map((ml) => {
+    const layerName = (ml.annotations?.["org.easyflow.layer.name"] ?? "config") as
+      | "identity"
+      | "knowledge"
+      | "tools"
+      | "config";
+    const buf = layers.get(layerName);
+    const size = buf?.length ?? ml.size ?? 0;
+    // tar エントリ数のカウント（簡易: バッファが空なら 0）
+    const fileCount = buf && buf.length > 0 ? estimateTarFileCount(buf) : 0;
+
+    return {
+      name: layerName,
+      size,
+      fileCount,
+      digest: ml.digest ?? "",
+    };
+  });
+
+  // manifest から digest を取得（storedImage の digest を利用するため再計算）
+  // manifest に存在する config.digest を利用
+  const cfgDescriptor = manifest.config as { digest?: string } | undefined;
+  const digest = cfgDescriptor?.digest ?? "";
+
+  // StoredImage の情報を取得するために image.json を読む（直接 load では取得できないため）
+  // サイズと createdAt はストアの別 API で取得するか推定する
+  const totalSize = layerInfos.reduce((acc, l) => acc + l.size, 0);
+
+  return {
+    ref,
+    digest,
+    size: totalSize,
+    createdAt: (cfgMetadata.createdAt as string) ?? new Date().toISOString(),
+    metadata,
+    identity: {
+      name: identityName,
+      soulPreview,
+      policyCount,
+    },
+    knowledge,
+    tools: cfgTools,
+    channels: cfgChannels,
+    layers: layerInfos,
+  };
+}
+
+/**
+ * tar.gz バッファからファイル数を推定する（簡易実装）。
+ * ヘッダーブロック(512 バイト)をスキャンして非空エントリを数える。
+ */
+function estimateTarFileCount(buf: Buffer): number {
+  // gzip ヘッダーで始まる場合はデコードできないため 1 を返す
+  // 実際の実装では tar パッケージを利用するが、同期処理のためシンプルに推定
+  if (buf.length < 2) return 0;
+  // gzip magic bytes: 0x1f 0x8b
+  if (buf[0] === 0x1f && buf[1] === 0x8b) {
+    // gz 圧縮済み — 正確なカウントは非同期 tar パースが必要
+    // フォールバック: 1 以上のファイルが存在すると推定
+    return buf.length > 0 ? 1 : 0;
+  }
+  return 0;
+}

--- a/packages/easyflow-cli/src/inspect/inspector.ts
+++ b/packages/easyflow-cli/src/inspect/inspector.ts
@@ -1,13 +1,24 @@
+import { Readable } from "node:stream";
+import * as tar from "tar";
 import { ImageStore } from "../store/image-store.js";
 import { EasyflowError } from "../utils/errors.js";
 import type { InspectReport } from "./types.js";
+
+// tar.Parser は @types/tar v6 では型定義が不完全なため型キャストで使用
+// biome-ignore lint/suspicious/noExplicitAny: tar.Parser not fully typed in @types/tar
+const TarParse = (tar as Record<string, any>)["Parser"] as new (opts: {
+  gzip: boolean;
+}) => NodeJS.WritableStream;
 
 /**
  * ImageStore からイメージ情報を取得して InspectReport を構築する。
  */
 export async function inspectImage(ref: string, store?: ImageStore): Promise<InspectReport> {
   const imageStore = store ?? new ImageStore();
-  const data = await imageStore.load(ref);
+  const [data, storedImage] = await Promise.all([
+    imageStore.load(ref),
+    imageStore.loadStoredImage(ref),
+  ]);
 
   if (!data) {
     throw new EasyflowError(`image not found: ${ref}`);
@@ -37,13 +48,26 @@ export async function inspectImage(ref: string, store?: ImageStore): Promise<Ins
       : {}),
   };
 
-  // identity セクション (config.json にはソウルを持たないため description をプレビューとして使用)
-  const identityName = (cfgMetadata.name as string) ?? "";
+  // identity セクション — identity レイヤー tar.gz から IDENTITY.md / SOUL.md / POLICY.md を読む
+  const identityBuf = layers.get("identity");
+  const identityFiles =
+    identityBuf && identityBuf.length > 0
+      ? await readTarGzFiles(identityBuf, ["IDENTITY.md", "SOUL.md", "POLICY.md"]).catch(
+          () => new Map<string, string>(),
+        )
+      : new Map<string, string>();
+
+  const identityName =
+    parseIdentityName(identityFiles.get("IDENTITY.md") ?? "") || (cfgMetadata.name as string) || "";
+  const soulText = identityFiles.get("SOUL.md") ?? "";
+  const soulBody = soulText.replace(/^#[^\n]*\n\n?/, "").trim();
   const soulPreview =
-    metadata.description.length > 80
-      ? `${metadata.description.slice(0, 80)}...`
-      : metadata.description || "(no soul)";
-  const policyCount = 0; // config.json には policy 情報を含まない
+    soulBody.length > 0
+      ? soulBody.length > 80
+        ? `${soulBody.slice(0, 80)}...`
+        : soulBody
+      : "(no soul)";
+  const policyCount = parsePolicyCount(identityFiles.get("POLICY.md") ?? "");
 
   // knowledge セクション
   const knowledge = {
@@ -57,46 +81,45 @@ export async function inspectImage(ref: string, store?: ImageStore): Promise<Ins
     })),
   };
 
-  // layers セクション: manifest から digest を、layers Map からサイズを取得
+  // layers セクション: バッファを tar.Parse で正確にカウント
   const manifestLayers = (manifest.layers ?? []) as Array<{
     digest: string;
     size: number;
     annotations?: { "org.easyflow.layer.name"?: string };
   }>;
 
-  const layerInfos = manifestLayers.map((ml) => {
-    const layerName = (ml.annotations?.["org.easyflow.layer.name"] ?? "config") as
-      | "identity"
-      | "knowledge"
-      | "tools"
-      | "config";
-    const buf = layers.get(layerName);
-    const size = buf?.length ?? ml.size ?? 0;
-    // tar エントリ数のカウント（簡易: バッファが空なら 0）
-    const fileCount = buf && buf.length > 0 ? estimateTarFileCount(buf) : 0;
+  const layerInfos = await Promise.all(
+    manifestLayers.map(async (ml) => {
+      const layerName = (ml.annotations?.["org.easyflow.layer.name"] ?? "config") as
+        | "identity"
+        | "knowledge"
+        | "tools"
+        | "config";
+      const buf = layers.get(layerName);
+      const size = buf?.length ?? ml.size ?? 0;
+      const fileCount = buf && buf.length > 0 ? await countTarGzEntries(buf).catch(() => 0) : 0;
 
-    return {
-      name: layerName,
-      size,
-      fileCount,
-      digest: ml.digest ?? "",
-    };
-  });
+      return {
+        name: layerName,
+        size,
+        fileCount,
+        digest: ml.digest ?? "",
+      };
+    }),
+  );
 
-  // manifest から digest を取得（storedImage の digest を利用するため再計算）
-  // manifest に存在する config.digest を利用
-  const cfgDescriptor = manifest.config as { digest?: string } | undefined;
-  const digest = cfgDescriptor?.digest ?? "";
-
-  // StoredImage の情報を取得するために image.json を読む（直接 load では取得できないため）
-  // サイズと createdAt はストアの別 API で取得するか推定する
-  const totalSize = layerInfos.reduce((acc, l) => acc + l.size, 0);
+  // StoredImage から保存時の正確な digest / size / createdAt を取得
+  const digest =
+    storedImage?.digest ?? (manifest.config as { digest?: string } | undefined)?.digest ?? "";
+  const totalSize = storedImage?.size ?? layerInfos.reduce((acc, l) => acc + l.size, 0);
+  const createdAt =
+    storedImage?.createdAt ?? (cfgMetadata.createdAt as string) ?? new Date().toISOString();
 
   return {
     ref,
     digest,
     size: totalSize,
-    createdAt: (cfgMetadata.createdAt as string) ?? new Date().toISOString(),
+    createdAt,
     metadata,
     identity: {
       name: identityName,
@@ -110,19 +133,59 @@ export async function inspectImage(ref: string, store?: ImageStore): Promise<Ins
   };
 }
 
-/**
- * tar.gz バッファからファイル数を推定する（簡易実装）。
- * ヘッダーブロック(512 バイト)をスキャンして非空エントリを数える。
- */
-function estimateTarFileCount(buf: Buffer): number {
-  // gzip ヘッダーで始まる場合はデコードできないため 1 を返す
-  // 実際の実装では tar パッケージを利用するが、同期処理のためシンプルに推定
-  if (buf.length < 2) return 0;
-  // gzip magic bytes: 0x1f 0x8b
-  if (buf[0] === 0x1f && buf[1] === 0x8b) {
-    // gz 圧縮済み — 正確なカウントは非同期 tar パースが必要
-    // フォールバック: 1 以上のファイルが存在すると推定
-    return buf.length > 0 ? 1 : 0;
-  }
-  return 0;
+/** IDENTITY.md の先頭 `# <name>` 行から identity.name を取得する */
+function parseIdentityName(content: string): string {
+  const match = content.match(/^#\s+(.+)/m);
+  return match?.[1]?.trim() ?? "";
+}
+
+/** POLICY.md の箇条書き（`- ...`）の行数を policyCount として返す */
+function parsePolicyCount(content: string): number {
+  return content.split("\n").filter((l) => /^\s*-\s+/.test(l)).length;
+}
+
+/** tar.gz バッファから指定ファイルの内容を読み出す */
+async function readTarGzFiles(buf: Buffer, targetFiles: string[]): Promise<Map<string, string>> {
+  const result = new Map<string, string>();
+  const targetSet = new Set(targetFiles);
+
+  await new Promise<void>((resolve, reject) => {
+    const parser = new TarParse({ gzip: true });
+    // biome-ignore lint/suspicious/noExplicitAny: entry is tar.ReadEntry
+    parser.on("entry" as any, (entry: any) => {
+      const basename = (entry.path as string).replace(/^\.\//, "").replace(/\/$/, "");
+      if (targetSet.has(basename)) {
+        const chunks: Buffer[] = [];
+        entry.on("data", (chunk: Buffer) => chunks.push(chunk));
+        entry.on("end", () => {
+          result.set(basename, Buffer.concat(chunks).toString("utf-8"));
+        });
+        entry.on("error", reject);
+      } else {
+        entry.resume();
+      }
+    });
+    (parser as NodeJS.EventEmitter).on("finish", resolve);
+    (parser as NodeJS.EventEmitter).on("error", reject);
+    Readable.from(buf).pipe(parser);
+  });
+
+  return result;
+}
+
+/** tar.gz バッファ内のファイル（非ディレクトリ）エントリ数を返す */
+async function countTarGzEntries(buf: Buffer): Promise<number> {
+  let count = 0;
+  await new Promise<void>((resolve, reject) => {
+    const parser = new TarParse({ gzip: true });
+    // biome-ignore lint/suspicious/noExplicitAny: entry is tar.ReadEntry
+    parser.on("entry" as any, (entry: any) => {
+      if (entry.type !== "Directory") count++;
+      entry.resume();
+    });
+    (parser as NodeJS.EventEmitter).on("finish", resolve);
+    (parser as NodeJS.EventEmitter).on("error", reject);
+    Readable.from(buf).pipe(parser);
+  });
+  return count;
 }

--- a/packages/easyflow-cli/src/inspect/types.ts
+++ b/packages/easyflow-cli/src/inspect/types.ts
@@ -1,0 +1,31 @@
+export interface InspectReport {
+  ref: string;
+  digest: string;
+  size: number;
+  createdAt: string;
+  metadata: {
+    name: string;
+    version: string;
+    description: string;
+    author: string;
+    base?: { ref: string; digest?: string };
+  };
+  identity: {
+    name: string;
+    soulPreview: string;
+    policyCount: number;
+  };
+  knowledge: {
+    totalChunks: number;
+    totalTokens: number;
+    sources: { path: string; type: string; chunks: number; tokens: number }[];
+  };
+  tools: string[];
+  channels: string[];
+  layers: {
+    name: "identity" | "knowledge" | "tools" | "config";
+    size: number;
+    fileCount: number;
+    digest: string;
+  }[];
+}

--- a/packages/easyflow-cli/src/store/image-store.ts
+++ b/packages/easyflow-cli/src/store/image-store.ts
@@ -77,6 +77,24 @@ export class ImageStore {
     return storedImage;
   }
 
+  /** ref に対応する StoredImage（image.json の内容）を返す。存在しなければ null。 */
+  async loadStoredImage(ref: string): Promise<StoredImage | null> {
+    ImageStore.validateRef(ref);
+    const { org, name, tag } = ImageStore.parseRef(ref);
+    const tagDir = path.join(this.refsDir, org, name, "tags", tag);
+
+    try {
+      const realDir = await fs.realpath(tagDir);
+      if (!(await this.assertInsideStore(realDir))) {
+        return null;
+      }
+      const raw = await fs.readFile(path.join(realDir, "image.json"), "utf-8");
+      return JSON.parse(raw) as StoredImage;
+    } catch {
+      return null;
+    }
+  }
+
   async load(ref: string): Promise<ImageData | null> {
     ImageStore.validateRef(ref);
     const { org, name, tag } = ImageStore.parseRef(ref);

--- a/packages/easyflow-cli/src/validate/formatter.ts
+++ b/packages/easyflow-cli/src/validate/formatter.ts
@@ -1,0 +1,43 @@
+import type { ValidationReport } from "./types.js";
+
+/**
+ * ValidationReport を人間向けテキスト形式にフォーマットする。
+ */
+export function formatHuman(report: ValidationReport): string {
+  const lines: string[] = [];
+
+  if (report.ok) {
+    lines.push(`✓ ${report.file} — OK`);
+  } else {
+    lines.push(
+      `✗ ${report.file} — ${report.errors.length} error(s), ${report.warnings.length} warning(s)`,
+    );
+  }
+
+  if (report.errors.length > 0) {
+    lines.push("");
+    lines.push("Errors:");
+    for (const err of report.errors) {
+      const loc = err.path ? ` [${err.path}]` : "";
+      lines.push(`  [${err.category}]${loc} ${err.message}`);
+    }
+  }
+
+  if (report.warnings.length > 0) {
+    lines.push("");
+    lines.push("Warnings:");
+    for (const warn of report.warnings) {
+      const loc = warn.path ? ` [${warn.path}]` : "";
+      lines.push(`  [${warn.category}]${loc} ${warn.message}`);
+    }
+  }
+
+  return lines.join("\n");
+}
+
+/**
+ * ValidationReport を JSON 形式にフォーマットする。
+ */
+export function formatJson(report: ValidationReport): string {
+  return JSON.stringify(report, null, 2);
+}

--- a/packages/easyflow-cli/src/validate/types.ts
+++ b/packages/easyflow-cli/src/validate/types.ts
@@ -1,0 +1,12 @@
+export interface ValidationReport {
+  ok: boolean;
+  file: string;
+  errors: ValidationIssue[];
+  warnings: ValidationIssue[];
+}
+
+export interface ValidationIssue {
+  category: "schema" | "file-missing" | "base-resolution" | "tool-unknown" | "reference" | "other";
+  message: string;
+  path?: string;
+}

--- a/packages/easyflow-cli/src/validate/validator.ts
+++ b/packages/easyflow-cli/src/validate/validator.ts
@@ -1,0 +1,113 @@
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { AgentfileParseError, parseAgentfile } from "../agentfile/parser.js";
+import type { ValidationIssue, ValidationReport } from "./types.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+/** 組み込みテンプレートディレクトリ */
+const BUILTIN_TEMPLATES_DIR = path.join(__dirname, "../../templates");
+
+/**
+ * AgentfileParseError のキーワードとパスからカテゴリを推定する。
+ */
+function classifyIssue(keyword: string, issuePath?: string): ValidationIssue["category"] {
+  if (keyword === "fileExists") {
+    return "file-missing";
+  }
+  if (
+    keyword === "baseTemplateNotFound" ||
+    keyword === "baseTemplateParse" ||
+    keyword === "baseTemplateType"
+  ) {
+    return "base-resolution";
+  }
+  if (keyword === "builtinToolName") {
+    return "tool-unknown";
+  }
+  // JSON Schema の enum エラーで tools/builtin パスの場合は tool-unknown
+  if (keyword === "enum" && issuePath?.includes("/tools/builtin")) {
+    return "tool-unknown";
+  }
+  if (
+    keyword === "yamlParse" ||
+    keyword === "type" ||
+    keyword === "required" ||
+    keyword === "minLength" ||
+    keyword === "maxLength" ||
+    keyword === "format" ||
+    keyword === "enum" ||
+    keyword === "pattern" ||
+    keyword === "additionalProperties"
+  ) {
+    return "schema";
+  }
+  return "other";
+}
+
+/**
+ * Agentfile をパースしてバリデーション結果を返す。
+ * @param filePath Agentfile のパス（絶対または相対パス）
+ * @param templatePaths ベーステンプレートの検索パス
+ */
+export async function validateAgentfile(
+  filePath: string,
+  templatePaths?: string[],
+): Promise<ValidationReport> {
+  const absPath = path.resolve(filePath);
+  const basedir = path.dirname(absPath);
+  const resolvedTemplatePaths = templatePaths ?? [BUILTIN_TEMPLATES_DIR];
+
+  const errors: ValidationIssue[] = [];
+  const warnings: ValidationIssue[] = [];
+
+  // ファイル読み込み
+  let content: string;
+  try {
+    content = await fs.readFile(absPath, "utf-8");
+  } catch (e) {
+    errors.push({
+      category: "file-missing",
+      message: `Agentfile not found: ${filePath}`,
+      path: filePath,
+    });
+    return {
+      ok: false,
+      file: filePath,
+      errors,
+      warnings,
+    };
+  }
+
+  // パース・バリデーション
+  try {
+    await parseAgentfile(content, {
+      basedir,
+      templatePaths: resolvedTemplatePaths,
+    });
+  } catch (e) {
+    if (e instanceof AgentfileParseError) {
+      for (const issue of e.errors) {
+        const category = classifyIssue(issue.keyword, issue.path);
+        errors.push({
+          category,
+          message: issue.message,
+          ...(issue.path ? { path: issue.path } : {}),
+        });
+      }
+    } else {
+      errors.push({
+        category: "other",
+        message: e instanceof Error ? e.message : String(e),
+      });
+    }
+  }
+
+  return {
+    ok: errors.length === 0,
+    file: filePath,
+    errors,
+    warnings,
+  };
+}

--- a/packages/easyflow-cli/test/cli/inspect.test.ts
+++ b/packages/easyflow-cli/test/cli/inspect.test.ts
@@ -1,0 +1,112 @@
+import { execFile } from "node:child_process";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { promisify } from "node:util";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { ImageStore } from "../../src/store/image-store.js";
+import type { ImageData } from "../../src/store/types.js";
+
+const execFileAsync = promisify(execFile);
+const ENTRY_PATH = path.resolve(import.meta.dirname, "../../src/cli/index.ts");
+
+async function runCli(
+  args: string[],
+  env?: Record<string, string>,
+): Promise<{ stdout: string; stderr: string; code: number }> {
+  try {
+    const result = await execFileAsync(process.execPath, ["--import", "tsx", ENTRY_PATH, ...args], {
+      env: { ...process.env, ...env },
+      timeout: 15000,
+    });
+    return { stdout: result.stdout, stderr: result.stderr, code: 0 };
+  } catch (error) {
+    const err = error as { stdout?: string; stderr?: string; code?: number | string };
+    return {
+      stdout: err.stdout ?? "",
+      stderr: err.stderr ?? "",
+      code: typeof err.code === "number" ? err.code : 1,
+    };
+  }
+}
+
+function createTestImageData(): ImageData {
+  return {
+    manifest: {
+      schemaVersion: 2,
+      config: { digest: "sha256:configdigest", size: 100 },
+      layers: [
+        {
+          digest: "sha256:identity123",
+          size: 512,
+          annotations: { "org.easyflow.layer.name": "identity" },
+        },
+        {
+          digest: "sha256:config123",
+          size: 128,
+          annotations: { "org.easyflow.layer.name": "config" },
+        },
+      ],
+    },
+    config: {
+      schemaVersion: 1,
+      agentfile: "easyflow/v1",
+      metadata: {
+        name: "test-agent",
+        version: "1.0.0",
+        description: "CLI inspect test agent",
+        author: "tester",
+        createdAt: "2026-04-17T00:00:00.000Z",
+        buildTool: "easyflow-cli/0.1.0",
+      },
+      knowledge: { totalChunks: 0, totalTokens: 0, sources: [] },
+      tools: ["workflow-controller"],
+      channels: ["slack"],
+    },
+    layers: new Map([
+      ["identity", Buffer.from("identity-tar-gz")],
+      ["config", Buffer.from("config-tar-gz")],
+    ]),
+  };
+}
+
+describe("easyflow inspect (CLI)", () => {
+  let storeDir: string;
+
+  beforeEach(async () => {
+    storeDir = await fs.mkdtemp(path.join(os.tmpdir(), "easyflow-inspect-cli-test-"));
+    const store = new ImageStore(storeDir);
+    await store.save("org/inspect-test:1.0.0", createTestImageData());
+  });
+
+  afterEach(async () => {
+    await fs.rm(storeDir, { recursive: true, force: true });
+  });
+
+  it("存在する ref で exit code 0 が返る", async () => {
+    const { code, stdout } = await runCli(["inspect", "org/inspect-test:1.0.0"], {
+      EASYFLOW_STORE_DIR: storeDir,
+    });
+    expect(code).toBe(0);
+    expect(stdout).toContain("=== Image ===");
+  });
+
+  it("存在しない ref で exit code 1 が返る", async () => {
+    const { code, stderr } = await runCli(["inspect", "org/missing:1.0.0"], {
+      EASYFLOW_STORE_DIR: storeDir,
+    });
+    expect(code).toBe(1);
+    expect(stderr).toContain("image not found");
+  });
+
+  it("--json で JSON 形式の出力が得られる", async () => {
+    const { code, stdout } = await runCli(["inspect", "org/inspect-test:1.0.0", "--json"], {
+      EASYFLOW_STORE_DIR: storeDir,
+    });
+    expect(code).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ref).toBe("org/inspect-test:1.0.0");
+    expect(parsed.metadata).toBeDefined();
+    expect(parsed.layers).toBeDefined();
+  });
+});

--- a/packages/easyflow-cli/test/cli/validate.test.ts
+++ b/packages/easyflow-cli/test/cli/validate.test.ts
@@ -1,0 +1,102 @@
+import { execFile } from "node:child_process";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { promisify } from "node:util";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+const execFileAsync = promisify(execFile);
+const ENTRY_PATH = path.resolve(import.meta.dirname, "../../src/cli/index.ts");
+const FIXTURE_DIR = path.resolve(import.meta.dirname, "../fixtures");
+const TEMPLATES_DIR = path.resolve(import.meta.dirname, "../../templates");
+
+async function runCli(
+  args: string[],
+  env?: Record<string, string>,
+): Promise<{ stdout: string; stderr: string; code: number }> {
+  try {
+    const result = await execFileAsync(process.execPath, ["--import", "tsx", ENTRY_PATH, ...args], {
+      env: { ...process.env, ...env },
+      timeout: 15000,
+    });
+    return { stdout: result.stdout, stderr: result.stderr, code: 0 };
+  } catch (error) {
+    const err = error as { stdout?: string; stderr?: string; code?: number | string };
+    return {
+      stdout: err.stdout ?? "",
+      stderr: err.stderr ?? "",
+      code: typeof err.code === "number" ? err.code : 1,
+    };
+  }
+}
+
+describe("easyflow validate (CLI)", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "easyflow-validate-cli-test-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("valid な Agentfile で exit code 0 が返る", async () => {
+    const { code, stdout } = await runCli([
+      "validate",
+      "-f",
+      path.join(FIXTURE_DIR, "valid-minimal.yaml"),
+    ]);
+    expect(code).toBe(0);
+    expect(stdout).toContain("✓");
+  });
+
+  it("invalid な Agentfile で exit code 1 が返る", async () => {
+    const { code, stdout } = await runCli([
+      "validate",
+      "-f",
+      path.join(FIXTURE_DIR, "invalid-bad-name.yaml"),
+    ]);
+    expect(code).toBe(1);
+    expect(stdout).toContain("✗");
+  });
+
+  it("警告のみの場合は exit code 0 が返る（warnings は ok を妨げない）", async () => {
+    // valid-minimal.yaml は ok:true なので警告のみの場合は exit 0
+    const { code } = await runCli(["validate", "-f", path.join(FIXTURE_DIR, "valid-minimal.yaml")]);
+    expect(code).toBe(0);
+  });
+
+  it("--json で JSON 形式の出力が得られる", async () => {
+    const { code, stdout } = await runCli([
+      "validate",
+      "-f",
+      path.join(FIXTURE_DIR, "valid-minimal.yaml"),
+      "--json",
+    ]);
+    expect(code).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.errors).toBeDefined();
+    expect(parsed.warnings).toBeDefined();
+  });
+
+  it("--json でエラーがある場合も JSON 形式で exit 1 が返る", async () => {
+    const { code, stdout } = await runCli([
+      "validate",
+      "-f",
+      path.join(FIXTURE_DIR, "invalid-bad-name.yaml"),
+      "--json",
+    ]);
+    expect(code).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.errors.length).toBeGreaterThan(0);
+  });
+
+  it("-f オプションなしでエラーになる", async () => {
+    const { code, stderr } = await runCli(["validate"]);
+    expect(code).not.toBe(0);
+    expect(stderr).toMatch(/required option|必須/i);
+  });
+});

--- a/packages/easyflow-cli/test/inspect/formatter.test.ts
+++ b/packages/easyflow-cli/test/inspect/formatter.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "vitest";
+import { formatHuman, formatJson } from "../../src/inspect/formatter.js";
+import type { InspectReport } from "../../src/inspect/types.js";
+
+function createReport(overrides: Partial<InspectReport> = {}): InspectReport {
+  return {
+    ref: "org/test-agent:1.0.0",
+    digest: "sha256:abc123",
+    size: 4096,
+    createdAt: "2026-04-17T00:00:00.000Z",
+    metadata: {
+      name: "test-agent",
+      version: "1.0.0",
+      description: "A test agent",
+      author: "tester",
+      base: { ref: "estack-inc/monitor:latest" },
+    },
+    identity: {
+      name: "テストエージェント",
+      soulPreview: "あなたはテスト用エージェントです。",
+      policyCount: 2,
+    },
+    knowledge: {
+      totalChunks: 10,
+      totalTokens: 500,
+      sources: [
+        { path: "./docs", type: "agents_rule", chunks: 5, tokens: 250 },
+        { path: "./data", type: "customer_doc", chunks: 5, tokens: 250 },
+      ],
+    },
+    tools: ["workflow-controller", "file-serve"],
+    channels: ["slack", "webchat"],
+    layers: [
+      { name: "identity", size: 512, fileCount: 3, digest: "sha256:identity123" },
+      { name: "knowledge", size: 1024, fileCount: 2, digest: "sha256:knowledge123" },
+      { name: "tools", size: 256, fileCount: 1, digest: "sha256:tools123" },
+      { name: "config", size: 128, fileCount: 1, digest: "sha256:config123" },
+    ],
+    ...overrides,
+  };
+}
+
+describe("formatHuman", () => {
+  it("=== Image === セクションを含む", () => {
+    const output = formatHuman(createReport());
+    expect(output).toContain("=== Image ===");
+    expect(output).toContain("org/test-agent:1.0.0");
+    expect(output).toContain("sha256:abc123");
+  });
+
+  it("=== Metadata === セクションを含む", () => {
+    const output = formatHuman(createReport());
+    expect(output).toContain("=== Metadata ===");
+    expect(output).toContain("test-agent");
+    expect(output).toContain("1.0.0");
+    expect(output).toContain("A test agent");
+    expect(output).toContain("tester");
+    expect(output).toContain("estack-inc/monitor:latest");
+  });
+
+  it("=== Identity === セクションを含む", () => {
+    const output = formatHuman(createReport());
+    expect(output).toContain("=== Identity ===");
+    expect(output).toContain("テストエージェント");
+    expect(output).toContain("あなたはテスト用エージェントです。");
+  });
+
+  it("=== Knowledge === セクションを含む", () => {
+    const output = formatHuman(createReport());
+    expect(output).toContain("=== Knowledge ===");
+    expect(output).toContain("Total Chunks: 10");
+    expect(output).toContain("Total Tokens: 500");
+    expect(output).toContain("./docs");
+    expect(output).toContain("agents_rule");
+  });
+
+  it("=== Tools === セクションを含む", () => {
+    const output = formatHuman(createReport());
+    expect(output).toContain("=== Tools ===");
+    expect(output).toContain("workflow-controller");
+    expect(output).toContain("file-serve");
+  });
+
+  it("=== Channels === セクションを含む", () => {
+    const output = formatHuman(createReport());
+    expect(output).toContain("=== Channels ===");
+    expect(output).toContain("slack");
+    expect(output).toContain("webchat");
+  });
+
+  it("=== Layers === セクションを含む", () => {
+    const output = formatHuman(createReport());
+    expect(output).toContain("=== Layers ===");
+    expect(output).toContain("identity");
+    expect(output).toContain("knowledge");
+    expect(output).toContain("tools");
+    expect(output).toContain("config");
+  });
+
+  it("tools が空の場合 (none) を表示", () => {
+    const output = formatHuman(createReport({ tools: [] }));
+    expect(output).toContain("=== Tools ===");
+    expect(output).toContain("(none)");
+  });
+
+  it("channels が空の場合 (none) を表示", () => {
+    const output = formatHuman(createReport({ channels: [] }));
+    expect(output).toContain("=== Channels ===");
+    expect(output).toContain("(none)");
+  });
+
+  it("knowledge sources が空の場合 (none) を表示", () => {
+    const output = formatHuman(
+      createReport({
+        knowledge: { totalChunks: 0, totalTokens: 0, sources: [] },
+      }),
+    );
+    expect(output).toContain("Sources: (none)");
+  });
+});
+
+describe("formatJson", () => {
+  it("有効な JSON 文字列を返す", () => {
+    const output = formatJson(createReport());
+    expect(() => JSON.parse(output)).not.toThrow();
+  });
+
+  it("パースした結果が InspectReport と等価", () => {
+    const report = createReport();
+    const parsed = JSON.parse(formatJson(report));
+    expect(parsed).toEqual(report);
+  });
+
+  it("ref が JSON に含まれる", () => {
+    const output = formatJson(createReport());
+    const parsed = JSON.parse(output);
+    expect(parsed.ref).toBe("org/test-agent:1.0.0");
+  });
+});

--- a/packages/easyflow-cli/test/inspect/inspector.test.ts
+++ b/packages/easyflow-cli/test/inspect/inspector.test.ts
@@ -1,0 +1,172 @@
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { inspectImage } from "../../src/inspect/inspector.js";
+import { ImageStore } from "../../src/store/image-store.js";
+import type { ImageData } from "../../src/store/types.js";
+import { EasyflowError } from "../../src/utils/errors.js";
+
+function createTestManifest(layers: { name: string; digest: string; size: number }[]) {
+  return {
+    schemaVersion: 2,
+    config: { digest: "sha256:configdigest", size: 100 },
+    layers: layers.map((l) => ({
+      digest: l.digest,
+      size: l.size,
+      annotations: { "org.easyflow.layer.name": l.name },
+    })),
+  };
+}
+
+function createTestImageData(
+  overrides: Partial<{
+    name: string;
+    description: string;
+    tools: string[];
+    channels: string[];
+    knowledgeSources: { path: string; type: string; chunks: number; tokens: number }[];
+    base: { ref: string; digest?: string };
+  }> = {},
+): ImageData {
+  const {
+    name = "test-agent",
+    description = "A test agent",
+    tools = ["workflow-controller"],
+    channels = ["slack"],
+    knowledgeSources = [],
+    base,
+  } = overrides;
+
+  return {
+    manifest: createTestManifest([
+      { name: "identity", digest: "sha256:identity123", size: 512 },
+      { name: "knowledge", digest: "sha256:knowledge123", size: 1024 },
+      { name: "tools", digest: "sha256:tools123", size: 256 },
+      { name: "config", digest: "sha256:config123", size: 128 },
+    ]),
+    config: {
+      schemaVersion: 1,
+      agentfile: "easyflow/v1",
+      metadata: {
+        name,
+        version: "1.0.0",
+        description,
+        author: "tester",
+        createdAt: "2026-04-17T00:00:00.000Z",
+        buildTool: "easyflow-cli/0.1.0",
+      },
+      ...(base ? { base } : {}),
+      knowledge: {
+        totalChunks: knowledgeSources.reduce((acc, s) => acc + s.chunks, 0),
+        totalTokens: knowledgeSources.reduce((acc, s) => acc + s.tokens, 0),
+        sources: knowledgeSources,
+      },
+      tools,
+      channels,
+    },
+    layers: new Map([
+      ["identity", Buffer.from("identity-tar-gz")],
+      ["knowledge", Buffer.from("knowledge-tar-gz")],
+      ["tools", Buffer.from("tools-tar-gz")],
+      ["config", Buffer.from("config-tar-gz")],
+    ]),
+  };
+}
+
+describe("inspectImage", () => {
+  let tmpDir: string;
+  let store: ImageStore;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "easyflow-inspect-test-"));
+    store = new ImageStore(tmpDir);
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("既存イメージで完全な InspectReport が返る", async () => {
+    const ref = "org/test-agent:1.0.0";
+    await store.save(ref, createTestImageData());
+
+    const report = await inspectImage(ref, store);
+
+    expect(report.ref).toBe(ref);
+    expect(report.metadata.name).toBe("test-agent");
+    expect(report.metadata.version).toBe("1.0.0");
+    expect(report.metadata.description).toBe("A test agent");
+    expect(report.metadata.author).toBe("tester");
+    expect(report.tools).toEqual(["workflow-controller"]);
+    expect(report.channels).toEqual(["slack"]);
+    expect(report.knowledge.totalChunks).toBe(0);
+    expect(report.knowledge.totalTokens).toBe(0);
+    expect(report.knowledge.sources).toHaveLength(0);
+    expect(report.layers).toHaveLength(4);
+    expect(report.layers.map((l) => l.name)).toEqual(["identity", "knowledge", "tools", "config"]);
+  });
+
+  it("存在しない ref で EasyflowError がスローされる", async () => {
+    await expect(inspectImage("org/missing:1.0.0", store)).rejects.toThrow(EasyflowError);
+    await expect(inspectImage("org/missing:1.0.0", store)).rejects.toThrow(
+      "image not found: org/missing:1.0.0",
+    );
+  });
+
+  it("base あり の場合 metadata.base に ref が含まれる", async () => {
+    const ref = "org/based-agent:2.0.0";
+    await store.save(
+      ref,
+      createTestImageData({ base: { ref: "estack-inc/monitor:latest", digest: "sha256:base123" } }),
+    );
+
+    const report = await inspectImage(ref, store);
+
+    expect(report.metadata.base).toBeDefined();
+    expect(report.metadata.base?.ref).toBe("estack-inc/monitor:latest");
+    expect(report.metadata.base?.digest).toBe("sha256:base123");
+  });
+
+  it("base なし の場合 metadata.base は undefined", async () => {
+    const ref = "org/no-base:1.0.0";
+    await store.save(ref, createTestImageData());
+
+    const report = await inspectImage(ref, store);
+
+    expect(report.metadata.base).toBeUndefined();
+  });
+
+  it("knowledge sources がある場合に sources が含まれる", async () => {
+    const ref = "org/knowledge-agent:1.0.0";
+    await store.save(
+      ref,
+      createTestImageData({
+        knowledgeSources: [
+          { path: "./docs", type: "agents_rule", chunks: 10, tokens: 500 },
+          { path: "./data", type: "customer_doc", chunks: 5, tokens: 200 },
+        ],
+      }),
+    );
+
+    const report = await inspectImage(ref, store);
+
+    expect(report.knowledge.totalChunks).toBe(15);
+    expect(report.knowledge.totalTokens).toBe(700);
+    expect(report.knowledge.sources).toHaveLength(2);
+    expect(report.knowledge.sources[0].path).toBe("./docs");
+  });
+
+  it("layers の fileCount が数値として返る", async () => {
+    const ref = "org/layers-agent:1.0.0";
+    await store.save(ref, createTestImageData());
+
+    const report = await inspectImage(ref, store);
+
+    for (const layer of report.layers) {
+      expect(typeof layer.fileCount).toBe("number");
+      expect(typeof layer.size).toBe("number");
+      expect(typeof layer.digest).toBe("string");
+    }
+  });
+});

--- a/packages/easyflow-cli/test/inspect/inspector.test.ts
+++ b/packages/easyflow-cli/test/inspect/inspector.test.ts
@@ -2,6 +2,7 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { packLayer } from "../../src/image/tar-pack.js";
 import { inspectImage } from "../../src/inspect/inspector.js";
 import { ImageStore } from "../../src/store/image-store.js";
 import type { ImageData } from "../../src/store/types.js";
@@ -168,5 +169,59 @@ describe("inspectImage", () => {
       expect(typeof layer.size).toBe("number");
       expect(typeof layer.digest).toBe("string");
     }
+  });
+
+  // 指摘 1: digest / size が StoredImage と一致することを検証
+  it("digest と size が保存済み StoredImage と一致する", async () => {
+    const ref = "org/digest-check:1.0.0";
+    const storedImage = await store.save(ref, createTestImageData());
+
+    const report = await inspectImage(ref, store);
+
+    expect(report.digest).toBe(storedImage.digest);
+    expect(report.size).toBe(storedImage.size);
+  });
+
+  // 指摘 2: identity レイヤーから policyCount を正しく取得することを検証
+  it("identity レイヤーから name / soulPreview / policyCount を読む", async () => {
+    const ref = "org/identity-full:1.0.0";
+    const identityLayer = await packLayer([
+      { kind: "file", name: "IDENTITY.md", content: "# MyAgent\n\n- name: my-agent\n" },
+      { kind: "file", name: "SOUL.md", content: "# Soul\n\nI am a helpful and reliable agent." },
+      {
+        kind: "file",
+        name: "POLICY.md",
+        content: "# Policy\n\n- Be helpful\n- Be honest\n- Be safe\n",
+      },
+    ]);
+    const data = createTestImageData();
+    data.layers.set("identity", identityLayer.content);
+    await store.save(ref, data);
+
+    const report = await inspectImage(ref, store);
+
+    expect(report.identity.name).toBe("MyAgent");
+    expect(report.identity.soulPreview).toContain("helpful");
+    expect(report.identity.policyCount).toBeGreaterThan(1);
+    expect(report.identity.policyCount).toBe(3);
+  });
+
+  // 指摘 3: 複数ファイルを持つレイヤーで fileCount > 1 になることを検証
+  it("複数ファイルのレイヤーで fileCount が実際のファイル数を返す", async () => {
+    const ref = "org/filecount-real:1.0.0";
+    const identityLayer = await packLayer([
+      { kind: "file", name: "IDENTITY.md", content: "# Agent" },
+      { kind: "file", name: "SOUL.md", content: "# Soul\n\nSoul text." },
+      { kind: "file", name: "POLICY.md", content: "# Policy\n\n- Rule 1\n" },
+    ]);
+    const data = createTestImageData();
+    data.layers.set("identity", identityLayer.content);
+    await store.save(ref, data);
+
+    const report = await inspectImage(ref, store);
+
+    const identityLayerInfo = report.layers.find((l) => l.name === "identity");
+    expect(identityLayerInfo?.fileCount).toBeGreaterThan(1);
+    expect(identityLayerInfo?.fileCount).toBe(3);
   });
 });

--- a/packages/easyflow-cli/test/validate/formatter.test.ts
+++ b/packages/easyflow-cli/test/validate/formatter.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import { formatHuman, formatJson } from "../../src/validate/formatter.js";
+import type { ValidationReport } from "../../src/validate/types.js";
+
+function createOkReport(file = "Agentfile.yaml"): ValidationReport {
+  return {
+    ok: true,
+    file,
+    errors: [],
+    warnings: [],
+  };
+}
+
+function createErrorReport(file = "Agentfile.yaml"): ValidationReport {
+  return {
+    ok: false,
+    file,
+    errors: [
+      { category: "schema", message: "must have required property 'soul'", path: "/identity" },
+      {
+        category: "file-missing",
+        message: "File not found: ./missing.md",
+        path: "/knowledge/sources/0/path",
+      },
+    ],
+    warnings: [{ category: "other", message: "deprecated field detected" }],
+  };
+}
+
+describe("formatHuman (ValidationReport)", () => {
+  it("OK レポートで ✓ マークを含む", () => {
+    const output = formatHuman(createOkReport());
+    expect(output).toContain("✓");
+    expect(output).toContain("OK");
+  });
+
+  it("OK レポートにファイル名が含まれる", () => {
+    const output = formatHuman(createOkReport("my/Agentfile.yaml"));
+    expect(output).toContain("my/Agentfile.yaml");
+  });
+
+  it("エラーレポートで ✗ マークを含む", () => {
+    const output = formatHuman(createErrorReport());
+    expect(output).toContain("✗");
+  });
+
+  it("エラーレポートにエラー数が含まれる", () => {
+    const output = formatHuman(createErrorReport());
+    expect(output).toContain("2 error(s)");
+  });
+
+  it("エラーレポートにカテゴリが含まれる", () => {
+    const output = formatHuman(createErrorReport());
+    expect(output).toContain("[schema]");
+    expect(output).toContain("[file-missing]");
+  });
+
+  it("エラーレポートにエラーメッセージが含まれる", () => {
+    const output = formatHuman(createErrorReport());
+    expect(output).toContain("must have required property 'soul'");
+    expect(output).toContain("File not found: ./missing.md");
+  });
+
+  it("警告がある場合 Warnings セクションを含む", () => {
+    const output = formatHuman(createErrorReport());
+    expect(output).toContain("Warnings:");
+    expect(output).toContain("deprecated field detected");
+  });
+
+  it("警告がない OK レポートには Warnings セクションを含まない", () => {
+    const output = formatHuman(createOkReport());
+    expect(output).not.toContain("Warnings:");
+  });
+});
+
+describe("formatJson (ValidationReport)", () => {
+  it("有効な JSON 文字列を返す", () => {
+    expect(() => JSON.parse(formatJson(createOkReport()))).not.toThrow();
+    expect(() => JSON.parse(formatJson(createErrorReport()))).not.toThrow();
+  });
+
+  it("OK レポートの JSON が ValidationReport と等価", () => {
+    const report = createOkReport();
+    const parsed = JSON.parse(formatJson(report));
+    expect(parsed).toEqual(report);
+  });
+
+  it("エラーレポートの JSON が ValidationReport と等価", () => {
+    const report = createErrorReport();
+    const parsed = JSON.parse(formatJson(report));
+    expect(parsed).toEqual(report);
+  });
+});

--- a/packages/easyflow-cli/test/validate/validator.test.ts
+++ b/packages/easyflow-cli/test/validate/validator.test.ts
@@ -1,0 +1,156 @@
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { validateAgentfile } from "../../src/validate/validator.js";
+
+const FIXTURE_DIR = path.resolve(import.meta.dirname, "../fixtures");
+const TEMPLATES_DIR = path.resolve(import.meta.dirname, "../../templates");
+
+describe("validateAgentfile", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "easyflow-validate-test-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("valid-minimal.yaml で ok:true を返す", async () => {
+    const result = await validateAgentfile(path.join(FIXTURE_DIR, "valid-minimal.yaml"), [
+      TEMPLATES_DIR,
+    ]);
+    expect(result.ok).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it("存在しない Agentfile で category:file-missing エラーを返す", async () => {
+    const result = await validateAgentfile(path.join(tmpDir, "nonexistent.yaml"), [TEMPLATES_DIR]);
+    expect(result.ok).toBe(false);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].category).toBe("file-missing");
+  });
+
+  it("スキーマエラー（不正な name）で category:schema エラーを返す", async () => {
+    const result = await validateAgentfile(path.join(FIXTURE_DIR, "invalid-bad-name.yaml"), [
+      TEMPLATES_DIR,
+    ]);
+    expect(result.ok).toBe(false);
+    expect(result.errors.length).toBeGreaterThan(0);
+    expect(result.errors.some((e) => e.category === "schema")).toBe(true);
+  });
+
+  it("存在しないファイルパスを参照する知識ソースで category:file-missing エラーを返す", async () => {
+    const agentfileContent = `apiVersion: easyflow/v1
+kind: Agent
+metadata:
+  name: test-agent
+  version: "1.0.0"
+  description: "テスト"
+  author: test
+identity:
+  name: "テスト"
+  soul: "テスト用。"
+knowledge:
+  sources:
+    - path: ./nonexistent-dir
+      type: agents_rule
+      description: "存在しないディレクトリ"
+channels:
+  webchat:
+    enabled: true
+`;
+    const agentfilePath = path.join(tmpDir, "Agentfile.yaml");
+    await fs.writeFile(agentfilePath, agentfileContent);
+
+    const result = await validateAgentfile(agentfilePath, [TEMPLATES_DIR]);
+    expect(result.ok).toBe(false);
+    expect(result.errors.some((e) => e.category === "file-missing")).toBe(true);
+  });
+
+  it("不明な builtin ツールで category:tool-unknown エラーを返す", async () => {
+    const agentfileContent = `apiVersion: easyflow/v1
+kind: Agent
+metadata:
+  name: test-agent
+  version: "1.0.0"
+  description: "テスト"
+  author: test
+identity:
+  name: "テスト"
+  soul: "テスト用。"
+tools:
+  builtin:
+    - unknown-tool-xyz
+channels:
+  webchat:
+    enabled: true
+`;
+    const agentfilePath = path.join(tmpDir, "Agentfile.yaml");
+    await fs.writeFile(agentfilePath, agentfileContent);
+
+    const result = await validateAgentfile(agentfilePath, [TEMPLATES_DIR]);
+    expect(result.ok).toBe(false);
+    expect(result.errors.some((e) => e.category === "tool-unknown")).toBe(true);
+  });
+
+  it("存在しない base テンプレートで category:base-resolution エラーを返す", async () => {
+    // 有効なフォーマットだが存在しないテンプレートの ref を使用
+    const agentfileContent = `apiVersion: easyflow/v1
+kind: Agent
+metadata:
+  name: test-agent
+  version: "1.0.0"
+  description: "テスト"
+  author: test
+base: estack-inc/nonexistent:latest
+identity:
+  name: "テスト"
+  soul: "テスト用。"
+channels:
+  webchat:
+    enabled: true
+`;
+    const agentfilePath = path.join(tmpDir, "Agentfile.yaml");
+    await fs.writeFile(agentfilePath, agentfileContent);
+
+    // 空のテンプレートパス（テンプレートが見つからない）
+    const emptyTemplatesDir = path.join(tmpDir, "no-templates");
+    await fs.mkdir(emptyTemplatesDir, { recursive: true });
+
+    const result = await validateAgentfile(agentfilePath, [emptyTemplatesDir]);
+    expect(result.ok).toBe(false);
+    expect(result.errors.some((e) => e.category === "base-resolution")).toBe(true);
+  });
+
+  it("複数エラーがある場合すべて返される", async () => {
+    const agentfileContent = `apiVersion: easyflow/v1
+kind: Agent
+metadata:
+  name: "Bad Name!"
+  version: "not-semver"
+  description: "テスト"
+  author: test
+identity:
+  name: "テスト"
+  soul: "テスト用。"
+channels:
+  webchat:
+    enabled: true
+`;
+    const agentfilePath = path.join(tmpDir, "Agentfile.yaml");
+    await fs.writeFile(agentfilePath, agentfileContent);
+
+    const result = await validateAgentfile(agentfilePath, [TEMPLATES_DIR]);
+    expect(result.ok).toBe(false);
+    expect(result.errors.length).toBeGreaterThan(1);
+  });
+
+  it("file フィールドにパスが設定される", async () => {
+    const filePath = path.join(FIXTURE_DIR, "valid-minimal.yaml");
+    const result = await validateAgentfile(filePath, [TEMPLATES_DIR]);
+    expect(result.file).toBe(filePath);
+  });
+});


### PR DESCRIPTION
## Summary
- `easyflow inspect <ref>` でローカルイメージのメタデータ・レイヤー情報を表示
- `easyflow validate -f <Agentfile>` で Agentfile のスキーマ・ファイル存在・base 解決を検証
- 両コマンドとも `--json` オプションで機械可読な JSON 出力をサポート

## Changes
- `src/inspect/`: InspectReport 型・Inspector クラス・フォーマッター
- `src/validate/`: ValidationReport 型・バリデーター・フォーマッター
- `src/cli/commands/inspect.ts`: inspect コマンド CLI 配線
- `src/cli/commands/validate.ts`: validate コマンド CLI 配線
- `src/cli/index.ts`: スタブ削除、実コマンド登録
- テスト: 各モジュールの単体テスト・CLI テスト

## Test Plan
- [ ] `npm test` で全テストパス
- [ ] `easyflow inspect <ref>` で人間向け出力確認
- [ ] `easyflow validate -f Agentfile` でバリデーション確認
- [ ] エラー時 exit code 1、警告のみ exit code 0

Closes estack-inc/easy-flow#223