### PR TITLE
fix(codex-review): sha 付きマーカーでレビュー履歴を保持

### DIFF
--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -149,11 +149,13 @@ jobs:
             exit 1
           fi
           # 移行期互換: 旧 workflow (openai/codex-action@v1 時代) の APPROVED には
-          # 新マーカー `<!-- codex-reviewer-bot:v1 -->` が付いていない。旧 body の先頭定型文
+          # 新マーカー `<!-- codex-reviewer-bot:v1 ... -->` が付いていない。旧 body の先頭定型文
           # `🤖 AIレビュー判定` でも bot review を識別し、新旧双方の stale APPROVED を dismiss する。
+          # マーカーは sha 付き形式 (`<!-- codex-reviewer-bot:v1 sha=... -->`) に拡張したため、
+          # listing は末尾 `-->` を含まない接頭辞マッチで新旧両対応させる。
           set +e
           BOT_APPROVAL_IDS=$(gh api --paginate "repos/$REPO/pulls/$PR_NUM/reviews" \
-            --jq '.[] | select(.state=="APPROVED" and ((.body // "") | (contains("<!-- codex-reviewer-bot:v1 -->") or contains("🤖 AIレビュー判定")))) | .id' 2>/dev/null)
+            --jq '.[] | select(.state=="APPROVED" and ((.body // "") | (contains("<!-- codex-reviewer-bot:v1") or contains("🤖 AIレビュー判定")))) | .id' 2>/dev/null)
           LISTING_RC=$?
           set -e
           DISMISS_FAILED=0
@@ -283,6 +285,7 @@ jobs:
           PR_NUM: ${{ github.event.pull_request.number }}
           HTTP_STATUS: ${{ steps.codex_review.outputs.http_status }}
           CURL_RC: ${{ steps.codex_review.outputs.curl_rc }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           # 意図: infra 障害（認証切れ・Funnel 停止・一時的 502・通信断 等）では
           # 本 run での新規 verdict 提出をスキップする。ただし前回 run の APPROVED が残ると、
@@ -293,10 +296,13 @@ jobs:
           # 本 step 末尾で job を fail させて未レビュー承認状態での merge を塞ぐ（fail-closed）。
           # 移行期互換: 旧 workflow 時代の APPROVED（マーカー無し、body 先頭 `🤖 AIレビュー判定`）も
           # dismiss 対象に含める。
-          MARKER='<!-- codex-reviewer-bot:v1 -->'
+          #
+          # コメント本体のマーカーには head SHA を埋め込み、head が変わるたびに新規コメントを
+          # 立てる（履歴保持）。同一 head 内の再試行は EXISTING_ID の prefix マッチで更新される。
+          MARKER="<!-- codex-reviewer-bot:v1 sha=${PR_HEAD_SHA} -->"
           set +e
           BOT_APPROVAL_IDS=$(gh api --paginate "repos/$REPO/pulls/$PR_NUM/reviews" \
-            --jq '.[] | select(.state=="APPROVED" and ((.body // "") | (contains("<!-- codex-reviewer-bot:v1 -->") or contains("🤖 AIレビュー判定")))) | .id' 2>/dev/null)
+            --jq '.[] | select(.state=="APPROVED" and ((.body // "") | (contains("<!-- codex-reviewer-bot:v1") or contains("🤖 AIレビュー判定")))) | .id' 2>/dev/null)
           LISTING_RC=$?
           set -e
           DISMISS_FAILED=0
@@ -358,6 +364,7 @@ jobs:
           GH_TOKEN: ${{ secrets.REPO_ACCESS_TOKEN }}
           REPO: ${{ github.repository }}
           PR_NUM: ${{ github.event.pull_request.number }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           # 空レスポンス（http=200 だが body が空）の場合でも Post step は失敗させない。
           # Submit verdict 側で VERDICT_COUNT=0 → --request-changes（fail-closed）に倒すため、
@@ -366,7 +373,11 @@ jobs:
           # 人手コメントを上書きしないため、--edit-last は使わない。
           # VERDICT マーカー本体だけを削ることで、Codex が同一行に他テキストを書いた場合でも
           # VERDICT マーカーの露出を防ぐ（server.js `ensureVerdict()` の正規表現と整合）。
-          MARKER='<!-- codex-reviewer-bot:v1 -->'
+          #
+          # マーカーに head SHA を埋め込む設計。synchronize で head が変わった 2 回目以降の
+          # レビューは新規コメントとして投稿され、過去 SHA のコメントは履歴として残す。
+          # 同一 head 内の再試行（rerun）は prefix 一致で既存コメントを更新する。
+          MARKER="<!-- codex-reviewer-bot:v1 sha=${PR_HEAD_SHA} -->"
           # sed の区切り文字には `#` を使う。`|` だと ERE の alternation（`|`）と衝突し、
           # `s|...(APPROVED|CHANGES_REQUESTED)...||g` は sed 側で pattern 終端と誤解釈されて
           # `RE error: parentheses not balanced` で step が落ちるため。
@@ -397,6 +408,7 @@ jobs:
           GH_TOKEN: ${{ secrets.REPO_ACCESS_TOKEN }}
           REPO: ${{ github.repository }}
           PR_NUM: ${{ github.event.pull_request.number }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           # review body にも bot マーカーを埋め込む。infra 障害時の dismiss 対象を
           # 「このボット由来の review」に限定するために body 先頭でマーカーを照合する。
@@ -408,7 +420,9 @@ jobs:
           #   - Actions 側からの GitHub API 一時障害
           # いずれも早期検知が必要なので、config / 権限系の misconfig が green のまま埋もれるのを避ける。
           set -e
-          MARKER='<!-- codex-reviewer-bot:v1 -->'
+          # Post review comment と同じ sha 埋め込みマーカーを使う。review listing 側は
+          # prefix contains("<!-- codex-reviewer-bot:v1") で新旧両対応済み。
+          MARKER="<!-- codex-reviewer-bot:v1 sha=${PR_HEAD_SHA} -->"
           # server.js `ensureVerdict()` と同じ正規表現で APPROVED / CHANGES_REQUESTED を抽出。
           # 「ちょうど 1 件」の場合のみ --approve / --request-changes を実行する（fail-closed）。
           # 0 件・2 件以上・矛盾が来た場合は --request-changes に倒し、曖昧な出力を誤って


### PR DESCRIPTION
## 背景

estack-inc/easy-flow#316 の横展開。現行の codex-review は bot コメントのマーカーを `<!-- codex-reviewer-bot:v1 -->` 固定にしており、同マーカー付きの既存コメントを `PATCH` で上書き更新する設計。このため synchronize で新しい commit が push されると **2 回目以降のレビュー指摘が 1 回目のコメントを上書きし、レビュー履歴が消える**。

## 変更

### 1. マーカーに head SHA を埋め込む

- 旧: `<!-- codex-reviewer-bot:v1 -->`
- 新: `<!-- codex-reviewer-bot:v1 sha=<PR head sha> -->`

SHA が一致する既存コメント（手動 rerun 等、同 head での再実行）は従来通り PATCH で更新。SHA が変わる（synchronize で新 commit）場合は新規コメントとして投稿し、過去 SHA のコメントは履歴として残す。

### 2. listing の接頭辞マッチ化（fail-closed 維持）

`Dismiss stale bot approval` / `Report infra failure` の review listing は `contains("<!-- codex-reviewer-bot:v1 -->")` の**末尾 \`-->\` 含み完全リテラル**だったため、新マーカー（sha 付き）では一切ヒットしなくなる → 過去 APPROVED の dismiss 経路破綻 → fail-closed 保護が無効化。これを防ぐため `contains("<!-- codex-reviewer-bot:v1")` に変更し、新旧両方のマーカーを prefix で拾えるようにした。

### 3. スコープ外

G2 head SHA drift check（estack-inc/easy-flow#314）は本リポジトリ未導入のため、本 PR では追加しない。Submit review verdict step の MARKER 定義のみ sha 付き形式に差し替えた。

## 影響範囲

- 既存の sha 無しマーカー付きコメント（旧 run 由来）は **そのまま残る**。新しい run は別の新規コメントとして投稿される
- branch protection / Slack 通知 / verdict 提出ロジックには変更なし
- fail-closed 挙動は維持（listing 条件変更で旧マーカーも引き続き dismiss 対象）

## 参照

- 本体修正: estack-inc/easy-flow#316