### PR TITLE
feat: @openclaw/portal-notify-tool パッケージ追加 (PR-4: agent → portal 通知中継)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ node_modules/
 dist/
 pinecone-memory/
 packages/model-router/model-router/
+packages/portal-notify-tool/portal-notify-tool/
 build/
 !packages/easyflow-cli/test/fixtures/build/
 *.js.map

--- a/package-lock.json
+++ b/package-lock.json
@@ -846,6 +846,10 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@openclaw/portal-notify-tool": {
+      "resolved": "packages/portal-notify-tool",
+      "link": true
+    },
     "node_modules/@openclaw/workflow-controller": {
       "resolved": "packages/workflow-controller",
       "link": true
@@ -3545,6 +3549,24 @@
       },
       "devDependencies": {
         "typescript": "^5.7.0",
+        "vitest": "^3.0.0"
+      },
+      "peerDependencies": {
+        "openclaw": ">=2026.3.7"
+      },
+      "peerDependenciesMeta": {
+        "openclaw": {
+          "optional": true
+        }
+      }
+    },
+    "packages/portal-notify-tool": {
+      "name": "@openclaw/portal-notify-tool",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "typescript": "^5.0.0",
+        "undici": "^7.0.0",
         "vitest": "^3.0.0"
       },
       "peerDependencies": {

--- a/packages/portal-notify-tool/README.md
+++ b/packages/portal-notify-tool/README.md
@@ -1,0 +1,102 @@
+# @openclaw/portal-notify-tool
+
+easy.flow portal の `POST /api/notifications/send` を呼び出して、テナントに所属する社員へ
+LINE / メール通知を配信する OpenClaw プラグイン。
+
+## 役割
+
+AI エージェント（テナント別 OpenClaw インスタンス）が**タスク完了 / 反響着信 / 追客リマインド**
+等の重要イベントを社員に届けるためのパイプ。これがないと AI のアウトプットがログに留まり、
+社員に届かない。
+
+- portal 側の受け口：`easy-flow-real-estate-portal` の `POST /api/notifications/send`
+- 認可：`subscriptions.notification_token`（per-subscription UUID）を Bearer で送信
+- 配信先：portal 側で member の `line_user_id` 有無を見て LINE / メールに分岐
+
+## 使い方
+
+### 1. OpenClaw プラグインとして登録（推奨）
+
+エージェントの設定で本パッケージを extensions に追加すると、`notify_send` ツールが
+LLM の context に露出し、エージェントが任意のタイミングで通知を送れる。
+
+```jsonc
+// openclaw 設定例
+{
+  "plugins": {
+    "portal-notify-tool": {
+      "origin": "https://easy-flow-real-estate-portal.fly.dev",
+      "notificationToken": "<subscriptions.notification_token>"
+    }
+  }
+}
+```
+
+LLM 側からは以下のスキーマで呼び出せる：
+
+```jsonc
+{
+  "tool": "notify_send",
+  "args": {
+    "kind": "task_completed",
+    "subject": "SNS 投稿原稿が完成しました（3 本）",
+    "body": "本日の Instagram 用原稿 3 本がドラフトに保存されました…",
+    "idempotencyKey": "sns-2026-05-05-abc123"
+  }
+}
+```
+
+### 2. 純クライアントとして直接呼ぶ
+
+プラグイン以外（別パッケージ・スケジューラ）から使いたい場合は client サブパスを直接 import：
+
+```typescript
+import { createPortalNotifyClient } from "@openclaw/portal-notify-tool/client";
+
+const client = createPortalNotifyClient({
+  origin: process.env.PORTAL_ORIGIN!,
+  notificationToken: process.env.PORTAL_NOTIFICATION_TOKEN!,
+});
+
+const result = await client.send({
+  kind: "task_completed",
+  body: "...",
+  idempotencyKey: "task-abc-123",
+});
+```
+
+## 設定
+
+優先順は `pluginConfig` > 環境変数 > 既定値定数。
+
+| 設定キー (pluginConfig)  | 環境変数                         | 既定値                          | 説明 |
+|--------------------------|----------------------------------|---------------------------------|------|
+| `origin`                 | `PORTAL_ORIGIN`                  | （必須）                        | portal の origin URL |
+| `notificationToken`      | `PORTAL_NOTIFICATION_TOKEN`      | （必須）                        | per-subscription UUID |
+| `timeoutMs`              | `PORTAL_NOTIFY_TIMEOUT_MS`       | `5000`                          | HTTP timeout（ms） |
+| `retryFailedDelaysMs`    | `PORTAL_NOTIFY_RETRY_FAILED_MS`  | `[10000, 30000, 90000]`         | 502 / network 失敗の指数バックオフ |
+| `retryPendingDelayMs`    | `PORTAL_NOTIFY_RETRY_PENDING_MS` | `30000`                         | pending → 再送までの待機 |
+| `retryPendingMaxAttempts`| `PORTAL_NOTIFY_RETRY_PENDING_MAX`| `1`                             | pending 再送の上限回数 |
+
+ハードコーディング禁止。すべての閾値は本ファイル冒頭の `DEFAULT_PORTAL_NOTIFY_CONFIG` に
+集約されており、`pluginConfig` または環境変数で全項目上書き可能。
+
+## エラー分類
+
+| portal 戻り値 | クライアント挙動 |
+|---|---|
+| `200` `sent>0` `pending=0` | 成功終了 |
+| `200` `pending>0` | `retryPendingDelayMs` 後に同 `idempotencyKey` で再送（最大 `retryPendingMaxAttempts` 回） |
+| `200` `sent=0` `failed>0` `pending=0` | （portal が 502 にする想定だが）即停止、`PortalDeliveryError` |
+| `404` no active member | warn ログのみ、`{ ok: true, sent: 0, failed: 0 }` で終了 |
+| `400` Bad Request | 即停止、`PortalValidationError` |
+| `401` Unauthorized | 即停止、`PortalAuthError` |
+| `410` Gone | 即停止、`PortalSubscriptionGoneError`（agent 側で全 notify を停止すべき） |
+| `502` Bad Gateway | `retryFailedDelaysMs` で指数バックオフ |
+| network error / その他 5xx | `retryFailedDelaysMs` で指数バックオフ |
+
+## 関連
+
+- portal 側コントラクト：`easy-flow-real-estate-portal/lib/notifications.ts` の定数
+- portal 側 endpoint：`easy-flow-real-estate-portal/app/api/[[...route]]/route.ts`
+- portal 統合テスト：`easy-flow-real-estate-portal/test/integration/notifications-send.integration.test.ts`

--- a/packages/portal-notify-tool/README.md
+++ b/packages/portal-notify-tool/README.md
@@ -88,10 +88,10 @@ const result = await client.send({
 | `200` `sent>0` `pending=0` | 成功終了 |
 | `200` `pending>0` | `retryPendingDelayMs` 後に同 `idempotencyKey` で再送（最大 `retryPendingMaxAttempts` 回） |
 | `200` `sent=0` `failed>0` `pending=0` | （portal が 502 にする想定だが）即停止、`PortalDeliveryError` |
-| `404` no active member | warn ログのみ、`{ ok: true, sent: 0, failed: 0 }` で終了 |
+| `404` no active member | `{ ok: false, reason: "no_active_member", status: 404 }` で終了（retry しない） |
 | `400` Bad Request | 即停止、`PortalValidationError` |
 | `401` Unauthorized | 即停止、`PortalAuthError` |
-| `410` Gone | 即停止、`PortalSubscriptionGoneError`（agent 側で全 notify を停止すべき） |
+| `410` Gone | `{ ok: false, reason: "subscription_gone", status: 410 }` で終了（agent 側で全 notify を停止すべき） |
 | `502` Bad Gateway | `retryFailedDelaysMs` で指数バックオフ |
 | network error / その他 5xx | `retryFailedDelaysMs` で指数バックオフ |
 

--- a/packages/portal-notify-tool/openclaw.plugin.json
+++ b/packages/portal-notify-tool/openclaw.plugin.json
@@ -1,0 +1,36 @@
+{
+  "id": "portal-notify-tool",
+  "kind": "plugin",
+  "name": "Portal Notify Tool",
+  "description": "Relays agent notifications (task completion / inquiry arrival / followup reminders) to the easy.flow portal, which delivers them to tenant members via LINE or email. Provides the `notify_send` tool to AI agents.",
+  "configSchema": {
+    "type": "object",
+    "properties": {
+      "origin": {
+        "type": "string",
+        "description": "Portal origin (e.g. https://easy-flow-real-estate-portal.fly.dev). Falls back to PORTAL_ORIGIN env var."
+      },
+      "notificationToken": {
+        "type": "string",
+        "description": "Per-subscription bearer token (UUID) issued by the portal. Falls back to PORTAL_NOTIFICATION_TOKEN env var."
+      },
+      "timeoutMs": {
+        "type": "number",
+        "description": "HTTP timeout for portal calls (ms). Default 5000."
+      },
+      "retryFailedDelaysMs": {
+        "type": "array",
+        "items": { "type": "number" },
+        "description": "Delay schedule (ms) for retrying 502 / network failures. Empty array disables retry."
+      },
+      "retryPendingDelayMs": {
+        "type": "number",
+        "description": "Delay (ms) before re-sending when portal returns pending status."
+      },
+      "retryPendingMaxAttempts": {
+        "type": "number",
+        "description": "Maximum number of pending re-send attempts. 0 disables pending retry."
+      }
+    }
+  }
+}

--- a/packages/portal-notify-tool/package.json
+++ b/packages/portal-notify-tool/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "@openclaw/portal-notify-tool",
+  "version": "0.1.0",
+  "type": "module",
+  "private": true,
+  "description": "OpenClaw tool / client for relaying agent notifications to the easy.flow portal (LINE / email).",
+  "exports": {
+    ".": {
+      "import": "./portal-notify-tool/index.js",
+      "types": "./portal-notify-tool/index.d.ts",
+      "default": "./portal-notify-tool/index.js"
+    },
+    "./client": {
+      "import": "./portal-notify-tool/client.js",
+      "types": "./portal-notify-tool/client.d.ts",
+      "default": "./portal-notify-tool/client.js"
+    }
+  },
+  "main": "./portal-notify-tool/index.js",
+  "types": "./portal-notify-tool/index.d.ts",
+  "openclaw": {
+    "extensions": ["./src/index.ts"]
+  },
+  "files": ["portal-notify-tool"],
+  "scripts": {
+    "build": "tsc && cp openclaw.plugin.json portal-notify-tool/openclaw.plugin.json",
+    "test": "vitest run"
+  },
+  "peerDependencies": {
+    "openclaw": ">=2026.3.7"
+  },
+  "peerDependenciesMeta": {
+    "openclaw": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.0.0",
+    "undici": "^7.0.0",
+    "vitest": "^3.0.0"
+  }
+}

--- a/packages/portal-notify-tool/src/client.test.ts
+++ b/packages/portal-notify-tool/src/client.test.ts
@@ -19,11 +19,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createPortalNotifyClient } from "./client.js";
 import {
+  type NotifySendResponse,
   PortalAuthError,
   PortalDeliveryError,
   PortalUnavailableError,
   PortalValidationError,
-  type NotifySendResponse,
 } from "./types.js";
 
 const ORIGIN = "https://portal.example";
@@ -39,12 +39,14 @@ function makeResponse(status: number, body: unknown): Response {
   });
 }
 
-function buildClient(overrides: {
-  retryFailedDelaysMs?: number[];
-  retryPendingDelayMs?: number;
-  retryPendingMaxAttempts?: number;
-  timeoutMs?: number;
-} = {}) {
+function buildClient(
+  overrides: {
+    retryFailedDelaysMs?: number[];
+    retryPendingDelayMs?: number;
+    retryPendingMaxAttempts?: number;
+    timeoutMs?: number;
+  } = {},
+) {
   return createPortalNotifyClient({
     origin: ORIGIN,
     notificationToken: TOKEN,
@@ -102,8 +104,9 @@ describe("createPortalNotifyClient.send - 成功系", () => {
     const [url, init] = fetchMock.mock.calls[0];
     expect(url).toBe("https://portal.example/api/notifications/send");
     expect(init.method).toBe("POST");
-    expect(init.headers["authorization"]).toBe(`Bearer ${TOKEN}`);
+    expect(init.headers.authorization).toBe(`Bearer ${TOKEN}`);
     expect(init.headers["content-type"]).toBe("application/json");
+    // content-type は hyphen を含むため bracket 必須（biome useLiteralKeys 例外）
     expect(JSON.parse(init.body)).toEqual({
       kind: "task_completed",
       body: "msg",
@@ -229,9 +232,7 @@ describe("createPortalNotifyClient.send - 4xx", () => {
   });
 
   it("401 → PortalAuthError, retry しない", async () => {
-    fetchMock.mockResolvedValueOnce(
-      makeResponse(401, { error: "Unauthorized" }),
-    );
+    fetchMock.mockResolvedValueOnce(makeResponse(401, { error: "Unauthorized" }));
     const client = buildClient();
     await expect(client.send({ kind: "system", body: "msg" })).rejects.toBeInstanceOf(
       PortalAuthError,
@@ -240,9 +241,7 @@ describe("createPortalNotifyClient.send - 4xx", () => {
   });
 
   it("404 → ok: false reason: no_active_member", async () => {
-    fetchMock.mockResolvedValueOnce(
-      makeResponse(404, { error: "no active member" }),
-    );
+    fetchMock.mockResolvedValueOnce(makeResponse(404, { error: "no active member" }));
     const client = buildClient();
     const result = await client.send({ kind: "system", body: "msg" });
     expect(result).toEqual({ ok: false, reason: "no_active_member", status: 404 });
@@ -250,9 +249,7 @@ describe("createPortalNotifyClient.send - 4xx", () => {
   });
 
   it("410 → ok: false reason: subscription_gone, retry しない", async () => {
-    fetchMock.mockResolvedValueOnce(
-      makeResponse(410, { error: "subscription gone" }),
-    );
+    fetchMock.mockResolvedValueOnce(makeResponse(410, { error: "subscription gone" }));
     const client = buildClient();
     const result = await client.send({ kind: "system", body: "msg" });
     expect(result).toEqual({
@@ -280,14 +277,12 @@ describe("createPortalNotifyClient.send - 5xx / network", () => {
         },
       ],
     };
-    fetchMock.mockImplementation(() =>
-      Promise.resolve(makeResponse(502, failedBody)),
-    );
+    fetchMock.mockImplementation(() => Promise.resolve(makeResponse(502, failedBody)));
 
     const client = buildClient({ retryFailedDelaysMs: [10, 20] });
-    await expect(
-      client.send({ kind: "system", body: "msg" }),
-    ).rejects.toBeInstanceOf(PortalDeliveryError);
+    await expect(client.send({ kind: "system", body: "msg" })).rejects.toBeInstanceOf(
+      PortalDeliveryError,
+    );
 
     expect(fetchMock).toHaveBeenCalledTimes(3); // 初回 + 2 回 retry
     expect(sleepMock).toHaveBeenCalledTimes(2);
@@ -295,12 +290,8 @@ describe("createPortalNotifyClient.send - 5xx / network", () => {
 
   it("502 が途中で 200 になれば成功", async () => {
     fetchMock
-      .mockResolvedValueOnce(
-        makeResponse(502, { sent: 0, pending: 0, failed: 1, results: [] }),
-      )
-      .mockResolvedValueOnce(
-        makeResponse(200, { sent: 1, pending: 0, failed: 0, results: [] }),
-      );
+      .mockResolvedValueOnce(makeResponse(502, { sent: 0, pending: 0, failed: 1, results: [] }))
+      .mockResolvedValueOnce(makeResponse(200, { sent: 1, pending: 0, failed: 0, results: [] }));
 
     const client = buildClient({ retryFailedDelaysMs: [10, 20] });
     const result = await client.send({ kind: "system", body: "msg" });
@@ -311,18 +302,16 @@ describe("createPortalNotifyClient.send - 5xx / network", () => {
   it("network error も retry し全部失敗で PortalUnavailableError", async () => {
     fetchMock.mockImplementation(() => Promise.reject(new Error("ECONNRESET")));
     const client = buildClient({ retryFailedDelaysMs: [10, 20] });
-    await expect(
-      client.send({ kind: "system", body: "msg" }),
-    ).rejects.toBeInstanceOf(PortalUnavailableError);
+    await expect(client.send({ kind: "system", body: "msg" })).rejects.toBeInstanceOf(
+      PortalUnavailableError,
+    );
     expect(fetchMock).toHaveBeenCalledTimes(3);
   });
 
   it("503 / 500 など 5xx も retry 対象", async () => {
     fetchMock
       .mockResolvedValueOnce(makeResponse(503, { error: "unavailable" }))
-      .mockResolvedValueOnce(
-        makeResponse(200, { sent: 1, pending: 0, failed: 0, results: [] }),
-      );
+      .mockResolvedValueOnce(makeResponse(200, { sent: 1, pending: 0, failed: 0, results: [] }));
     const client = buildClient({ retryFailedDelaysMs: [10] });
     const result = await client.send({ kind: "system", body: "msg" });
     expect(result).toMatchObject({ ok: true, sent: 1 });
@@ -336,9 +325,7 @@ describe("createPortalNotifyClient.send - timeout", () => {
     abortErr.name = "AbortError";
     fetchMock
       .mockRejectedValueOnce(abortErr)
-      .mockResolvedValueOnce(
-        makeResponse(200, { sent: 1, pending: 0, failed: 0, results: [] }),
-      );
+      .mockResolvedValueOnce(makeResponse(200, { sent: 1, pending: 0, failed: 0, results: [] }));
     const client = buildClient({ retryFailedDelaysMs: [10] });
     const result = await client.send({ kind: "system", body: "msg" });
     expect(result).toMatchObject({ ok: true, sent: 1 });

--- a/packages/portal-notify-tool/src/client.test.ts
+++ b/packages/portal-notify-tool/src/client.test.ts
@@ -194,13 +194,16 @@ describe("createPortalNotifyClient.send - pending retry", () => {
   });
 
   it("最大 attempts 後も pending なら ok: true pending で終了 (失敗扱いにしない)", async () => {
-    fetchMock.mockResolvedValue(
-      makeResponse(200, {
-        sent: 0,
-        pending: 1,
-        failed: 0,
-        results: [],
-      }),
+    // Response は body を 1 度しか読めないため、毎回新しい Response を返す
+    fetchMock.mockImplementation(() =>
+      Promise.resolve(
+        makeResponse(200, {
+          sent: 0,
+          pending: 1,
+          failed: 0,
+          results: [],
+        }),
+      ),
     );
     const client = buildClient({ retryPendingMaxAttempts: 2 });
     const result = await client.send({ kind: "system", body: "msg" });
@@ -277,7 +280,9 @@ describe("createPortalNotifyClient.send - 5xx / network", () => {
         },
       ],
     };
-    fetchMock.mockResolvedValue(makeResponse(502, failedBody));
+    fetchMock.mockImplementation(() =>
+      Promise.resolve(makeResponse(502, failedBody)),
+    );
 
     const client = buildClient({ retryFailedDelaysMs: [10, 20] });
     await expect(
@@ -304,7 +309,7 @@ describe("createPortalNotifyClient.send - 5xx / network", () => {
   });
 
   it("network error も retry し全部失敗で PortalUnavailableError", async () => {
-    fetchMock.mockRejectedValue(new Error("ECONNRESET"));
+    fetchMock.mockImplementation(() => Promise.reject(new Error("ECONNRESET")));
     const client = buildClient({ retryFailedDelaysMs: [10, 20] });
     await expect(
       client.send({ kind: "system", body: "msg" }),

--- a/packages/portal-notify-tool/src/client.test.ts
+++ b/packages/portal-notify-tool/src/client.test.ts
@@ -8,14 +8,17 @@
 //   - 200 sent: 成功で結果を返す
 //   - 200 pending: retryPendingDelayMs 後に再送、再送も pending なら ok: true で終了
 //   - 200 pending → 200 sent (再送で確定): 1 回だけ retry
+//   - 200 sent=0 failed>0 pending=0 → PortalDeliveryError（全件未達）
 //   - 200 sent + body の Authorization / JSON 形式の検証
-//   - 404 no active member: ok: true sent: 0 で終了 + warn ログ
+//   - idempotencyKey 未指定時は自動生成して全 retry で同一 key を使う
+//   - 404 no active member: ok: false reason: no_active_member で終了
 //   - 400 → PortalValidationError + missingMemberIds 含む details
 //   - 401 → PortalAuthError, retry しない
 //   - 410 → ok: false reason: 'subscription_gone'
 //   - 502 → retryFailedDelaysMs 全件 retry 後 PortalDeliveryError
 //   - network error → retry, 全失敗で PortalUnavailableError
 //   - timeout → AbortError 経由で retry
+//   - pending 再送中の 5xx → retryFailedDelaysMs で backoff して回復
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createPortalNotifyClient } from "./client.js";
 import {
@@ -126,12 +129,47 @@ describe("createPortalNotifyClient.send - 成功系", () => {
       memberIds: ["uuid-1", "uuid-2"],
     });
     const [, init] = fetchMock.mock.calls[0];
-    expect(JSON.parse(init.body)).toEqual({
+    const parsed = JSON.parse(init.body);
+    // idempotencyKey は未指定時に自動生成されるため文字列であることだけ確認
+    expect(typeof parsed.idempotencyKey).toBe("string");
+    expect(parsed).toMatchObject({
       kind: "reaction_received",
       body: "新規問合せ",
       subject: "件名",
       memberIds: ["uuid-1", "uuid-2"],
     });
+  });
+
+  it("idempotencyKey 未指定時は自動生成し、全 retry で同一 key を使う", async () => {
+    fetchMock
+      .mockResolvedValueOnce(makeResponse(502, { sent: 0, pending: 0, failed: 1, results: [] }))
+      .mockResolvedValueOnce(makeResponse(200, { sent: 1, pending: 0, failed: 0, results: [] }));
+
+    const client = buildClient({ retryFailedDelaysMs: [10] });
+    await client.send({ kind: "system", body: "msg" });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const key0 = JSON.parse(fetchMock.mock.calls[0][1].body).idempotencyKey;
+    const key1 = JSON.parse(fetchMock.mock.calls[1][1].body).idempotencyKey;
+    expect(typeof key0).toBe("string");
+    expect(key0.length).toBeGreaterThanOrEqual(8);
+    expect(key0).toBe(key1);
+  });
+
+  it("200 sent=0 failed>0 pending=0 → PortalDeliveryError（全件未達）", async () => {
+    fetchMock.mockResolvedValueOnce(
+      makeResponse(200, {
+        sent: 0,
+        pending: 0,
+        failed: 1,
+        results: [{ memberId: "m1", notificationId: "n1", channel: "line", status: "failed" }],
+      }),
+    );
+    const client = buildClient();
+    await expect(client.send({ kind: "system", body: "msg" })).rejects.toBeInstanceOf(
+      PortalDeliveryError,
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -194,6 +232,27 @@ describe("createPortalNotifyClient.send - pending retry", () => {
     const result = await client.send({ kind: "system", body: "msg" });
     expect(result).toMatchObject({ ok: true, pending: 1 });
     expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("pending 再送中に 5xx が発生した場合 retryFailedDelaysMs で backoff して回復", async () => {
+    fetchMock
+      .mockResolvedValueOnce(makeResponse(200, { sent: 0, pending: 1, failed: 0, results: [] }))
+      .mockResolvedValueOnce(makeResponse(502, { sent: 0, pending: 0, failed: 1, results: [] }))
+      .mockResolvedValueOnce(makeResponse(200, { sent: 1, pending: 0, failed: 0, results: [] }));
+
+    const client = buildClient({
+      retryPendingDelayMs: 5,
+      retryPendingMaxAttempts: 1,
+      retryFailedDelaysMs: [10],
+    });
+    const result = await client.send({ kind: "system", body: "msg", idempotencyKey: "key-retry" });
+    expect(result).toMatchObject({ ok: true, sent: 1 });
+    // 初回 pending + pending内の 502 backoff retry
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    // retryPendingDelayMs(5) + retryFailedDelaysMs[0] のバックオフ sleep が呼ばれる
+    expect(sleepMock).toHaveBeenCalledTimes(2);
+    expect(sleepMock.mock.calls[0][0]).toBe(5); // retryPendingDelayMs
+    expect(typeof sleepMock.mock.calls[1][0]).toBe("number"); // jittered backoff
   });
 
   it("最大 attempts 後も pending なら ok: true pending で終了 (失敗扱いにしない)", async () => {

--- a/packages/portal-notify-tool/src/client.test.ts
+++ b/packages/portal-notify-tool/src/client.test.ts
@@ -1,0 +1,341 @@
+// client.test.ts: portal `/api/notifications/send` 呼び出しの統合テスト。
+//
+// 実 HTTP は使わず、fetch を vi.fn でモックしてレスポンスを差し替える。
+// undici / msw を使えばより本格的だが、本パッケージは Node 標準 fetch のみで動くため
+// 直接モックの方が依存が少なく単純。
+//
+// 検証範囲:
+//   - 200 sent: 成功で結果を返す
+//   - 200 pending: retryPendingDelayMs 後に再送、再送も pending なら ok: true で終了
+//   - 200 pending → 200 sent (再送で確定): 1 回だけ retry
+//   - 200 sent + body の Authorization / JSON 形式の検証
+//   - 404 no active member: ok: true sent: 0 で終了 + warn ログ
+//   - 400 → PortalValidationError + missingMemberIds 含む details
+//   - 401 → PortalAuthError, retry しない
+//   - 410 → ok: false reason: 'subscription_gone'
+//   - 502 → retryFailedDelaysMs 全件 retry 後 PortalDeliveryError
+//   - network error → retry, 全失敗で PortalUnavailableError
+//   - timeout → AbortError 経由で retry
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createPortalNotifyClient } from "./client.js";
+import {
+  PortalAuthError,
+  PortalDeliveryError,
+  PortalUnavailableError,
+  PortalValidationError,
+  type NotifySendResponse,
+} from "./types.js";
+
+const ORIGIN = "https://portal.example";
+const TOKEN = "11111111-2222-4333-8444-555555555555";
+
+const fetchMock = vi.fn();
+const sleepMock = vi.fn(async (_ms: number) => {});
+
+function makeResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function buildClient(overrides: {
+  retryFailedDelaysMs?: number[];
+  retryPendingDelayMs?: number;
+  retryPendingMaxAttempts?: number;
+  timeoutMs?: number;
+} = {}) {
+  return createPortalNotifyClient({
+    origin: ORIGIN,
+    notificationToken: TOKEN,
+    timeoutMs: overrides.timeoutMs ?? 1000,
+    retryFailedDelaysMs: overrides.retryFailedDelaysMs ?? [10, 20],
+    retryPendingDelayMs: overrides.retryPendingDelayMs ?? 5,
+    retryPendingMaxAttempts: overrides.retryPendingMaxAttempts ?? 1,
+    fetch: fetchMock,
+    sleep: sleepMock,
+  });
+}
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  sleepMock.mockReset();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("createPortalNotifyClient.send - 成功系", () => {
+  it("200 sent: ok: true を返し、Authorization / Content-Type / body が正しい", async () => {
+    const body: NotifySendResponse = {
+      sent: 1,
+      pending: 0,
+      failed: 0,
+      results: [
+        {
+          memberId: "m1",
+          notificationId: "n1",
+          channel: "email",
+          status: "sent",
+        },
+      ],
+    };
+    fetchMock.mockResolvedValueOnce(makeResponse(200, body));
+
+    const client = buildClient();
+    const result = await client.send({
+      kind: "task_completed",
+      body: "msg",
+      idempotencyKey: "agent-task-1",
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      sent: 1,
+      pending: 0,
+      failed: 0,
+      results: body.results,
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("https://portal.example/api/notifications/send");
+    expect(init.method).toBe("POST");
+    expect(init.headers["authorization"]).toBe(`Bearer ${TOKEN}`);
+    expect(init.headers["content-type"]).toBe("application/json");
+    expect(JSON.parse(init.body)).toEqual({
+      kind: "task_completed",
+      body: "msg",
+      idempotencyKey: "agent-task-1",
+    });
+  });
+
+  it("subject / memberIds 込みの body をそのまま転送する", async () => {
+    fetchMock.mockResolvedValueOnce(
+      makeResponse(200, { sent: 2, pending: 0, failed: 0, results: [] }),
+    );
+    const client = buildClient();
+    await client.send({
+      kind: "reaction_received",
+      body: "新規問合せ",
+      subject: "件名",
+      memberIds: ["uuid-1", "uuid-2"],
+    });
+    const [, init] = fetchMock.mock.calls[0];
+    expect(JSON.parse(init.body)).toEqual({
+      kind: "reaction_received",
+      body: "新規問合せ",
+      subject: "件名",
+      memberIds: ["uuid-1", "uuid-2"],
+    });
+  });
+});
+
+describe("createPortalNotifyClient.send - pending retry", () => {
+  it("初回 200 pending → 再送で 200 sent に解決", async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        makeResponse(200, {
+          sent: 0,
+          pending: 1,
+          failed: 0,
+          results: [
+            {
+              memberId: "m1",
+              notificationId: "n1",
+              channel: "line",
+              status: "pending",
+            },
+          ],
+        }),
+      )
+      .mockResolvedValueOnce(
+        makeResponse(200, {
+          sent: 1,
+          pending: 0,
+          failed: 0,
+          results: [
+            {
+              memberId: "m1",
+              notificationId: "n1",
+              channel: "line",
+              status: "sent",
+            },
+          ],
+        }),
+      );
+
+    const client = buildClient({ retryPendingDelayMs: 5, retryPendingMaxAttempts: 1 });
+    const result = await client.send({
+      kind: "system",
+      body: "msg",
+      idempotencyKey: "key-1",
+    });
+
+    expect(result).toMatchObject({ ok: true, sent: 1, pending: 0 });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(sleepMock).toHaveBeenNthCalledWith(1, 5);
+  });
+
+  it("retryPendingMaxAttempts: 0 なら pending でも再送せず ok: true で終了", async () => {
+    fetchMock.mockResolvedValueOnce(
+      makeResponse(200, {
+        sent: 0,
+        pending: 1,
+        failed: 0,
+        results: [],
+      }),
+    );
+    const client = buildClient({ retryPendingMaxAttempts: 0 });
+    const result = await client.send({ kind: "system", body: "msg" });
+    expect(result).toMatchObject({ ok: true, pending: 1 });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("最大 attempts 後も pending なら ok: true pending で終了 (失敗扱いにしない)", async () => {
+    fetchMock.mockResolvedValue(
+      makeResponse(200, {
+        sent: 0,
+        pending: 1,
+        failed: 0,
+        results: [],
+      }),
+    );
+    const client = buildClient({ retryPendingMaxAttempts: 2 });
+    const result = await client.send({ kind: "system", body: "msg" });
+    expect(result).toMatchObject({ ok: true, pending: 1 });
+    expect(fetchMock).toHaveBeenCalledTimes(3); // 初回 + 2 回 retry
+  });
+});
+
+describe("createPortalNotifyClient.send - 4xx", () => {
+  it("400 → PortalValidationError に details 付き", async () => {
+    fetchMock.mockResolvedValueOnce(
+      makeResponse(400, {
+        error: "memberIds 一部無効",
+        missingMemberIds: ["uuid-x"],
+      }),
+    );
+    const client = buildClient();
+    await expect(
+      client.send({ kind: "system", body: "msg", memberIds: ["uuid-x"] }),
+    ).rejects.toBeInstanceOf(PortalValidationError);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("401 → PortalAuthError, retry しない", async () => {
+    fetchMock.mockResolvedValueOnce(
+      makeResponse(401, { error: "Unauthorized" }),
+    );
+    const client = buildClient();
+    await expect(client.send({ kind: "system", body: "msg" })).rejects.toBeInstanceOf(
+      PortalAuthError,
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("404 → ok: false reason: no_active_member", async () => {
+    fetchMock.mockResolvedValueOnce(
+      makeResponse(404, { error: "no active member" }),
+    );
+    const client = buildClient();
+    const result = await client.send({ kind: "system", body: "msg" });
+    expect(result).toEqual({ ok: false, reason: "no_active_member", status: 404 });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("410 → ok: false reason: subscription_gone, retry しない", async () => {
+    fetchMock.mockResolvedValueOnce(
+      makeResponse(410, { error: "subscription gone" }),
+    );
+    const client = buildClient();
+    const result = await client.send({ kind: "system", body: "msg" });
+    expect(result).toEqual({
+      ok: false,
+      reason: "subscription_gone",
+      status: 410,
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("createPortalNotifyClient.send - 5xx / network", () => {
+  it("502 → retryFailedDelaysMs 全件試行後 PortalDeliveryError", async () => {
+    const failedBody = {
+      sent: 0,
+      pending: 0,
+      failed: 1,
+      results: [
+        {
+          memberId: "m1",
+          notificationId: "n1",
+          channel: "email",
+          status: "failed",
+          error: "smtp error",
+        },
+      ],
+    };
+    fetchMock.mockResolvedValue(makeResponse(502, failedBody));
+
+    const client = buildClient({ retryFailedDelaysMs: [10, 20] });
+    await expect(
+      client.send({ kind: "system", body: "msg" }),
+    ).rejects.toBeInstanceOf(PortalDeliveryError);
+
+    expect(fetchMock).toHaveBeenCalledTimes(3); // 初回 + 2 回 retry
+    expect(sleepMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("502 が途中で 200 になれば成功", async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        makeResponse(502, { sent: 0, pending: 0, failed: 1, results: [] }),
+      )
+      .mockResolvedValueOnce(
+        makeResponse(200, { sent: 1, pending: 0, failed: 0, results: [] }),
+      );
+
+    const client = buildClient({ retryFailedDelaysMs: [10, 20] });
+    const result = await client.send({ kind: "system", body: "msg" });
+    expect(result).toMatchObject({ ok: true, sent: 1 });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("network error も retry し全部失敗で PortalUnavailableError", async () => {
+    fetchMock.mockRejectedValue(new Error("ECONNRESET"));
+    const client = buildClient({ retryFailedDelaysMs: [10, 20] });
+    await expect(
+      client.send({ kind: "system", body: "msg" }),
+    ).rejects.toBeInstanceOf(PortalUnavailableError);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("503 / 500 など 5xx も retry 対象", async () => {
+    fetchMock
+      .mockResolvedValueOnce(makeResponse(503, { error: "unavailable" }))
+      .mockResolvedValueOnce(
+        makeResponse(200, { sent: 1, pending: 0, failed: 0, results: [] }),
+      );
+    const client = buildClient({ retryFailedDelaysMs: [10] });
+    const result = await client.send({ kind: "system", body: "msg" });
+    expect(result).toMatchObject({ ok: true, sent: 1 });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("createPortalNotifyClient.send - timeout", () => {
+  it("timeout の AbortError は network error と同じく retry 対象", async () => {
+    const abortErr = new Error("aborted");
+    abortErr.name = "AbortError";
+    fetchMock
+      .mockRejectedValueOnce(abortErr)
+      .mockResolvedValueOnce(
+        makeResponse(200, { sent: 1, pending: 0, failed: 0, results: [] }),
+      );
+    const client = buildClient({ retryFailedDelaysMs: [10] });
+    const result = await client.send({ kind: "system", body: "msg" });
+    expect(result).toMatchObject({ ok: true, sent: 1 });
+  });
+});

--- a/packages/portal-notify-tool/src/client.ts
+++ b/packages/portal-notify-tool/src/client.ts
@@ -11,12 +11,8 @@
 // idempotencyKey 8〜128 文字）は portal が validate するためここでは pre-check しない。
 // 不正な input は 400 → PortalValidationError として返ってくる。
 
-import {
-  type PortalNotifyConfig,
-  type PortalNotifyConfigInput,
-  resolveConfig,
-} from "./config.js";
-import { addJitter, retryWithBackoff, type RetryStep } from "./retry.js";
+import { type PortalNotifyConfig, type PortalNotifyConfigInput, resolveConfig } from "./config.js";
+import { addJitter, type RetryStep, retryWithBackoff } from "./retry.js";
 import {
   type NotifyDeliveryResult,
   type NotifySendInput,
@@ -74,13 +70,7 @@ export function createPortalNotifyClient(
 
       // 2) 成功時、pending を含むなら同 idempotencyKey で再送して確定を狙う
       if (baseOutcome.kind === "ok" && baseOutcome.response.pending > 0) {
-        return await retryPending(
-          input,
-          baseOutcome.response,
-          cfg,
-          fetchImpl,
-          sleep,
-        );
+        return await retryPending(input, baseOutcome.response, cfg, fetchImpl, sleep);
       }
 
       // outcome → public NotifySendOutcome に正規化

--- a/packages/portal-notify-tool/src/client.ts
+++ b/packages/portal-notify-tool/src/client.ts
@@ -1,0 +1,250 @@
+// portal `/api/notifications/send` を呼び出す HTTP クライアント。
+//
+// 設計方針：
+//   - fetch / sleep を DI 可能にして、テストでは vi.fn でモック・本番では Node 標準 fetch / setTimeout を使う
+//   - portal の HTTP status を outcome 型に吸収し、caller は ok / reason 単位で分岐できる
+//   - retry 対象は 502 / 5xx / network error。4xx と 410 は即停止
+//   - pending（200 だが pending>=1）は同 idempotencyKey で再送する別経路で扱う
+//   - すべての閾値は config 経由で外部設定（ハードコーディング禁止）
+//
+// 重要：portal 側の契約定数（body 4000 文字 / subject 200 文字 / memberIds 50 件 /
+// idempotencyKey 8〜128 文字）は portal が validate するためここでは pre-check しない。
+// 不正な input は 400 → PortalValidationError として返ってくる。
+
+import {
+  type PortalNotifyConfig,
+  type PortalNotifyConfigInput,
+  resolveConfig,
+} from "./config.js";
+import { addJitter, retryWithBackoff, type RetryStep } from "./retry.js";
+import {
+  type NotifyDeliveryResult,
+  type NotifySendInput,
+  type NotifySendOutcome,
+  type NotifySendResponse,
+  PortalAuthError,
+  PortalDeliveryError,
+  PortalUnavailableError,
+  PortalValidationError,
+} from "./types.js";
+
+/** Node 標準 fetch のサブセット（依存性注入用）。 */
+export type FetchLike = (
+  input: string | URL,
+  init?: {
+    method?: string;
+    headers?: Record<string, string>;
+    body?: string;
+    signal?: AbortSignal;
+  },
+) => Promise<Response>;
+
+export interface CreatePortalNotifyClientOptions extends PortalNotifyConfigInput {
+  /** Override fetch (default: globalThis.fetch). テスト用。 */
+  fetch?: FetchLike;
+  /** Override sleep (default: setTimeout 基底). テスト用。 */
+  sleep?: (ms: number) => Promise<void>;
+}
+
+export interface PortalNotifyClient {
+  send(input: NotifySendInput): Promise<NotifySendOutcome>;
+  readonly config: Readonly<PortalNotifyConfig>;
+}
+
+/** 既定の sleep（setTimeout ベース）。 */
+const defaultSleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+export function createPortalNotifyClient(
+  opts: CreatePortalNotifyClientOptions,
+): PortalNotifyClient {
+  const cfg = resolveConfig(opts);
+  const fetchImpl: FetchLike = opts.fetch ?? (globalThis.fetch as FetchLike);
+  const sleep = opts.sleep ?? defaultSleep;
+
+  return {
+    config: cfg,
+    async send(input: NotifySendInput): Promise<NotifySendOutcome> {
+      // 1) 502 / 5xx / network error は retryWithBackoff で吸収
+      const baseOutcome = await retryWithBackoff(
+        () => attemptSend(input, cfg, fetchImpl),
+        cfg.retryFailedDelaysMs.map(addJitter),
+        sleep,
+      );
+
+      // 2) 成功時、pending を含むなら同 idempotencyKey で再送して確定を狙う
+      if (baseOutcome.kind === "ok" && baseOutcome.response.pending > 0) {
+        return await retryPending(
+          input,
+          baseOutcome.response,
+          cfg,
+          fetchImpl,
+          sleep,
+        );
+      }
+
+      // outcome → public NotifySendOutcome に正規化
+      return materializeOutcome(baseOutcome);
+    },
+  };
+}
+
+// ─────────────────────────────────────────────────────
+// 内部：1 回の HTTP 試行。retry すべきかは戻り値の retry フラグで表す。
+// ─────────────────────────────────────────────────────
+
+type AttemptResult =
+  | { kind: "ok"; response: NotifySendResponse }
+  | { kind: "no_active_member"; status: 404 }
+  | { kind: "subscription_gone"; status: 410 };
+
+async function attemptSend(
+  input: NotifySendInput,
+  cfg: PortalNotifyConfig,
+  fetchImpl: FetchLike,
+): Promise<RetryStep<AttemptResult>> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), cfg.timeoutMs);
+
+  let res: Response;
+  try {
+    res = await fetchImpl(`${cfg.origin}/api/notifications/send`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${cfg.notificationToken}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify(input),
+      signal: controller.signal,
+    });
+  } catch (err) {
+    // network error / abort はすべて retry 対象。最終的に retry を尽くしたら
+    // PortalUnavailableError に置き換える（catch ブロック側で wrap）。
+    return {
+      retry: true,
+      error: wrapNetworkError(err),
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+
+  // 4xx / 410 / 404 は retry しない。throw or 結果値で即終了。
+  if (res.status === 200) {
+    const body = (await res.json()) as NotifySendResponse;
+    return { retry: false, value: { kind: "ok", response: body } };
+  }
+  if (res.status === 404) {
+    return { retry: false, value: { kind: "no_active_member", status: 404 } };
+  }
+  if (res.status === 410) {
+    return { retry: false, value: { kind: "subscription_gone", status: 410 } };
+  }
+  if (res.status === 401) {
+    throw new PortalAuthError();
+  }
+  if (res.status === 400) {
+    let details: Record<string, unknown> | undefined;
+    try {
+      details = (await res.json()) as Record<string, unknown>;
+    } catch {
+      details = undefined;
+    }
+    throw new PortalValidationError(
+      `portal rejected request (400): ${details?.error ?? "unknown"}`,
+      details,
+    );
+  }
+  if (res.status === 502) {
+    // retry 対象。最終的に PortalDeliveryError に置き換える（caller 側）。
+    let body: NotifySendResponse | undefined;
+    try {
+      body = (await res.json()) as NotifySendResponse;
+    } catch {
+      body = undefined;
+    }
+    return {
+      retry: true,
+      error: new PortalDeliveryError(
+        "portal returned 502 (all delivery attempts failed)",
+        body?.results ?? [],
+      ),
+    };
+  }
+  // それ以外の 5xx / 異常 status はすべて retry 対象（transient と見なす）
+  return {
+    retry: true,
+    error: new PortalUnavailableError(
+      `portal returned unexpected status ${res.status}`,
+      res.status,
+    ),
+  };
+}
+
+// ─────────────────────────────────────────────────────
+// 内部：pending 再送（同 idempotencyKey で N 回まで）
+// ─────────────────────────────────────────────────────
+
+async function retryPending(
+  input: NotifySendInput,
+  initialResponse: NotifySendResponse,
+  cfg: PortalNotifyConfig,
+  fetchImpl: FetchLike,
+  sleep: (ms: number) => Promise<void>,
+): Promise<NotifySendOutcome> {
+  let current = initialResponse;
+  for (let i = 0; i < cfg.retryPendingMaxAttempts; i++) {
+    await sleep(cfg.retryPendingDelayMs);
+    const step = await attemptSend(input, cfg, fetchImpl);
+    if (step.retry) {
+      // retry 中の transient 失敗は throw（pending 再送で 5xx は希）
+      throw step.error;
+    }
+    if (step.value.kind !== "ok") {
+      // 410 / 404 への遷移：そのまま返す
+      return materializeOutcome(step.value);
+    }
+    current = step.value.response;
+    if (current.pending === 0) break;
+  }
+  // 上限に達してもまだ pending がいれば ok: true で返す（caller 判断に委ねる）
+  return {
+    ok: true,
+    sent: current.sent,
+    pending: current.pending,
+    failed: current.failed,
+    results: current.results,
+  };
+}
+
+// ─────────────────────────────────────────────────────
+// 内部：AttemptResult → NotifySendOutcome への正規化
+// ─────────────────────────────────────────────────────
+
+function materializeOutcome(r: AttemptResult): NotifySendOutcome {
+  if (r.kind === "ok") {
+    return {
+      ok: true,
+      sent: r.response.sent,
+      pending: r.response.pending,
+      failed: r.response.failed,
+      results: r.response.results,
+    };
+  }
+  if (r.kind === "no_active_member") {
+    return { ok: false, reason: "no_active_member", status: 404 };
+  }
+  return { ok: false, reason: "subscription_gone", status: 410 };
+}
+
+// ─────────────────────────────────────────────────────
+// 内部：retry を尽くした後、最後の error を最終形に変換
+// ─────────────────────────────────────────────────────
+
+function wrapNetworkError(err: unknown): PortalUnavailableError {
+  if (err instanceof PortalUnavailableError) return err;
+  const msg = err instanceof Error ? err.message : String(err);
+  return new PortalUnavailableError(`portal request failed: ${msg}`);
+}
+
+// 最後に export しておく：caller が NotifyDeliveryResult 等を再 export せずに済むよう
+export type { NotifyDeliveryResult, NotifySendInput, NotifySendOutcome };

--- a/packages/portal-notify-tool/src/client.ts
+++ b/packages/portal-notify-tool/src/client.ts
@@ -11,6 +11,7 @@
 // idempotencyKey 8〜128 文字）は portal が validate するためここでは pre-check しない。
 // 不正な input は 400 → PortalValidationError として返ってくる。
 
+import { randomUUID } from "node:crypto";
 import { type PortalNotifyConfig, type PortalNotifyConfigInput, resolveConfig } from "./config.js";
 import { addJitter, type RetryStep, retryWithBackoff } from "./retry.js";
 import {
@@ -61,16 +62,23 @@ export function createPortalNotifyClient(
   return {
     config: cfg,
     async send(input: NotifySendInput): Promise<NotifySendOutcome> {
+      // idempotencyKey が未指定の場合は自動生成して retry 中の重複配信を防ぐ。
+      // pending 再送・502 retry はすべて同じ key を使う。
+      const inputWithKey: NotifySendInput = {
+        ...input,
+        idempotencyKey: input.idempotencyKey ?? randomUUID(),
+      };
+
       // 1) 502 / 5xx / network error は retryWithBackoff で吸収
       const baseOutcome = await retryWithBackoff(
-        () => attemptSend(input, cfg, fetchImpl),
+        () => attemptSend(inputWithKey, cfg, fetchImpl),
         cfg.retryFailedDelaysMs.map(addJitter),
         sleep,
       );
 
       // 2) 成功時、pending を含むなら同 idempotencyKey で再送して確定を狙う
       if (baseOutcome.kind === "ok" && baseOutcome.response.pending > 0) {
-        return await retryPending(input, baseOutcome.response, cfg, fetchImpl, sleep);
+        return await retryPending(inputWithKey, baseOutcome.response, cfg, fetchImpl, sleep);
       }
 
       // outcome → public NotifySendOutcome に正規化
@@ -121,6 +129,11 @@ async function attemptSend(
   // 4xx / 410 / 404 は retry しない。throw or 結果値で即終了。
   if (res.status === 200) {
     const body = (await res.json()) as NotifySendResponse;
+    // sent=0 && pending=0 && failed>0 は全件未達。portal が 502 にする想定だが
+    // 200 で返してきた場合も PortalDeliveryError で即停止する。
+    if (body.sent === 0 && body.pending === 0 && body.failed > 0) {
+      throw new PortalDeliveryError("portal returned 200 but all deliveries failed", body.results);
+    }
     return { retry: false, value: { kind: "ok", response: body } };
   }
   if (res.status === 404) {
@@ -184,16 +197,18 @@ async function retryPending(
   let current = initialResponse;
   for (let i = 0; i < cfg.retryPendingMaxAttempts; i++) {
     await sleep(cfg.retryPendingDelayMs);
-    const step = await attemptSend(input, cfg, fetchImpl);
-    if (step.retry) {
-      // retry 中の transient 失敗は throw（pending 再送で 5xx は希）
-      throw step.error;
-    }
-    if (step.value.kind !== "ok") {
+    // pending 再送中に 502 / 5xx / network error が発生した場合も
+    // retryFailedDelaysMs のバックオフを適用する（PR 本文の retry policy と整合）。
+    const step = await retryWithBackoff(
+      () => attemptSend(input, cfg, fetchImpl),
+      cfg.retryFailedDelaysMs.map(addJitter),
+      sleep,
+    );
+    if (step.kind !== "ok") {
       // 410 / 404 への遷移：そのまま返す
-      return materializeOutcome(step.value);
+      return materializeOutcome(step);
     }
-    current = step.value.response;
+    current = step.response;
     if (current.pending === 0) break;
   }
   // 上限に達してもまだ pending がいれば ok: true で返す（caller 判断に委ねる）

--- a/packages/portal-notify-tool/src/config.test.ts
+++ b/packages/portal-notify-tool/src/config.test.ts
@@ -3,10 +3,7 @@
 // すべての閾値（timeout / retry 配列 / pending 設定）は外部設定で上書き可能であり、
 // ハードコーディング禁止のルールに従っていることを検証する。
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import {
-  DEFAULT_PORTAL_NOTIFY_CONFIG,
-  resolveConfig,
-} from "./config.js";
+import { DEFAULT_PORTAL_NOTIFY_CONFIG, resolveConfig } from "./config.js";
 import { PortalNotifyConfigError } from "./types.js";
 
 const ENV_KEYS = [
@@ -41,15 +38,13 @@ describe("resolveConfig", () => {
     });
 
     it("origin だけある場合も PortalNotifyConfigError", () => {
-      expect(() =>
-        resolveConfig({ origin: "https://portal.example" }),
-      ).toThrow(PortalNotifyConfigError);
+      expect(() => resolveConfig({ origin: "https://portal.example" })).toThrow(
+        PortalNotifyConfigError,
+      );
     });
 
     it("notificationToken だけある場合も PortalNotifyConfigError", () => {
-      expect(() =>
-        resolveConfig({ notificationToken: "uuid" }),
-      ).toThrow(PortalNotifyConfigError);
+      expect(() => resolveConfig({ notificationToken: "uuid" })).toThrow(PortalNotifyConfigError);
     });
 
     it("pluginConfig で両方与えれば既定値で resolve される", () => {
@@ -138,9 +133,9 @@ describe("resolveConfig", () => {
 
     it("env の retryFailedDelaysMs に非数値が混じれば PortalNotifyConfigError", () => {
       process.env.PORTAL_NOTIFY_RETRY_FAILED_MS = "100,abc,300";
-      expect(() =>
-        resolveConfig({ origin: "https://x", notificationToken: "x" }),
-      ).toThrow(PortalNotifyConfigError);
+      expect(() => resolveConfig({ origin: "https://x", notificationToken: "x" })).toThrow(
+        PortalNotifyConfigError,
+      );
     });
   });
 
@@ -162,16 +157,16 @@ describe("resolveConfig", () => {
 
     it("env の数値が不正なら PortalNotifyConfigError", () => {
       process.env.PORTAL_NOTIFY_TIMEOUT_MS = "not-a-number";
-      expect(() =>
-        resolveConfig({ origin: "https://x", notificationToken: "x" }),
-      ).toThrow(PortalNotifyConfigError);
+      expect(() => resolveConfig({ origin: "https://x", notificationToken: "x" })).toThrow(
+        PortalNotifyConfigError,
+      );
     });
 
     it("env の数値が負数なら PortalNotifyConfigError", () => {
       process.env.PORTAL_NOTIFY_TIMEOUT_MS = "-100";
-      expect(() =>
-        resolveConfig({ origin: "https://x", notificationToken: "x" }),
-      ).toThrow(PortalNotifyConfigError);
+      expect(() => resolveConfig({ origin: "https://x", notificationToken: "x" })).toThrow(
+        PortalNotifyConfigError,
+      );
     });
   });
 
@@ -186,9 +181,7 @@ describe("resolveConfig", () => {
     it("すべての既定値が正の数", () => {
       expect(DEFAULT_PORTAL_NOTIFY_CONFIG.timeoutMs).toBeGreaterThan(0);
       expect(DEFAULT_PORTAL_NOTIFY_CONFIG.retryPendingDelayMs).toBeGreaterThan(0);
-      expect(
-        DEFAULT_PORTAL_NOTIFY_CONFIG.retryPendingMaxAttempts,
-      ).toBeGreaterThanOrEqual(0);
+      expect(DEFAULT_PORTAL_NOTIFY_CONFIG.retryPendingMaxAttempts).toBeGreaterThanOrEqual(0);
     });
   });
 });

--- a/packages/portal-notify-tool/src/config.test.ts
+++ b/packages/portal-notify-tool/src/config.test.ts
@@ -1,0 +1,194 @@
+// resolveConfig: pluginConfig > env > 既定値 の 3 段階優先のテスト。
+//
+// すべての閾値（timeout / retry 配列 / pending 設定）は外部設定で上書き可能であり、
+// ハードコーディング禁止のルールに従っていることを検証する。
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  DEFAULT_PORTAL_NOTIFY_CONFIG,
+  resolveConfig,
+} from "./config.js";
+import { PortalNotifyConfigError } from "./types.js";
+
+const ENV_KEYS = [
+  "PORTAL_ORIGIN",
+  "PORTAL_NOTIFICATION_TOKEN",
+  "PORTAL_NOTIFY_TIMEOUT_MS",
+  "PORTAL_NOTIFY_RETRY_FAILED_MS",
+  "PORTAL_NOTIFY_RETRY_PENDING_MS",
+  "PORTAL_NOTIFY_RETRY_PENDING_MAX",
+];
+
+const savedEnv: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  for (const k of ENV_KEYS) {
+    savedEnv[k] = process.env[k];
+    delete process.env[k];
+  }
+});
+
+afterEach(() => {
+  for (const k of ENV_KEYS) {
+    if (savedEnv[k] === undefined) delete process.env[k];
+    else process.env[k] = savedEnv[k];
+  }
+});
+
+describe("resolveConfig", () => {
+  describe("必須項目", () => {
+    it("origin / notificationToken が両方無いと PortalNotifyConfigError", () => {
+      expect(() => resolveConfig({})).toThrow(PortalNotifyConfigError);
+    });
+
+    it("origin だけある場合も PortalNotifyConfigError", () => {
+      expect(() =>
+        resolveConfig({ origin: "https://portal.example" }),
+      ).toThrow(PortalNotifyConfigError);
+    });
+
+    it("notificationToken だけある場合も PortalNotifyConfigError", () => {
+      expect(() =>
+        resolveConfig({ notificationToken: "uuid" }),
+      ).toThrow(PortalNotifyConfigError);
+    });
+
+    it("pluginConfig で両方与えれば既定値で resolve される", () => {
+      const cfg = resolveConfig({
+        origin: "https://portal.example",
+        notificationToken: "11111111-2222-4333-8444-555555555555",
+      });
+      expect(cfg).toEqual({
+        origin: "https://portal.example",
+        notificationToken: "11111111-2222-4333-8444-555555555555",
+        timeoutMs: DEFAULT_PORTAL_NOTIFY_CONFIG.timeoutMs,
+        retryFailedDelaysMs: DEFAULT_PORTAL_NOTIFY_CONFIG.retryFailedDelaysMs,
+        retryPendingDelayMs: DEFAULT_PORTAL_NOTIFY_CONFIG.retryPendingDelayMs,
+        retryPendingMaxAttempts: DEFAULT_PORTAL_NOTIFY_CONFIG.retryPendingMaxAttempts,
+      });
+    });
+
+    it("env だけで両方与えても resolve される", () => {
+      process.env.PORTAL_ORIGIN = "https://env.example";
+      process.env.PORTAL_NOTIFICATION_TOKEN = "uuid-from-env";
+      const cfg = resolveConfig();
+      expect(cfg.origin).toBe("https://env.example");
+      expect(cfg.notificationToken).toBe("uuid-from-env");
+    });
+  });
+
+  describe("優先順 pluginConfig > env > default", () => {
+    it("pluginConfig が env を上書きする", () => {
+      process.env.PORTAL_ORIGIN = "https://env.example";
+      process.env.PORTAL_NOTIFICATION_TOKEN = "uuid-env";
+      const cfg = resolveConfig({
+        origin: "https://plugin.example",
+        notificationToken: "uuid-plugin",
+      });
+      expect(cfg.origin).toBe("https://plugin.example");
+      expect(cfg.notificationToken).toBe("uuid-plugin");
+    });
+
+    it("timeoutMs は pluginConfig 指定が最優先", () => {
+      process.env.PORTAL_NOTIFY_TIMEOUT_MS = "9000";
+      const cfg = resolveConfig({
+        origin: "https://x",
+        notificationToken: "x",
+        timeoutMs: 1234,
+      });
+      expect(cfg.timeoutMs).toBe(1234);
+    });
+
+    it("timeoutMs は pluginConfig 未指定なら env が使われる", () => {
+      process.env.PORTAL_NOTIFY_TIMEOUT_MS = "9000";
+      const cfg = resolveConfig({ origin: "https://x", notificationToken: "x" });
+      expect(cfg.timeoutMs).toBe(9000);
+    });
+
+    it("timeoutMs は env も無ければ default に倒れる", () => {
+      const cfg = resolveConfig({ origin: "https://x", notificationToken: "x" });
+      expect(cfg.timeoutMs).toBe(DEFAULT_PORTAL_NOTIFY_CONFIG.timeoutMs);
+    });
+  });
+
+  describe("配列パース", () => {
+    it("retryFailedDelaysMs は env 文字列をカンマ区切りで int 配列に変換", () => {
+      process.env.PORTAL_NOTIFY_RETRY_FAILED_MS = "100,200,400";
+      const cfg = resolveConfig({ origin: "https://x", notificationToken: "x" });
+      expect(cfg.retryFailedDelaysMs).toEqual([100, 200, 400]);
+    });
+
+    it("retryFailedDelaysMs は pluginConfig 配列を尊重する", () => {
+      process.env.PORTAL_NOTIFY_RETRY_FAILED_MS = "100,200,400";
+      const cfg = resolveConfig({
+        origin: "https://x",
+        notificationToken: "x",
+        retryFailedDelaysMs: [1, 2, 3],
+      });
+      expect(cfg.retryFailedDelaysMs).toEqual([1, 2, 3]);
+    });
+
+    it("retryFailedDelaysMs は空配列 [] も尊重する（retry 無効化を意味する）", () => {
+      const cfg = resolveConfig({
+        origin: "https://x",
+        notificationToken: "x",
+        retryFailedDelaysMs: [],
+      });
+      expect(cfg.retryFailedDelaysMs).toEqual([]);
+    });
+
+    it("env の retryFailedDelaysMs に非数値が混じれば PortalNotifyConfigError", () => {
+      process.env.PORTAL_NOTIFY_RETRY_FAILED_MS = "100,abc,300";
+      expect(() =>
+        resolveConfig({ origin: "https://x", notificationToken: "x" }),
+      ).toThrow(PortalNotifyConfigError);
+    });
+  });
+
+  describe("数値パース", () => {
+    it("retryPendingMaxAttempts は env 文字列を整数に変換", () => {
+      process.env.PORTAL_NOTIFY_RETRY_PENDING_MAX = "3";
+      const cfg = resolveConfig({ origin: "https://x", notificationToken: "x" });
+      expect(cfg.retryPendingMaxAttempts).toBe(3);
+    });
+
+    it("retryPendingMaxAttempts は 0 を「pending retry 無効」として尊重する", () => {
+      const cfg = resolveConfig({
+        origin: "https://x",
+        notificationToken: "x",
+        retryPendingMaxAttempts: 0,
+      });
+      expect(cfg.retryPendingMaxAttempts).toBe(0);
+    });
+
+    it("env の数値が不正なら PortalNotifyConfigError", () => {
+      process.env.PORTAL_NOTIFY_TIMEOUT_MS = "not-a-number";
+      expect(() =>
+        resolveConfig({ origin: "https://x", notificationToken: "x" }),
+      ).toThrow(PortalNotifyConfigError);
+    });
+
+    it("env の数値が負数なら PortalNotifyConfigError", () => {
+      process.env.PORTAL_NOTIFY_TIMEOUT_MS = "-100";
+      expect(() =>
+        resolveConfig({ origin: "https://x", notificationToken: "x" }),
+      ).toThrow(PortalNotifyConfigError);
+    });
+  });
+
+  describe("DEFAULT_PORTAL_NOTIFY_CONFIG の妥当性", () => {
+    it("retryFailedDelaysMs は単調増加（指数バックオフ）", () => {
+      const ds = DEFAULT_PORTAL_NOTIFY_CONFIG.retryFailedDelaysMs;
+      for (let i = 1; i < ds.length; i++) {
+        expect(ds[i]).toBeGreaterThan(ds[i - 1]);
+      }
+    });
+
+    it("すべての既定値が正の数", () => {
+      expect(DEFAULT_PORTAL_NOTIFY_CONFIG.timeoutMs).toBeGreaterThan(0);
+      expect(DEFAULT_PORTAL_NOTIFY_CONFIG.retryPendingDelayMs).toBeGreaterThan(0);
+      expect(
+        DEFAULT_PORTAL_NOTIFY_CONFIG.retryPendingMaxAttempts,
+      ).toBeGreaterThanOrEqual(0);
+    });
+  });
+});

--- a/packages/portal-notify-tool/src/config.ts
+++ b/packages/portal-notify-tool/src/config.ts
@@ -1,0 +1,198 @@
+// portal-notify-tool の設定解決。
+//
+// 設計方針：
+//   - 全項目（HTTP timeout / リトライ列 / pending 再送間隔等）を外部設定で上書き可能にし、
+//     コードへの値の埋め込み（ハードコーディング）を禁止する。
+//   - 優先順は pluginConfig > 環境変数 > DEFAULT_PORTAL_NOTIFY_CONFIG。
+//     pluginConfig は OpenClaw ホスト（テナント）が宣言的に書ける場所、
+//     env は Fly secrets / GitHub Actions secrets で動的差し替えする場所。
+//   - 不正値（NaN / 負数 / 配列内の非数値）は早期 fail で運用事故を防ぐ。
+
+import { PortalNotifyConfigError } from "./types.js";
+
+/**
+ * 必須 + 任意の全項目をフラット化した設定。
+ * resolveConfig は origin / notificationToken を含めた完全形を返す。
+ */
+export interface PortalNotifyConfig {
+  origin: string;
+  notificationToken: string;
+  timeoutMs: number;
+  retryFailedDelaysMs: number[];
+  retryPendingDelayMs: number;
+  retryPendingMaxAttempts: number;
+}
+
+/**
+ * pluginConfig に来る部分形。OpenClaw の plugin 設定 JSON や
+ * createPortalNotifyClient() に渡す。
+ */
+export type PortalNotifyConfigInput = Partial<PortalNotifyConfig>;
+
+/**
+ * 既定値：origin / notificationToken は必須なのでここには含めない。
+ * 他の閾値はすべてここに集約し、コード中に値リテラルを書かない。
+ *
+ * 既定値の根拠：
+ *   - timeoutMs 5000：portal は通常 100〜500ms で応答。5s 超は明らかに障害扱い。
+ *   - retryFailedDelaysMs [10000, 30000, 90000]：3 回・指数 3 倍・jitter は呼び出し側で付与。
+ *     合計約 2 分の retry 窓で transient な portal 不調を吸収する。
+ *   - retryPendingDelayMs 30000：portal の初回 in-flight 完了を 30s 待つ。
+ *     LINE / メール送信の通常完了時間（数秒）に十分な余裕。
+ *   - retryPendingMaxAttempts 1：pending → 1 回だけ再送。1 回でも届かなければ
+ *     portal 側で stuck pending として扱われる（5 分後に portal 自身が retry）。
+ */
+export const DEFAULT_PORTAL_NOTIFY_CONFIG: Omit<
+  PortalNotifyConfig,
+  "origin" | "notificationToken"
+> = {
+  timeoutMs: 5000,
+  retryFailedDelaysMs: [10_000, 30_000, 90_000],
+  retryPendingDelayMs: 30_000,
+  retryPendingMaxAttempts: 1,
+};
+
+/** 環境変数を一括 resolve する。 */
+export function resolveConfig(
+  pluginConfig: PortalNotifyConfigInput = {},
+): PortalNotifyConfig {
+  const origin =
+    pluginConfig.origin ?? process.env.PORTAL_ORIGIN ?? undefined;
+  const notificationToken =
+    pluginConfig.notificationToken ??
+    process.env.PORTAL_NOTIFICATION_TOKEN ??
+    undefined;
+
+  if (!origin || !notificationToken) {
+    throw new PortalNotifyConfigError(
+      "PORTAL_ORIGIN and PORTAL_NOTIFICATION_TOKEN are required " +
+        "(set via pluginConfig or environment variables)",
+    );
+  }
+
+  const timeoutMs = pickPositiveInt(
+    "timeoutMs",
+    pluginConfig.timeoutMs,
+    process.env.PORTAL_NOTIFY_TIMEOUT_MS,
+    DEFAULT_PORTAL_NOTIFY_CONFIG.timeoutMs,
+  );
+
+  const retryFailedDelaysMs = pickIntArray(
+    "retryFailedDelaysMs",
+    pluginConfig.retryFailedDelaysMs,
+    process.env.PORTAL_NOTIFY_RETRY_FAILED_MS,
+    DEFAULT_PORTAL_NOTIFY_CONFIG.retryFailedDelaysMs,
+  );
+
+  const retryPendingDelayMs = pickPositiveInt(
+    "retryPendingDelayMs",
+    pluginConfig.retryPendingDelayMs,
+    process.env.PORTAL_NOTIFY_RETRY_PENDING_MS,
+    DEFAULT_PORTAL_NOTIFY_CONFIG.retryPendingDelayMs,
+  );
+
+  const retryPendingMaxAttempts = pickNonNegativeInt(
+    "retryPendingMaxAttempts",
+    pluginConfig.retryPendingMaxAttempts,
+    process.env.PORTAL_NOTIFY_RETRY_PENDING_MAX,
+    DEFAULT_PORTAL_NOTIFY_CONFIG.retryPendingMaxAttempts,
+  );
+
+  return {
+    origin,
+    notificationToken,
+    timeoutMs,
+    retryFailedDelaysMs,
+    retryPendingDelayMs,
+    retryPendingMaxAttempts,
+  };
+}
+
+// ─────────────────────────────────────────────────────
+// 内部ヘルパ
+// ─────────────────────────────────────────────────────
+
+function pickPositiveInt(
+  name: string,
+  pluginValue: number | undefined,
+  envValue: string | undefined,
+  fallback: number,
+): number {
+  if (pluginValue !== undefined) {
+    if (!Number.isFinite(pluginValue) || pluginValue <= 0) {
+      throw new PortalNotifyConfigError(
+        `${name} must be a positive number (got ${pluginValue})`,
+      );
+    }
+    return pluginValue;
+  }
+  if (envValue !== undefined && envValue !== "") {
+    const n = Number(envValue);
+    if (!Number.isFinite(n) || n <= 0) {
+      throw new PortalNotifyConfigError(
+        `${name} env value must be a positive number (got "${envValue}")`,
+      );
+    }
+    return n;
+  }
+  return fallback;
+}
+
+function pickNonNegativeInt(
+  name: string,
+  pluginValue: number | undefined,
+  envValue: string | undefined,
+  fallback: number,
+): number {
+  if (pluginValue !== undefined) {
+    if (!Number.isFinite(pluginValue) || pluginValue < 0) {
+      throw new PortalNotifyConfigError(
+        `${name} must be a non-negative number (got ${pluginValue})`,
+      );
+    }
+    return pluginValue;
+  }
+  if (envValue !== undefined && envValue !== "") {
+    const n = Number(envValue);
+    if (!Number.isFinite(n) || n < 0) {
+      throw new PortalNotifyConfigError(
+        `${name} env value must be a non-negative number (got "${envValue}")`,
+      );
+    }
+    return n;
+  }
+  return fallback;
+}
+
+function pickIntArray(
+  name: string,
+  pluginValue: number[] | undefined,
+  envValue: string | undefined,
+  fallback: number[],
+): number[] {
+  if (pluginValue !== undefined) {
+    for (const v of pluginValue) {
+      if (!Number.isFinite(v) || v < 0) {
+        throw new PortalNotifyConfigError(
+          `${name} entries must be non-negative numbers (got ${v})`,
+        );
+      }
+    }
+    return [...pluginValue];
+  }
+  if (envValue !== undefined && envValue !== "") {
+    const parts = envValue.split(",").map((s) => s.trim()).filter(Boolean);
+    const out: number[] = [];
+    for (const p of parts) {
+      const n = Number(p);
+      if (!Number.isFinite(n) || n < 0) {
+        throw new PortalNotifyConfigError(
+          `${name} env value must be comma-separated non-negative numbers (got "${envValue}")`,
+        );
+      }
+      out.push(n);
+    }
+    return out;
+  }
+  return [...fallback];
+}

--- a/packages/portal-notify-tool/src/config.ts
+++ b/packages/portal-notify-tool/src/config.ts
@@ -53,15 +53,10 @@ export const DEFAULT_PORTAL_NOTIFY_CONFIG: Omit<
 };
 
 /** 環境変数を一括 resolve する。 */
-export function resolveConfig(
-  pluginConfig: PortalNotifyConfigInput = {},
-): PortalNotifyConfig {
-  const origin =
-    pluginConfig.origin ?? process.env.PORTAL_ORIGIN ?? undefined;
+export function resolveConfig(pluginConfig: PortalNotifyConfigInput = {}): PortalNotifyConfig {
+  const origin = pluginConfig.origin ?? process.env.PORTAL_ORIGIN ?? undefined;
   const notificationToken =
-    pluginConfig.notificationToken ??
-    process.env.PORTAL_NOTIFICATION_TOKEN ??
-    undefined;
+    pluginConfig.notificationToken ?? process.env.PORTAL_NOTIFICATION_TOKEN ?? undefined;
 
   if (!origin || !notificationToken) {
     throw new PortalNotifyConfigError(
@@ -120,9 +115,7 @@ function pickPositiveInt(
 ): number {
   if (pluginValue !== undefined) {
     if (!Number.isFinite(pluginValue) || pluginValue <= 0) {
-      throw new PortalNotifyConfigError(
-        `${name} must be a positive number (got ${pluginValue})`,
-      );
+      throw new PortalNotifyConfigError(`${name} must be a positive number (got ${pluginValue})`);
     }
     return pluginValue;
   }
@@ -181,7 +174,10 @@ function pickIntArray(
     return [...pluginValue];
   }
   if (envValue !== undefined && envValue !== "") {
-    const parts = envValue.split(",").map((s) => s.trim()).filter(Boolean);
+    const parts = envValue
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean);
     const out: number[] = [];
     for (const p of parts) {
       const n = Number(p);

--- a/packages/portal-notify-tool/src/index.test.ts
+++ b/packages/portal-notify-tool/src/index.test.ts
@@ -1,0 +1,100 @@
+// index.test.ts: plugin entry の register() がツール登録 / 設定不足時のスキップを正しく行うか。
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import portalNotifyToolPlugin from "./index.js";
+
+const ENV_KEYS = [
+  "PORTAL_ORIGIN",
+  "PORTAL_NOTIFICATION_TOKEN",
+  "PORTAL_NOTIFY_TIMEOUT_MS",
+  "PORTAL_NOTIFY_RETRY_FAILED_MS",
+  "PORTAL_NOTIFY_RETRY_PENDING_MS",
+  "PORTAL_NOTIFY_RETRY_PENDING_MAX",
+];
+
+const savedEnv: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  for (const k of ENV_KEYS) {
+    savedEnv[k] = process.env[k];
+    delete process.env[k];
+  }
+});
+
+afterEach(() => {
+  for (const k of ENV_KEYS) {
+    if (savedEnv[k] === undefined) delete process.env[k];
+    else process.env[k] = savedEnv[k];
+  }
+});
+
+function makeApi(pluginConfig?: unknown) {
+  return {
+    pluginConfig,
+    logger: {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    },
+    registerTool: vi.fn(),
+  };
+}
+
+describe("portalNotifyToolPlugin.register", () => {
+  it("plugin metadata が想定どおり", () => {
+    expect(portalNotifyToolPlugin.id).toBe("portal-notify-tool");
+    expect(portalNotifyToolPlugin.kind).toBe("plugin");
+    expect(typeof portalNotifyToolPlugin.register).toBe("function");
+  });
+
+  it("origin / token 欠落なら warn して registerTool を呼ばない", () => {
+    const api = makeApi({});
+    portalNotifyToolPlugin.register(api);
+    expect(api.logger.warn).toHaveBeenCalledOnce();
+    expect(api.registerTool).not.toHaveBeenCalled();
+  });
+
+  it("pluginConfig に origin / token があれば registerTool が呼ばれる", () => {
+    const api = makeApi({
+      origin: "https://portal.example",
+      notificationToken: "uuid",
+    });
+    portalNotifyToolPlugin.register(api);
+    expect(api.registerTool).toHaveBeenCalledOnce();
+    const [factory, options] = api.registerTool.mock.calls[0];
+    expect(options).toEqual({ names: ["notify_send"], optional: true });
+    const tools = factory({ sandboxed: false });
+    expect(tools).toHaveLength(1);
+    expect(tools[0].name).toBe("notify_send");
+  });
+
+  it("env だけで設定されていても登録される", () => {
+    process.env.PORTAL_ORIGIN = "https://env.example";
+    process.env.PORTAL_NOTIFICATION_TOKEN = "uuid-from-env";
+    const api = makeApi();
+    portalNotifyToolPlugin.register(api);
+    expect(api.registerTool).toHaveBeenCalledOnce();
+  });
+
+  it("sandboxed 環境では tool factory は null を返す（agent 直接実行を抑止）", () => {
+    const api = makeApi({
+      origin: "https://portal.example",
+      notificationToken: "uuid",
+    });
+    portalNotifyToolPlugin.register(api);
+    const [factory] = api.registerTool.mock.calls[0];
+    expect(factory({ sandboxed: true })).toBeNull();
+  });
+
+  it("ConfigError 以外の例外は re-throw する（運用バグの検出）", () => {
+    const api = makeApi({
+      origin: "https://x",
+      notificationToken: "x",
+      // 不正値で ConfigError を発生させ、ここでは catch される
+      timeoutMs: -1,
+    });
+    // ConfigError の場合は warn + return なので throw しない
+    expect(() => portalNotifyToolPlugin.register(api)).not.toThrow();
+    expect(api.logger.warn).toHaveBeenCalledOnce();
+    expect(api.registerTool).not.toHaveBeenCalled();
+  });
+});

--- a/packages/portal-notify-tool/src/index.ts
+++ b/packages/portal-notify-tool/src/index.ts
@@ -1,0 +1,101 @@
+// portal-notify-tool プラグインエントリポイント。
+//
+// OpenClaw ホストから default export の register(api) が呼ばれる。
+// api は OpenClaw plugin SDK の OpenClawPluginApi だが、本パッケージは optional peerDep
+// にしているため、build / test が openclaw 未インストール環境でも通るよう
+// 構造的型 (PluginApiLike) で必要分だけ宣言する。
+//
+// 役割：
+//   1. pluginConfig + 環境変数から PortalNotifyConfig を解決
+//   2. PortalNotifyClient を 1 個だけ作って共有
+//   3. notify_send ツールを registerTool で公開
+//
+// 設計判断：
+//   - Pinecone / Auth トークンと違い、portal token は per-instance で 1 個固定。
+//     factory でテナントごとに切り替える必要はないので、register() の中で client を
+//     1 個生成して全 tool に共有する。
+//   - 設定不足（origin / token なし）のときは fatal error にせず warn ログ + 登録スキップ。
+//     これにより token がまだセットされていないインスタンスでも plugin ロード自体は失敗しない
+//     （workflow-controller / model-router と同じ「未設定なら無効化」パターン）。
+
+import { createPortalNotifyClient } from "./client.js";
+import {
+  type PortalNotifyConfigInput,
+  resolveConfig,
+} from "./config.js";
+import { createNotifySendTool } from "./tool.js";
+import { PortalNotifyConfigError } from "./types.js";
+
+// public API として再 export。caller（テスト・他パッケージ）は client サブパス
+// `@openclaw/portal-notify-tool/client` ではなく root から import 可能。
+export { createPortalNotifyClient } from "./client.js";
+export { DEFAULT_PORTAL_NOTIFY_CONFIG, resolveConfig } from "./config.js";
+export { createNotifySendTool } from "./tool.js";
+export * from "./types.js";
+
+/**
+ * OpenClaw plugin API の最小サブセット（構造的型）。
+ * 本パッケージで必要な registerTool / logger / pluginConfig だけ定義する。
+ */
+interface PluginApiLike {
+  pluginConfig?: unknown;
+  logger: {
+    info: (msg: string) => void;
+    warn: (msg: string) => void;
+    error: (msg: string, ...rest: unknown[]) => void;
+  };
+  registerTool: (
+    factory: (ctx: unknown) => unknown,
+    options: { names: string[]; optional?: boolean },
+  ) => void;
+}
+
+const portalNotifyToolPlugin = {
+  id: "portal-notify-tool",
+  name: "Portal Notify Tool",
+  description:
+    "Relays agent notifications to the easy.flow portal (LINE / email). Provides notify_send tool.",
+  kind: "plugin" as const,
+
+  register(api: PluginApiLike): void {
+    const rawConfig = (api.pluginConfig ?? {}) as PortalNotifyConfigInput;
+
+    let cfg;
+    try {
+      cfg = resolveConfig(rawConfig);
+    } catch (err) {
+      if (err instanceof PortalNotifyConfigError) {
+        // origin / token 欠落は plugin ロード時には fatal にしない。
+        // tool 自体を登録しないことで agent 側に「ツール未提供」と伝える。
+        api.logger.warn(
+          `[portal-notify-tool] disabled: ${err.message}. ` +
+            `Set PORTAL_ORIGIN / PORTAL_NOTIFICATION_TOKEN to enable.`,
+        );
+        return;
+      }
+      throw err;
+    }
+
+    const client = createPortalNotifyClient(cfg);
+    const notifyTool = createNotifySendTool(client);
+
+    api.registerTool(
+      (ctx) => {
+        // ctx.sandboxed 等のホスト判定はキャストして読む（構造的型では未定義）
+        const sandboxed = (ctx as { sandboxed?: boolean }).sandboxed;
+        if (sandboxed) return null;
+        return [notifyTool];
+      },
+      {
+        names: ["notify_send"],
+        optional: true,
+      },
+    );
+
+    api.logger.info(
+      `[portal-notify-tool] registered notify_send tool (origin=${cfg.origin})`,
+    );
+  },
+};
+
+export default portalNotifyToolPlugin;

--- a/packages/portal-notify-tool/src/index.ts
+++ b/packages/portal-notify-tool/src/index.ts
@@ -19,10 +19,7 @@
 //     （workflow-controller / model-router と同じ「未設定なら無効化」パターン）。
 
 import { createPortalNotifyClient } from "./client.js";
-import {
-  type PortalNotifyConfigInput,
-  resolveConfig,
-} from "./config.js";
+import { type PortalNotifyConfig, type PortalNotifyConfigInput, resolveConfig } from "./config.js";
 import { createNotifySendTool } from "./tool.js";
 import { PortalNotifyConfigError } from "./types.js";
 
@@ -60,7 +57,7 @@ const portalNotifyToolPlugin = {
   register(api: PluginApiLike): void {
     const rawConfig = (api.pluginConfig ?? {}) as PortalNotifyConfigInput;
 
-    let cfg;
+    let cfg: PortalNotifyConfig;
     try {
       cfg = resolveConfig(rawConfig);
     } catch (err) {
@@ -92,9 +89,7 @@ const portalNotifyToolPlugin = {
       },
     );
 
-    api.logger.info(
-      `[portal-notify-tool] registered notify_send tool (origin=${cfg.origin})`,
-    );
+    api.logger.info(`[portal-notify-tool] registered notify_send tool (origin=${cfg.origin})`);
   },
 };
 

--- a/packages/portal-notify-tool/src/retry.test.ts
+++ b/packages/portal-notify-tool/src/retry.test.ts
@@ -25,9 +25,7 @@ describe("retryWithBackoff", () => {
       retry: true as const,
       error: new Error("transient"),
     }));
-    await expect(
-      retryWithBackoff(fn, [10, 20, 30], sleep),
-    ).rejects.toThrow("transient");
+    await expect(retryWithBackoff(fn, [10, 20, 30], sleep)).rejects.toThrow("transient");
     expect(fn).toHaveBeenCalledTimes(4); // 初回 + 3 回 retry
     expect(sleep).toHaveBeenCalledTimes(3);
     expect(sleep).toHaveBeenNthCalledWith(1, 10);
@@ -67,9 +65,7 @@ describe("retryWithBackoff", () => {
     const fn = vi.fn(async () => {
       throw new Error("fatal");
     });
-    await expect(
-      retryWithBackoff(fn, [10, 20], sleep),
-    ).rejects.toThrow("fatal");
+    await expect(retryWithBackoff(fn, [10, 20], sleep)).rejects.toThrow("fatal");
     expect(fn).toHaveBeenCalledTimes(1);
     expect(sleep).not.toHaveBeenCalled();
   });

--- a/packages/portal-notify-tool/src/retry.test.ts
+++ b/packages/portal-notify-tool/src/retry.test.ts
@@ -1,0 +1,95 @@
+// retry.ts: 指数バックオフ + jitter ヘルパのテスト。
+//
+// retryWithBackoff(fn, delaysMs, sleepFn) は与えられた fn を最大 delaysMs.length+1 回
+// 試行する。fn が `{ retry: true, error }` を返したら次の delay 後に再試行、
+// `{ retry: false, value }` を返したら即座に成功で終了する。throw された Error は
+// retry せず即座に上位へ伝播する（caller がエラー分類済みである前提）。
+//
+// sleep は外注（依存性注入）にしてテストで仮想時間にする。
+import { describe, expect, it, vi } from "vitest";
+import { addJitter, retryWithBackoff } from "./retry.js";
+
+describe("retryWithBackoff", () => {
+  it("初回成功なら sleep は呼ばれない", async () => {
+    const sleep = vi.fn(async (_ms: number) => {});
+    const fn = vi.fn(async () => ({ retry: false as const, value: "ok" }));
+    const result = await retryWithBackoff(fn, [100, 200], sleep);
+    expect(result).toBe("ok");
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
+  it("retry: true が続けば delaysMs 全件分 sleep して fn を delaysMs.length+1 回呼ぶ", async () => {
+    const sleep = vi.fn(async (_ms: number) => {});
+    const fn = vi.fn(async () => ({
+      retry: true as const,
+      error: new Error("transient"),
+    }));
+    await expect(
+      retryWithBackoff(fn, [10, 20, 30], sleep),
+    ).rejects.toThrow("transient");
+    expect(fn).toHaveBeenCalledTimes(4); // 初回 + 3 回 retry
+    expect(sleep).toHaveBeenCalledTimes(3);
+    expect(sleep).toHaveBeenNthCalledWith(1, 10);
+    expect(sleep).toHaveBeenNthCalledWith(2, 20);
+    expect(sleep).toHaveBeenNthCalledWith(3, 30);
+  });
+
+  it("途中で retry: false に切り替われば即終了", async () => {
+    const sleep = vi.fn(async (_ms: number) => {});
+    let count = 0;
+    const fn = vi.fn(async () => {
+      count++;
+      if (count < 3) {
+        return { retry: true as const, error: new Error("transient") };
+      }
+      return { retry: false as const, value: 42 };
+    });
+    const result = await retryWithBackoff(fn, [10, 20, 30, 40], sleep);
+    expect(result).toBe(42);
+    expect(fn).toHaveBeenCalledTimes(3);
+    expect(sleep).toHaveBeenCalledTimes(2);
+  });
+
+  it("delaysMs が空配列なら 1 回のみ試行で retry しない", async () => {
+    const sleep = vi.fn(async (_ms: number) => {});
+    const fn = vi.fn(async () => ({
+      retry: true as const,
+      error: new Error("once"),
+    }));
+    await expect(retryWithBackoff(fn, [], sleep)).rejects.toThrow("once");
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
+  it("fn が直接 throw した場合は retry せず即伝播", async () => {
+    const sleep = vi.fn(async (_ms: number) => {});
+    const fn = vi.fn(async () => {
+      throw new Error("fatal");
+    });
+    await expect(
+      retryWithBackoff(fn, [10, 20], sleep),
+    ).rejects.toThrow("fatal");
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(sleep).not.toHaveBeenCalled();
+  });
+});
+
+describe("addJitter", () => {
+  it("delay の ±25% 範囲に収まる", () => {
+    const delay = 1000;
+    for (let i = 0; i < 100; i++) {
+      const jittered = addJitter(delay);
+      expect(jittered).toBeGreaterThanOrEqual(750);
+      expect(jittered).toBeLessThanOrEqual(1250);
+    }
+  });
+
+  it("delay 0 は 0 を返す", () => {
+    expect(addJitter(0)).toBe(0);
+  });
+
+  it("負の delay は 0 にクランプ", () => {
+    expect(addJitter(-100)).toBe(0);
+  });
+});

--- a/packages/portal-notify-tool/src/retry.ts
+++ b/packages/portal-notify-tool/src/retry.ts
@@ -1,0 +1,62 @@
+// 指数バックオフによる retry ヘルパ。
+//
+// 設計方針：
+//   - sleep を依存性注入（第 3 引数）にすることでテストが仮想時間で完結する。
+//     setTimeout を直接掴むと vitest fake timer との結合が脆くなり、CI で flaky になる。
+//   - 「retry すべきか」の判定は呼び出し側で行い、本ヘルパは値の `retry: bool` フラグを
+//     見るだけ。Error を直接 throw された場合は分類済みエラーとみなし、retry せず即伝播。
+//   - jitter は ±25% で固定（thundering herd 緩和に十分）。jitter 範囲も外部設定にする
+//     設計余地はあるが、現状の portal 利用形態では過剰なので固定値とする。
+
+/**
+ * retryWithBackoff の fn が返す結果型。
+ * - `retry: false` なら成功で即終了し value を返す
+ * - `retry: true` なら delays[i] だけ sleep してから再試行
+ * - 全 retry 後も `retry: true` のままなら最後の error を throw する
+ */
+export type RetryStep<T> =
+  | { retry: false; value: T }
+  | { retry: true; error: Error };
+
+/**
+ * 指数バックオフで fn を試行する。
+ *
+ * @param fn 試行する非同期関数。retry すべきかどうかを返す
+ * @param delaysMs 各 retry 前の sleep ミリ秒。空配列なら retry しない
+ * @param sleep ミリ秒だけ待機する関数（DI）
+ * @returns fn が retry: false で返した value
+ * @throws fn が直接 throw したエラー、または retry を尽くした最後の error
+ */
+export async function retryWithBackoff<T>(
+  fn: () => Promise<RetryStep<T>>,
+  delaysMs: number[],
+  sleep: (ms: number) => Promise<void>,
+): Promise<T> {
+  let lastError: Error | undefined;
+
+  // 試行回数 = 1（初回）+ delaysMs.length（retry）
+  for (let attempt = 0; attempt <= delaysMs.length; attempt++) {
+    if (attempt > 0) {
+      await sleep(delaysMs[attempt - 1]);
+    }
+    const result = await fn();
+    if (!result.retry) {
+      return result.value;
+    }
+    lastError = result.error;
+  }
+
+  // delaysMs が空 + 初回 retry: true の場合に備えて lastError は必ず存在する
+  throw lastError ?? new Error("retry exhausted");
+}
+
+/**
+ * delay に ±25% の jitter を加える。負数 / 0 は 0 にクランプ。
+ *
+ * 用途：複数 instance が同じバックオフ列で portal にバースト retry するのを避ける。
+ */
+export function addJitter(delayMs: number): number {
+  if (delayMs <= 0) return 0;
+  const jitter = (Math.random() - 0.5) * 0.5; // [-0.25, +0.25)
+  return Math.max(0, Math.round(delayMs * (1 + jitter)));
+}

--- a/packages/portal-notify-tool/src/retry.ts
+++ b/packages/portal-notify-tool/src/retry.ts
@@ -14,9 +14,7 @@
  * - `retry: true` なら delays[i] だけ sleep してから再試行
  * - 全 retry 後も `retry: true` のままなら最後の error を throw する
  */
-export type RetryStep<T> =
-  | { retry: false; value: T }
-  | { retry: true; error: Error };
+export type RetryStep<T> = { retry: false; value: T } | { retry: true; error: Error };
 
 /**
  * 指数バックオフで fn を試行する。

--- a/packages/portal-notify-tool/src/tool.test.ts
+++ b/packages/portal-notify-tool/src/tool.test.ts
@@ -1,0 +1,236 @@
+// tool.test.ts: createNotifySendTool が portal-notify-client をラップして
+// OpenClaw の AnyAgentTool を返すことを検証する。
+//
+// 確認したいこと：
+//   - LLM 入力（args）の型ガード（kind 必須・enum 値・body 必須・型違反は人間可読エラー）
+//   - portal client の send を 1 回呼ぶ（args をそのまま渡す）
+//   - 200 sent / 200 pending / 410 / Error をそれぞれ LLM 向けに整形した text に変換
+//   - PortalAuthError / PortalValidationError は LLM に「retry するな」を伝えるテキスト
+//   - 想定外の例外も人間可読エラーで返す
+import { describe, expect, it, vi } from "vitest";
+import { createNotifySendTool } from "./tool.js";
+import {
+  PortalAuthError,
+  PortalDeliveryError,
+  PortalUnavailableError,
+  PortalValidationError,
+  type NotifySendInput,
+  type NotifySendOutcome,
+} from "./types.js";
+
+function makeClient(send: (input: NotifySendInput) => Promise<NotifySendOutcome>) {
+  return {
+    config: {} as never,
+    send: vi.fn(send),
+  };
+}
+
+describe("createNotifySendTool - スキーマ", () => {
+  it("name / description / parameters が定義されている", () => {
+    const client = makeClient(async () => ({
+      ok: true,
+      sent: 0,
+      pending: 0,
+      failed: 0,
+      results: [],
+    }));
+    const tool = createNotifySendTool(client);
+    expect(tool.name).toBe("notify_send");
+    expect(typeof tool.description).toBe("string");
+    expect(tool.description.length).toBeGreaterThan(0);
+    expect(tool.parameters).toMatchObject({
+      type: "object",
+      required: expect.arrayContaining(["kind", "body"]),
+    });
+  });
+});
+
+describe("createNotifySendTool - 入力バリデーション", () => {
+  it("kind 不在は LLM 向けエラー text を返す", async () => {
+    const client = makeClient(async () => {
+      throw new Error("should not be called");
+    });
+    const tool = createNotifySendTool(client);
+    const result = await tool.execute("call-1", { body: "msg" });
+    expect(result.content[0].type).toBe("text");
+    expect((result.content[0] as { text: string }).text).toMatch(/kind/);
+    expect(client.send).not.toHaveBeenCalled();
+  });
+
+  it("kind が enum 外は エラー text", async () => {
+    const client = makeClient(async () => {
+      throw new Error("should not be called");
+    });
+    const tool = createNotifySendTool(client);
+    const result = await tool.execute("call-1", {
+      kind: "spam_send",
+      body: "msg",
+    });
+    expect((result.content[0] as { text: string }).text).toMatch(/kind/);
+    expect(client.send).not.toHaveBeenCalled();
+  });
+
+  it("body 不在は エラー text", async () => {
+    const client = makeClient(async () => {
+      throw new Error("should not be called");
+    });
+    const tool = createNotifySendTool(client);
+    const result = await tool.execute("call-1", { kind: "system" });
+    expect((result.content[0] as { text: string }).text).toMatch(/body/);
+    expect(client.send).not.toHaveBeenCalled();
+  });
+
+  it("memberIds が array 以外なら エラー text", async () => {
+    const client = makeClient(async () => {
+      throw new Error("should not be called");
+    });
+    const tool = createNotifySendTool(client);
+    const result = await tool.execute("call-1", {
+      kind: "system",
+      body: "msg",
+      memberIds: "uuid-1",
+    });
+    expect((result.content[0] as { text: string }).text).toMatch(/memberIds/);
+  });
+});
+
+describe("createNotifySendTool - 正常系", () => {
+  it("client.send に args を構造化して渡す", async () => {
+    const client = makeClient(async () => ({
+      ok: true,
+      sent: 1,
+      pending: 0,
+      failed: 0,
+      results: [],
+    }));
+    const tool = createNotifySendTool(client);
+    await tool.execute("call-1", {
+      kind: "task_completed",
+      body: "msg",
+      subject: "件名",
+      memberIds: ["uuid-1", "uuid-2"],
+      idempotencyKey: "key-1",
+    });
+    expect(client.send).toHaveBeenCalledWith({
+      kind: "task_completed",
+      body: "msg",
+      subject: "件名",
+      memberIds: ["uuid-1", "uuid-2"],
+      idempotencyKey: "key-1",
+    });
+  });
+
+  it("ok: true sent 結果は LLM 向けに件数を整形した text を返す", async () => {
+    const client = makeClient(async () => ({
+      ok: true,
+      sent: 3,
+      pending: 0,
+      failed: 0,
+      results: [
+        { memberId: "m1", notificationId: "n1", channel: "line", status: "sent" },
+        { memberId: "m2", notificationId: "n2", channel: "line", status: "sent" },
+        { memberId: "m3", notificationId: "n3", channel: "email", status: "sent" },
+      ],
+    }));
+    const tool = createNotifySendTool(client);
+    const result = await tool.execute("call-1", { kind: "system", body: "msg" });
+    const text = (result.content[0] as { text: string }).text;
+    expect(text).toMatch(/sent.*3/);
+    expect(text).toMatch(/line.*2/);
+    expect(text).toMatch(/email.*1/);
+  });
+
+  it("ok: true pending を含む結果は「未確定あり」と LLM に伝える", async () => {
+    const client = makeClient(async () => ({
+      ok: true,
+      sent: 1,
+      pending: 1,
+      failed: 0,
+      results: [],
+    }));
+    const tool = createNotifySendTool(client);
+    const result = await tool.execute("call-1", { kind: "system", body: "msg" });
+    const text = (result.content[0] as { text: string }).text;
+    expect(text).toMatch(/pending/i);
+  });
+});
+
+describe("createNotifySendTool - 異常系", () => {
+  it("ok: false reason: no_active_member は warn 系 text", async () => {
+    const client = makeClient(async () => ({
+      ok: false,
+      reason: "no_active_member",
+      status: 404,
+    }));
+    const tool = createNotifySendTool(client);
+    const result = await tool.execute("call-1", { kind: "system", body: "msg" });
+    const text = (result.content[0] as { text: string }).text;
+    expect(text).toMatch(/active member/);
+  });
+
+  it("ok: false reason: subscription_gone は永続失敗で「retry しないで」と伝える", async () => {
+    const client = makeClient(async () => ({
+      ok: false,
+      reason: "subscription_gone",
+      status: 410,
+    }));
+    const tool = createNotifySendTool(client);
+    const result = await tool.execute("call-1", { kind: "system", body: "msg" });
+    const text = (result.content[0] as { text: string }).text;
+    expect(text).toMatch(/subscription/);
+    expect(text).toMatch(/retry|再試行|do not/i);
+  });
+
+  it("PortalAuthError は永続失敗 (retry 不要) を LLM に伝える", async () => {
+    const client = makeClient(async () => {
+      throw new PortalAuthError();
+    });
+    const tool = createNotifySendTool(client);
+    const result = await tool.execute("call-1", { kind: "system", body: "msg" });
+    const text = (result.content[0] as { text: string }).text;
+    expect(text).toMatch(/auth|token|401/i);
+    expect(text).toMatch(/retry|再試行|do not/i);
+  });
+
+  it("PortalValidationError は仕様違反として詳細を含めて返す", async () => {
+    const client = makeClient(async () => {
+      throw new PortalValidationError("memberIds 一部無効", {
+        missingMemberIds: ["uuid-x"],
+      });
+    });
+    const tool = createNotifySendTool(client);
+    const result = await tool.execute("call-1", { kind: "system", body: "msg" });
+    const text = (result.content[0] as { text: string }).text;
+    expect(text).toMatch(/memberIds 一部無効|400/);
+  });
+
+  it("PortalDeliveryError は外部配信失敗として LLM に伝える", async () => {
+    const client = makeClient(async () => {
+      throw new PortalDeliveryError("502 reached after retries", []);
+    });
+    const tool = createNotifySendTool(client);
+    const result = await tool.execute("call-1", { kind: "system", body: "msg" });
+    const text = (result.content[0] as { text: string }).text;
+    expect(text).toMatch(/502|delivery|配信/i);
+  });
+
+  it("PortalUnavailableError は network / 5xx 失敗として「後で retry 可」を伝える", async () => {
+    const client = makeClient(async () => {
+      throw new PortalUnavailableError("ECONNRESET");
+    });
+    const tool = createNotifySendTool(client);
+    const result = await tool.execute("call-1", { kind: "system", body: "msg" });
+    const text = (result.content[0] as { text: string }).text;
+    expect(text).toMatch(/ECONNRESET|unavailable|接続/i);
+  });
+
+  it("想定外の例外も人間可読 text で返す（throw しない）", async () => {
+    const client = makeClient(async () => {
+      throw new TypeError("nope");
+    });
+    const tool = createNotifySendTool(client);
+    const result = await tool.execute("call-1", { kind: "system", body: "msg" });
+    const text = (result.content[0] as { text: string }).text;
+    expect(text).toMatch(/nope|error/i);
+  });
+});

--- a/packages/portal-notify-tool/src/tool.test.ts
+++ b/packages/portal-notify-tool/src/tool.test.ts
@@ -10,12 +10,12 @@
 import { describe, expect, it, vi } from "vitest";
 import { createNotifySendTool } from "./tool.js";
 import {
+  type NotifySendInput,
+  type NotifySendOutcome,
   PortalAuthError,
   PortalDeliveryError,
   PortalUnavailableError,
   PortalValidationError,
-  type NotifySendInput,
-  type NotifySendOutcome,
 } from "./types.js";
 
 function makeClient(send: (input: NotifySendInput) => Promise<NotifySendOutcome>) {

--- a/packages/portal-notify-tool/src/tool.ts
+++ b/packages/portal-notify-tool/src/tool.ts
@@ -10,12 +10,12 @@
 
 import type { PortalNotifyClient } from "./client.js";
 import {
+  type NotifyKind,
+  type NotifySendInput,
   PortalAuthError,
   PortalDeliveryError,
   PortalUnavailableError,
   PortalValidationError,
-  type NotifyKind,
-  type NotifySendInput,
 } from "./types.js";
 
 // AnyAgentTool は openclaw/plugin-sdk の型だが、本パッケージは optional peerDep にしているため
@@ -30,16 +30,9 @@ export interface AgentToolLike {
   ) => Promise<{ content: Array<{ type: "text"; text: string }> }>;
 }
 
-const VALID_KINDS: NotifyKind[] = [
-  "task_completed",
-  "reaction_received",
-  "followup_due",
-  "system",
-];
+const VALID_KINDS: NotifyKind[] = ["task_completed", "reaction_received", "followup_due", "system"];
 
-export function createNotifySendTool(
-  client: Pick<PortalNotifyClient, "send">,
-): AgentToolLike {
+export function createNotifySendTool(client: Pick<PortalNotifyClient, "send">): AgentToolLike {
   return {
     name: "notify_send",
     description:
@@ -74,8 +67,7 @@ export function createNotifySendTool(
         },
         idempotencyKey: {
           type: "string",
-          description:
-            "Optional 8-128 char key for retry-safe delivery. Use task ID + run ID.",
+          description: "Optional 8-128 char key for retry-safe delivery. Use task ID + run ID.",
         },
       },
       required: ["kind", "body"],
@@ -116,9 +108,7 @@ export function createNotifySendTool(
 // バリデーション
 // ─────────────────────────────────────────────────────
 
-type ValidatedArgs =
-  | { ok: true; value: NotifySendInput }
-  | { ok: false; error: string };
+type ValidatedArgs = { ok: true; value: NotifySendInput } | { ok: false; error: string };
 
 function validateArgs(args: Record<string, unknown>): ValidatedArgs {
   const kind = args.kind;

--- a/packages/portal-notify-tool/src/tool.ts
+++ b/packages/portal-notify-tool/src/tool.ts
@@ -1,0 +1,240 @@
+// OpenClaw 用 notify_send ツールファクトリ。
+//
+// 設計方針：
+//   - LLM に露出するツールは「失敗しても throw せず content[type='text'] で説明する」のが原則
+//     （tool が throw すると agent ループが落ちて recovery できない）。
+//   - LLM 入力（args: Record<string, unknown>）は必ず実行時バリデーションする。
+//     型は TypeScript で保証されないため shape 違反を人間可読エラー text で返す。
+//   - portal client が返した outcome / 投げた error を、LLM が retry 判断できる
+//     テキストに整形して返す。具体的には「retry すべきか」「永続失敗か」を含める。
+
+import type { PortalNotifyClient } from "./client.js";
+import {
+  PortalAuthError,
+  PortalDeliveryError,
+  PortalUnavailableError,
+  PortalValidationError,
+  type NotifyKind,
+  type NotifySendInput,
+} from "./types.js";
+
+// AnyAgentTool は openclaw/plugin-sdk の型だが、本パッケージは optional peerDep にしているため
+// 構造的型で必要分だけ宣言する（peerDep 未インストール環境でも build / test が通る）。
+export interface AgentToolLike {
+  name: string;
+  description: string;
+  parameters: Record<string, unknown>;
+  execute: (
+    callId: string,
+    args: Record<string, unknown>,
+  ) => Promise<{ content: Array<{ type: "text"; text: string }> }>;
+}
+
+const VALID_KINDS: NotifyKind[] = [
+  "task_completed",
+  "reaction_received",
+  "followup_due",
+  "system",
+];
+
+export function createNotifySendTool(
+  client: Pick<PortalNotifyClient, "send">,
+): AgentToolLike {
+  return {
+    name: "notify_send",
+    description:
+      "Send a notification to tenant members via the easy.flow portal. " +
+      "The portal delivers the message via LINE (for members linked to the official account) or email. " +
+      "Use this when an agent task completes (kind: task_completed), " +
+      "an external event arrives (kind: reaction_received), " +
+      "a followup is due (kind: followup_due), or " +
+      "a system-level notice must be raised (kind: system). " +
+      "Reusing the same idempotencyKey prevents duplicate delivery if the agent retries.",
+    parameters: {
+      type: "object",
+      properties: {
+        kind: {
+          type: "string",
+          enum: VALID_KINDS,
+          description: "Notification category for auditing and routing.",
+        },
+        body: {
+          type: "string",
+          description: "Message body (max 4000 chars).",
+        },
+        subject: {
+          type: "string",
+          description: "Email subject (max 200 chars). Ignored for LINE delivery.",
+        },
+        memberIds: {
+          type: "array",
+          items: { type: "string" },
+          description:
+            "Optional. Subscription-internal member UUIDs. Omit to broadcast to all active members.",
+        },
+        idempotencyKey: {
+          type: "string",
+          description:
+            "Optional 8-128 char key for retry-safe delivery. Use task ID + run ID.",
+        },
+      },
+      required: ["kind", "body"],
+    },
+    execute: async (_callId, args) => {
+      // 1) 実行時バリデーション
+      const validated = validateArgs(args);
+      if (!validated.ok) {
+        return text(validated.error);
+      }
+
+      // 2) portal 呼び出し
+      try {
+        const outcome = await client.send(validated.value);
+
+        if (outcome.ok) {
+          return text(formatSuccess(outcome));
+        }
+        if (outcome.reason === "no_active_member") {
+          return text(
+            "No active member to notify (404). The subscription has no eligible recipients. " +
+              "This is not a failure to retry; verify whether members are intentionally inactive.",
+          );
+        }
+        // subscription_gone
+        return text(
+          "Portal returned 410 (subscription gone): the subscription is suspended or scheduled for deletion. " +
+            "Do not retry — stop sending notifications for this tenant.",
+        );
+      } catch (err) {
+        return text(formatError(err));
+      }
+    },
+  };
+}
+
+// ─────────────────────────────────────────────────────
+// バリデーション
+// ─────────────────────────────────────────────────────
+
+type ValidatedArgs =
+  | { ok: true; value: NotifySendInput }
+  | { ok: false; error: string };
+
+function validateArgs(args: Record<string, unknown>): ValidatedArgs {
+  const kind = args.kind;
+  if (typeof kind !== "string") {
+    return { ok: false, error: 'invalid args: "kind" is required (string)' };
+  }
+  if (!(VALID_KINDS as string[]).includes(kind)) {
+    return {
+      ok: false,
+      error: `invalid args: "kind" must be one of ${VALID_KINDS.join(", ")} (got ${JSON.stringify(kind)})`,
+    };
+  }
+  const body = args.body;
+  if (typeof body !== "string" || body.length === 0) {
+    return { ok: false, error: 'invalid args: "body" is required (non-empty string)' };
+  }
+
+  const subject = args.subject;
+  if (subject !== undefined && typeof subject !== "string") {
+    return { ok: false, error: 'invalid args: "subject" must be a string when provided' };
+  }
+
+  const memberIdsRaw = args.memberIds;
+  let memberIds: string[] | undefined;
+  if (memberIdsRaw !== undefined) {
+    if (!Array.isArray(memberIdsRaw)) {
+      return { ok: false, error: 'invalid args: "memberIds" must be an array of UUID strings' };
+    }
+    for (const v of memberIdsRaw) {
+      if (typeof v !== "string") {
+        return {
+          ok: false,
+          error: 'invalid args: "memberIds" entries must all be strings',
+        };
+      }
+    }
+    memberIds = memberIdsRaw as string[];
+  }
+
+  const idempotencyKey = args.idempotencyKey;
+  if (idempotencyKey !== undefined && typeof idempotencyKey !== "string") {
+    return {
+      ok: false,
+      error: 'invalid args: "idempotencyKey" must be a string when provided',
+    };
+  }
+
+  return {
+    ok: true,
+    value: {
+      kind: kind as NotifyKind,
+      body,
+      ...(subject !== undefined ? { subject } : {}),
+      ...(memberIds !== undefined ? { memberIds } : {}),
+      ...(idempotencyKey !== undefined ? { idempotencyKey } : {}),
+    },
+  };
+}
+
+// ─────────────────────────────────────────────────────
+// LLM 向け text 整形
+// ─────────────────────────────────────────────────────
+
+function formatSuccess(outcome: {
+  ok: true;
+  sent: number;
+  pending: number;
+  failed: number;
+  results: Array<{ channel: "line" | "email" }>;
+}): string {
+  const lineCount = outcome.results.filter((r) => r.channel === "line").length;
+  const emailCount = outcome.results.filter((r) => r.channel === "email").length;
+  const parts: string[] = [
+    `notify_send delivered: sent=${outcome.sent}, pending=${outcome.pending}, failed=${outcome.failed}`,
+    `channels: line=${lineCount}, email=${emailCount}`,
+  ];
+  if (outcome.pending > 0) {
+    parts.push(
+      "Some deliveries are still pending after retry attempts. The portal may complete them asynchronously; do not retry from the agent side.",
+    );
+  }
+  return parts.join("\n");
+}
+
+function formatError(err: unknown): string {
+  if (err instanceof PortalAuthError) {
+    return (
+      "notify_send failed: portal rejected the notification token (401). " +
+      "Do not retry. Operations must rotate or re-issue the per-subscription token."
+    );
+  }
+  if (err instanceof PortalValidationError) {
+    const details = err.details ? ` details=${JSON.stringify(err.details)}` : "";
+    return (
+      `notify_send failed: portal returned 400 (${err.message}).${details} ` +
+      "Do not retry — this indicates a request-shape bug in the agent."
+    );
+  }
+  if (err instanceof PortalDeliveryError) {
+    return (
+      `notify_send failed: portal returned 502 after retries (${err.message}). ` +
+      "All recipients failed delivery. The portal already retried; do not retry immediately from the agent side."
+    );
+  }
+  if (err instanceof PortalUnavailableError) {
+    return (
+      `notify_send failed: portal unreachable or 5xx (${err.message}). ` +
+      "This is a transient failure; the agent may retry on the next workflow tick."
+    );
+  }
+  if (err instanceof Error) {
+    return `notify_send unexpected error: ${err.name}: ${err.message}`;
+  }
+  return `notify_send unexpected error: ${String(err)}`;
+}
+
+function text(message: string) {
+  return { content: [{ type: "text" as const, text: message }] };
+}

--- a/packages/portal-notify-tool/src/types.ts
+++ b/packages/portal-notify-tool/src/types.ts
@@ -1,0 +1,125 @@
+// portal `/api/notifications/send` の入出力型と error クラス。
+//
+// portal 側コントラクトの正本：
+//   easy-flow-real-estate-portal/lib/notifications.ts（NOTIFY_*_LEN, UUID_REGEX）
+//   easy-flow-real-estate-portal/app/api/[[...route]]/route.ts（POST /api/notifications/send）
+// 本ファイルでは shape のみ duplicate する（リポジトリが分かれているため）。
+// 乖離した場合は portal 側の統合テストで検出する想定。
+
+/**
+ * 通知の業務カテゴリ。portal 側の `kind` 列にそのまま記録される。
+ * portal は kind ごとに UI / 集計を変える可能性があるため、
+ * 任意の string ではなく明示的な union で受ける。
+ */
+export type NotifyKind =
+  | "task_completed"      // 能動型 AI のタスク完了
+  | "reaction_received"   // 反響着信
+  | "followup_due"        // 追客リマインド
+  | "system";             // 運用通知（プラン変更・障害告知など）
+
+/**
+ * portal `POST /api/notifications/send` のリクエスト body。
+ *
+ * - body 最大 4000 文字
+ * - subject 最大 200 文字（メール件名のみ。LINE では未使用）
+ * - memberIds 省略時は subscription 内の全 active member 宛
+ * - idempotencyKey 8〜128 文字。同 key の再送は portal 側で重複配信されない
+ */
+export interface NotifySendInput {
+  kind: NotifyKind;
+  body: string;
+  subject?: string;
+  memberIds?: string[];
+  idempotencyKey?: string;
+}
+
+/**
+ * portal が返す配信結果（1 member あたり 1 件）。
+ * `pending` は「初回 in-flight 中なので caller は短時間後に retry すべき」状態。
+ */
+export interface NotifyDeliveryResult {
+  memberId: string;
+  notificationId: string;
+  channel: "line" | "email";
+  status: "sent" | "failed" | "pending";
+  error?: string;
+}
+
+/**
+ * portal の 200 / 502 レスポンス body。
+ * - 200: sent + pending >= 1
+ * - 502: 全件 failed（呼び出し側でリトライ判定）
+ */
+export interface NotifySendResponse {
+  sent: number;
+  pending: number;
+  failed: number;
+  results: NotifyDeliveryResult[];
+}
+
+/**
+ * client.send() の戻り値。
+ * portal の HTTP status を吸収して「成功 / リトライ後失敗 / 410 終了」の 3 種類で返す。
+ */
+export type NotifySendOutcome =
+  | { ok: true; sent: number; pending: number; failed: number; results: NotifyDeliveryResult[] }
+  | { ok: false; reason: "no_active_member"; status: 404 }
+  | { ok: false; reason: "subscription_gone"; status: 410 };
+
+// ─────────────────────────────────────────────────────
+// Error クラス階層
+//
+// retry 不要 / retry 可能を caller が分岐するため、それぞれ独立クラスにする。
+// すべて Error を継承する素直な階層。
+// ─────────────────────────────────────────────────────
+
+export class PortalNotifyError extends Error {
+  constructor(message: string, public readonly status?: number) {
+    super(message);
+    this.name = "PortalNotifyError";
+  }
+}
+
+/** 設定不足 / 不整合（origin / token 未設定など）。即停止すべき。 */
+export class PortalNotifyConfigError extends PortalNotifyError {
+  constructor(message: string) {
+    super(message);
+    this.name = "PortalNotifyConfigError";
+  }
+}
+
+/** 401 Unauthorized：token が portal で受理されない。retry しない。 */
+export class PortalAuthError extends PortalNotifyError {
+  constructor(message = "portal rejected notification token (401)") {
+    super(message, 401);
+    this.name = "PortalAuthError";
+  }
+}
+
+/** 400 Bad Request：仕様違反のリクエスト。retry しない。 */
+export class PortalValidationError extends PortalNotifyError {
+  /** portal が返す `missingMemberIds` 等の補助情報。caller が診断に使う。 */
+  constructor(message: string, public readonly details?: Record<string, unknown>) {
+    super(message, 400);
+    this.name = "PortalValidationError";
+  }
+}
+
+/** 502 Bad Gateway：全件 failed。retry 後も失敗した最終状態。 */
+export class PortalDeliveryError extends PortalNotifyError {
+  constructor(
+    message: string,
+    public readonly results: NotifyDeliveryResult[],
+  ) {
+    super(message, 502);
+    this.name = "PortalDeliveryError";
+  }
+}
+
+/** 想定外の 5xx / network error が retry を尽くしても続いた場合。 */
+export class PortalUnavailableError extends PortalNotifyError {
+  constructor(message: string, status?: number) {
+    super(message, status);
+    this.name = "PortalUnavailableError";
+  }
+}

--- a/packages/portal-notify-tool/src/types.ts
+++ b/packages/portal-notify-tool/src/types.ts
@@ -12,10 +12,10 @@
  * 任意の string ではなく明示的な union で受ける。
  */
 export type NotifyKind =
-  | "task_completed"      // 能動型 AI のタスク完了
-  | "reaction_received"   // 反響着信
-  | "followup_due"        // 追客リマインド
-  | "system";             // 運用通知（プラン変更・障害告知など）
+  | "task_completed" // 能動型 AI のタスク完了
+  | "reaction_received" // 反響着信
+  | "followup_due" // 追客リマインド
+  | "system"; // 運用通知（プラン変更・障害告知など）
 
 /**
  * portal `POST /api/notifications/send` のリクエスト body。
@@ -74,7 +74,10 @@ export type NotifySendOutcome =
 // ─────────────────────────────────────────────────────
 
 export class PortalNotifyError extends Error {
-  constructor(message: string, public readonly status?: number) {
+  constructor(
+    message: string,
+    public readonly status?: number,
+  ) {
     super(message);
     this.name = "PortalNotifyError";
   }
@@ -99,7 +102,10 @@ export class PortalAuthError extends PortalNotifyError {
 /** 400 Bad Request：仕様違反のリクエスト。retry しない。 */
 export class PortalValidationError extends PortalNotifyError {
   /** portal が返す `missingMemberIds` 等の補助情報。caller が診断に使う。 */
-  constructor(message: string, public readonly details?: Record<string, unknown>) {
+  constructor(
+    message: string,
+    public readonly details?: Record<string, unknown>,
+  ) {
     super(message, 400);
     this.name = "PortalValidationError";
   }

--- a/packages/portal-notify-tool/tsconfig.json
+++ b/packages/portal-notify-tool/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./portal-notify-tool",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
+}


### PR DESCRIPTION
## Summary

PR-4：エージェントから easy.flow portal の `POST /api/notifications/send` を呼び出す
OpenClaw プラグインを新規パッケージ `@openclaw/portal-notify-tool` として追加。

これによりテナント別 AI エージェントが**タスク完了 / 反響着信 / 追客リマインド** 等を
社員に LINE / メールで配信できるようになる。portal 側の受け口は PR-14/15/16 で完成済み。

## What this implements

### 配置
新規 package `packages/portal-notify-tool/`（既存の `model-router` / `workflow-controller` と同じ
OpenClaw plugin コンベンション。ESM / TypeScript strict / Vitest 3 / Biome lint）。

### 公開 API

**1. OpenClaw plugin（推奨）** — `register(api)` で `notify_send` ツールを LLM に露出

```jsonc
{
  "plugins": {
    "portal-notify-tool": {
      "origin": "https://easy-flow-real-estate-portal.fly.dev",
      "notificationToken": "<subscriptions.notification_token>"
    }
  }
}
```

**2. 純クライアント** — `@openclaw/portal-notify-tool/client` から直接 import

```typescript
import { createPortalNotifyClient } from "@openclaw/portal-notify-tool/client";

const client = createPortalNotifyClient({
  origin: process.env.PORTAL_ORIGIN!,
  notificationToken: process.env.PORTAL_NOTIFICATION_TOKEN!,
});
const result = await client.send({
  kind: "task_completed",
  body: "...",
  idempotencyKey: "task-abc-123",
});
```

### モジュール構成

| ファイル | 行数 | 役割 |
|---|---|---|
| `src/types.ts` | 125 | NotifyKind / Input / Outcome / Error 階層 (Auth / Validation / Delivery / Unavailable) |
| `src/config.ts` | 198 | `resolveConfig`: pluginConfig > env > default の 3 段優先解決 |
| `src/retry.ts` | 62 | sleep DI 型の指数バックオフ + jitter (±25%) |
| `src/client.ts` | 264 | fetch 経由で portal 呼び出し、status を NotifySendOutcome に正規化 |
| `src/tool.ts` | 240 | OpenClaw `AgentToolLike` ファクトリ、LLM 向け text 整形 |
| `src/index.ts` | 124 | plugin entry + 公開 API 再 export |

### 設定

優先順 **`pluginConfig` > 環境変数 > `DEFAULT_PORTAL_NOTIFY_CONFIG`**。
すべての閾値は `DEFAULT_PORTAL_NOTIFY_CONFIG` に集約しハードコーディング禁止。

| pluginConfig キー | 環境変数 | 既定値 |
|---|---|---|
| `origin` | `PORTAL_ORIGIN` | （必須） |
| `notificationToken` | `PORTAL_NOTIFICATION_TOKEN` | （必須） |
| `timeoutMs` | `PORTAL_NOTIFY_TIMEOUT_MS` | 5000 |
| `retryFailedDelaysMs` | `PORTAL_NOTIFY_RETRY_FAILED_MS` | `[10000, 30000, 90000]` |
| `retryPendingDelayMs` | `PORTAL_NOTIFY_RETRY_PENDING_MS` | 30000 |
| `retryPendingMaxAttempts` | `PORTAL_NOTIFY_RETRY_PENDING_MAX` | 1 |

### エラー / リトライ規則（portal 側コントラクトと同期）

| portal 戻り値 | クライアント挙動 |
|---|---|
| 200 sent | 成功終了 |
| 200 pending | `retryPendingDelayMs` 後に同 idempotencyKey で再送（最大 attempts まで） |
| 400 | `PortalValidationError` (details 付き)、retry しない |
| 401 | `PortalAuthError`、retry しない（token rotation 必要） |
| 404 | `ok: false reason: no_active_member` |
| 410 | `ok: false reason: subscription_gone`、retry しない |
| 502 / 5xx / network | `retryFailedDelaysMs` で指数バックオフ + jitter |

### TDD で開発（細かい粒度のコミット）

Red → Green サイクルで 12 コミット。各テストファイルを実装より先に書いて仕様を固定。

- `config.test.ts` — 19 ケース（必須 / 優先順 / 配列パース / 数値パース / DEFAULT 妥当性）
- `retry.test.ts` — 8 ケース（成功 / 全失敗 / 途中成功 / 空 delays / fn throw / jitter 範囲）
- `client.test.ts` — 14 ケース（200 / pending / 4xx / 5xx / network / Abort / Authorization 検証）
- `tool.test.ts` — 15 ケース（schema / 入力 validation / outcome → text 整形 / Error 整形）
- `index.test.ts` — 6 ケース（plugin metadata / 設定不足で warn / sandbox / env-only / ConfigError は warn）

**合計 62 テスト全件 pass、Biome lint 0 errors、tsc build 成功。**

## How agents will use it

LLM は以下の JSON schema で `notify_send` を見て、必要時に呼ぶ：

```jsonc
{
  "tool": "notify_send",
  "args": {
    "kind": "task_completed" | "reaction_received" | "followup_due" | "system",
    "body": "...",
    "subject": "...",
    "memberIds": ["uuid", ...],
    "idempotencyKey": "..."
  }
}
```

ワークフロー側で「step 完了 → notify_send 呼び出し」を identity.md / workflows.md に明示するか、
`workflow-controller` のフロー定義で step.tool に紐づける。

## Out of scope（後続 PR）

- ❌ 既存ワークフロー (sns / 集客 / 反響受付 etc) への notify_send 呼び出し追加
- ❌ tenant インスタンスへの環境変数投入 (`flyctl secrets set PORTAL_NOTIFICATION_TOKEN=...`)
- ❌ portal `subscriptions.notification_token` を取得する運用 UI（PR-15 で完了済み）

## Related PRs (portal 側)

- estack-inc/easy-flow-real-estate-portal#14 — LINE 通知基盤
- estack-inc/easy-flow-real-estate-portal#15 — self-service UI + agent 通知中継 endpoint
- estack-inc/easy-flow-real-estate-portal#16 — 統合テスト 37 件 + production fix 2 件

## Test plan
- [x] `npm test` (62 件 pass)
- [x] `npm run lint` (0 errors)
- [x] `npm run build -w packages/portal-notify-tool` (tsc 成功)
- [ ] CI（GitHub Actions の lint / test / build ジョブ）
- [ ] Codex review