### PR TITLE
codex-review の merge 可能時 Slack 通知を追加

### DIFF
--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -23,7 +23,7 @@
 #   REPO_ACCESS_TOKEN          — PR 作成者と別 identity の bot 用 PAT（PR 書き込み権限）
 #   CODEX_REVIEW_WEBHOOK_URL   — codex-connector 付き reviewer bridge のエンドポイント
 #   CODEX_REVIEW_WEBHOOK_TOKEN — reviewer bridge の Bearer token
-#   SLACK_WEBHOOK_URL          — 任意。失敗時 Slack 通知
+#   SLACK_WEBHOOK_URL          — 任意。失敗時、および Codex Review が APPROVED を提出後 5 分以内に PR の mergeStateStatus が CLEAN または HAS_HOOKS になった場合の Slack 通知
 
 name: Codex Code Review
 
@@ -48,7 +48,7 @@ permissions:
 jobs:
   review:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 25
     # 旧実装では job レベル `if` で draft / fork の PR を丸ごと skip していたが、
     # skip された PR でも過去 run の bot APPROVED が残ると、最新 head を見ていないのに
     # approval だけ残る stale 状態になる。job は必ず起動し、各 step 内で適用可否を判定する。
@@ -407,6 +407,7 @@ jobs:
           fi
 
       - name: Submit review verdict
+        id: submit_verdict
         # `!cancelled()` を付けることで、Post review comment が何らかの原因（例: sed の構文エラー、
         # GitHub API の一時障害）で failure になっても verdict 提出はスキップされず実行される。
         # これがないと Post 失敗 → Submit skip → 前回 run の APPROVED が残留という fail-closed の
@@ -451,10 +452,12 @@ jobs:
             CHANGES_REQUESTED)
               gh pr review "$PR_NUM" --repo "$REPO" --request-changes \
                 --body "$MARKER"$'\n'"🤖 AI レビュー判定: CHANGES_REQUESTED — 詳細はレビューコメントを確認してください。"
+              echo "submitted_verdict=CHANGES_REQUESTED" >> "$GITHUB_OUTPUT"
               ;;
             APPROVED)
               gh pr review "$PR_NUM" --repo "$REPO" --approve \
                 --body "$MARKER"$'\n'"🤖 AI レビュー判定: APPROVED ✅"
+              echo "submitted_verdict=APPROVED" >> "$GITHUB_OUTPUT"
               ;;
             *)
               # 判定不能は fail-closed 方針に合わせて --request-changes でマージをブロックする。
@@ -462,8 +465,75 @@ jobs:
               # 経路が開くため使わない。
               gh pr review "$PR_NUM" --repo "$REPO" --request-changes \
                 --body "$MARKER"$'\n'"🤖 AI レビュー判定: **判定不能** — VERDICT マーカーが 0 件・2 件以上・矛盾のいずれかのため fail-closed で CHANGES_REQUESTED に倒しました。Codex 応答を確認の上、manual レビューを依頼してください。"
+              echo "submitted_verdict=CHANGES_REQUESTED" >> "$GITHUB_OUTPUT"
               ;;
           esac
+
+      - name: マージ可能時 Slack 通知
+        if: steps.submit_verdict.outputs.submitted_verdict == 'APPROVED'
+        env:
+          GH_TOKEN: ${{ secrets.REPO_ACCESS_TOKEN }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          REPO: ${{ github.repository }}
+          PR_NUM: ${{ github.event.pull_request.number }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          if [ -z "$SLACK_WEBHOOK_URL" ]; then
+            echo "SLACK_WEBHOOK_URL が未設定です — マージ可能通知をスキップします"
+            exit 0
+          fi
+
+          # reviewDecision / mergeStateStatus は gh pr review 直後に反映が遅れることがあるため、
+          # 最大 5 分だけ待つ。マージ可能ではない状態では通知しない。
+          # CHANGES_REQUESTED は直前の APPROVED 提出直後に一時的に残ることがあるため、
+          # 即時 exit せず continue して反映を待つ。
+          API_FAIL_COUNT=0
+          for ATTEMPT in $(seq 1 20); do
+            set +e
+            PR_JSON=$(gh pr view "$PR_NUM" --repo "$REPO" --json headRefOid,mergeStateStatus,reviewDecision,isDraft,url,title 2>/tmp/pr-view-error.log)
+            PR_VIEW_RC=$?
+            set -e
+            if [ $PR_VIEW_RC -ne 0 ]; then
+              API_FAIL_COUNT=$((API_FAIL_COUNT + 1))
+              echo "::warning::gh pr view 失敗 (attempt=$ATTEMPT, rc=$PR_VIEW_RC): $(cat /tmp/pr-view-error.log)"
+              sleep 15
+              continue
+            fi
+
+            CURRENT_HEAD=$(printf '%s' "$PR_JSON" | jq -r '.headRefOid // ""')
+            MERGE_STATE=$(printf '%s' "$PR_JSON" | jq -r '.mergeStateStatus // "UNKNOWN"')
+            REVIEW_DECISION=$(printf '%s' "$PR_JSON" | jq -r '.reviewDecision // "UNKNOWN"')
+            IS_DRAFT=$(printf '%s' "$PR_JSON" | jq -r '.isDraft // false')
+            PR_URL=$(printf '%s' "$PR_JSON" | jq -r '.url')
+            PR_TITLE=$(printf '%s' "$PR_JSON" | jq -r '.title // "PR"')
+
+            if [ "$CURRENT_HEAD" != "$PR_HEAD_SHA" ]; then
+              echo "::notice::head SHA drift (event=$PR_HEAD_SHA, current=$CURRENT_HEAD) — マージ可能通知スキップ"
+              exit 0
+            fi
+            if [ "$IS_DRAFT" = "true" ]; then
+              echo "::notice::PR がドラフト状態のためマージ可能通知スキップ"
+              exit 0
+            fi
+            if [ "$REVIEW_DECISION" = "APPROVED" ] && { [ "$MERGE_STATE" = "CLEAN" ] || [ "$MERGE_STATE" = "HAS_HOOKS" ]; }; then
+              TEXT="Codex Review 完了: ${REPO}#${PR_NUM} がマージ可能です (${MERGE_STATE}/${REVIEW_DECISION}) — <${PR_URL}|${PR_TITLE}> / <https://github.com/${REPO}/actions/runs/${RUN_ID}|Actions>"
+              curl -sS -X POST "$SLACK_WEBHOOK_URL" \
+                -H 'Content-Type: application/json' \
+                --data "$(jq -n --arg t "$TEXT" '{text:$t}')" \
+                || echo "::warning::Slack 通知失敗（best-effort なので無視して継続）"
+              exit 0
+            fi
+
+            echo "::notice::PR はまだマージ可能ではありません (attempt=$ATTEMPT, mergeStateStatus=$MERGE_STATE, reviewDecision=$REVIEW_DECISION)"
+            sleep 15
+          done
+
+          if [ "$API_FAIL_COUNT" -eq 20 ]; then
+            echo "::warning::gh pr view が 20 回連続で失敗しました — GitHub API 障害の可能性があります。マージ可能通知は送信できませんでした。"
+            exit 0
+          fi
+          echo "::notice::APPROVED 判定を提出しましたが、通知待機窓内に PR がマージ可能になりませんでした — Slack 通知スキップ"
 
       - name: Slack notification on failure
         if: >-


### PR DESCRIPTION
## 概要

- easy-flow PR #381 で追加した codex-review の merge 可能時 Slack 通知を本リポジトリにも展開します。
- `Submit review verdict` に `submitted_verdict` output を追加し、`APPROVED` を実際に提出できた場合だけ後続通知を走らせます。
- `reviewDecision=APPROVED` かつ `mergeStateStatus=CLEAN` または `HAS_HOOKS` になった場合のみ Slack 通知します。
- `CHANGES_REQUESTED` と判定不能時の fail-closed `CHANGES_REQUESTED` では通知しません。
- 最大 5 分の merge 可能状態待機を追加するため、job timeout を 20 分から 25 分へ延長します。

## 検証

- `ruby -e 'require "yaml"; YAML.load_file(...)'`
- `git diff --check`
- `actionlint -shellcheck= .github/workflows/codex-review.yml`

補足: shellcheck 付きの `actionlint` は既存 workflow の `Determine review applicability` 由来の warning があるため、今回は GitHub Actions 構文確認として `-shellcheck=` で検証しています。