### PR TITLE
fix(plugins): ContextEngine の info.id を登録 id と一致させる (#160)

### DIFF
--- a/packages/openclaw-pgvector-plugin/src/index.test.ts
+++ b/packages/openclaw-pgvector-plugin/src/index.test.ts
@@ -100,6 +100,23 @@ describe("openclaw-pgvector-plugin", () => {
     );
   });
 
+  it("should pass info with id 'pgvector-memory' so registered id matches engine info.id", () => {
+    process.env.PGVECTOR_DATABASE_URL = "postgres://test@localhost/db";
+    process.env.GEMINI_API_KEY = "test-key";
+
+    const api = createMockApi();
+    register(api as never);
+
+    const factory = api.getRegisteredFactory();
+    factory?.();
+
+    expect(PineconeContextEngine).toHaveBeenCalledWith(
+      expect.objectContaining({
+        info: expect.objectContaining({ id: "pgvector-memory" }),
+      }),
+    );
+  });
+
   it("should use default agentId when not specified", () => {
     process.env.PGVECTOR_DATABASE_URL = "postgres://test@localhost/db";
     process.env.GEMINI_API_KEY = "test-key";

--- a/packages/openclaw-pgvector-plugin/src/index.ts
+++ b/packages/openclaw-pgvector-plugin/src/index.ts
@@ -62,6 +62,7 @@ export default function register(api: OpenClawPluginApi): void {
   api.registerContextEngine("pgvector-memory", () => {
     const client = new PgVectorClient({ databaseUrl, geminiApiKey });
     return new PineconeContextEngine({
+      info: { id: "pgvector-memory", name: "pgVector Memory", version: "1.0.0" },
       pineconeClient: client,
       agentId,
       compactAfterDays,

--- a/packages/openclaw-pinecone-plugin/src/index.test.ts
+++ b/packages/openclaw-pinecone-plugin/src/index.test.ts
@@ -149,6 +149,7 @@ describe("pinecone-memory plugin", () => {
     });
     expect(PineconeContextEngine).toHaveBeenCalledWith(
       expect.objectContaining({
+        info: expect.objectContaining({ id: "pinecone-memory" }),
         pineconeClient: expect.objectContaining({
           _config: { apiKey: "test-key", indexName: "custom-index" },
         }),

--- a/packages/openclaw-pinecone-plugin/src/index.ts
+++ b/packages/openclaw-pinecone-plugin/src/index.ts
@@ -98,6 +98,7 @@ export default function register(api: OpenClawPluginApi): void {
   api.registerContextEngine("pinecone-memory", () => {
     const client = new PineconeClient({ apiKey, indexName });
     return new PineconeContextEngine({
+      info: { id: "pinecone-memory", name: "Pinecone Memory", version: "1.0.0" },
       pineconeClient: client,
       agentId,
       compactAfterDays,

--- a/packages/openclaw-upstash-plugin/src/index.test.ts
+++ b/packages/openclaw-upstash-plugin/src/index.test.ts
@@ -92,6 +92,7 @@ describe("openclaw-upstash-plugin", () => {
     });
     expect(PineconeContextEngine).toHaveBeenCalledWith(
       expect.objectContaining({
+        info: expect.objectContaining({ id: "upstash-memory" }),
         agentId: "tom",
         compactAfterDays: 14,
       }),

--- a/packages/openclaw-upstash-plugin/src/index.ts
+++ b/packages/openclaw-upstash-plugin/src/index.ts
@@ -30,6 +30,7 @@ export default function register(api: OpenClawPluginApi): void {
   api.registerContextEngine("upstash-memory", () => {
     const client = new UpstashVectorClient({ url, token });
     return new PineconeContextEngine({
+      info: { id: "upstash-memory", name: "Upstash Memory", version: "1.0.0" },
       pineconeClient: client,
       agentId,
       compactAfterDays,

--- a/packages/pinecone-context-engine/src/pinecone-context-engine.test.ts
+++ b/packages/pinecone-context-engine/src/pinecone-context-engine.test.ts
@@ -61,6 +61,17 @@ describe("PineconeContextEngine", () => {
       expect(engine.info.name).toBe("Pinecone Context Engine");
       expect(engine.info.version).toBe("1.0.0");
     });
+
+    it("accepts info override so plugins can register under their own id", () => {
+      const engine = new PineconeContextEngine({
+        pineconeClient: createMockClient(),
+        agentId: "test-agent",
+        info: { id: "pgvector-memory", name: "pgVector Memory", version: "2.0.0" },
+      });
+      expect(engine.info.id).toBe("pgvector-memory");
+      expect(engine.info.name).toBe("pgVector Memory");
+      expect(engine.info.version).toBe("2.0.0");
+    });
   });
 
   describe("bootstrap", () => {

--- a/packages/pinecone-context-engine/src/pinecone-context-engine.ts
+++ b/packages/pinecone-context-engine/src/pinecone-context-engine.ts
@@ -40,12 +40,14 @@ import type { PineconeContextEngineParams } from "./types.js";
 // Re-export for backward compatibility
 export { buildEnrichedQuery, isQueryThin } from "./shared.js";
 
+const DEFAULT_INFO: ContextEngineInfo = {
+  id: "pinecone",
+  name: "Pinecone Context Engine",
+  version: "1.0.0",
+};
+
 export class PineconeContextEngine implements ContextEngine {
-  readonly info: ContextEngineInfo = {
-    id: "pinecone",
-    name: "Pinecone Context Engine",
-    version: "1.0.0",
-  };
+  readonly info: ContextEngineInfo;
 
   private readonly client: IPineconeClient;
   private readonly agentId: string;
@@ -66,6 +68,7 @@ export class PineconeContextEngine implements ContextEngine {
   private readonly maxQueryTokens: number;
 
   constructor(params: PineconeContextEngineParams) {
+    this.info = params.info ?? DEFAULT_INFO;
     this.client = params.pineconeClient;
     this.agentId = params.agentId;
     this.tokenBudget = params.tokenBudget ?? DEFAULT_TOKEN_BUDGET;

--- a/packages/pinecone-context-engine/src/types.ts
+++ b/packages/pinecone-context-engine/src/types.ts
@@ -1,11 +1,16 @@
 import type { IPineconeClient } from "@easy-flow/pinecone-client";
-import type { ContextEngine } from "openclaw/plugin-sdk";
+import type { ContextEngine, ContextEngineInfo } from "openclaw/plugin-sdk";
 
 export type { IPineconeClient } from "@easy-flow/pinecone-client";
 
 export interface PineconeContextEngineParams {
   pineconeClient: IPineconeClient;
   agentId: string;
+  /**
+   * ContextEngine info の上書き。プラグイン側で登録 id と一致させる必要がある。
+   * 省略時は `{ id: "pinecone", name: "Pinecone Context Engine", version: "1.0.0" }`。
+   */
+  info?: ContextEngineInfo;
   tokenBudget?: number;
   ingestRoles?: ("user" | "assistant")[];
   compactAfterDays?: number;


### PR DESCRIPTION
## Summary

- `PineconeContextEngine` の `info.id` が `"pinecone"` にハードコードされていたため、同クラスを流用する 3 プラグイン（pgvector / pinecone / upstash）で openclaw 本体の id 一致バリデーションに失敗 → **legacy フォールバック**していた
- `PineconeContextEngineParams` に `info?: ContextEngineInfo` を追加し、各プラグインで自身の登録 id と一致する info を渡すよう修正
- デフォルト値（`id: "pinecone"`）を維持し後方互換

Fixes #160

## 影響範囲

Easy Flow 全エージェントインスタンス（13+ 台）で pgvector RAG が legacy フォールバック中だった状態を復旧。本 PR マージ + イメージビルド + 各インスタンスへの配布が完了した時点で、`context-engine` のエラーログが解消される。

## Test plan

- [x] `packages/pinecone-context-engine` の単体テスト（113 件）pass
- [x] `packages/openclaw-pgvector-plugin` の単体テスト（16 件）pass
- [x] `packages/openclaw-pinecone-plugin` の単体テスト（16 件）pass
- [x] `packages/openclaw-upstash-plugin` の単体テスト（5 件）pass
- [x] lint（変更範囲）クリーン
- [ ] デプロイ後、クライアントインスタンスのログから `info.id must match registered id` が消えることを確認
- [ ] pgvector 検索が動作し、legacy ではなく `pgvector-memory` エンジンが選択されることを確認