### PR TITLE
file-serve の hook 登録を OpenClaw 2026.5.12 に対応

### DIFF
--- a/packages/file-serve/src/index.ts
+++ b/packages/file-serve/src/index.ts
@@ -16,7 +16,11 @@ type PluginApi = {
   /** OpenClaw がホスト設定（publicUrl 等）を公開する場合に利用 */
   config?: Record<string, unknown>;
   logger: PluginLogger;
-  registerHook: (event: string, handler: unknown) => void;
+  registerHook: (
+    event: string,
+    handler: unknown,
+    opts?: { name?: string; description?: string },
+  ) => void;
   registerHttpRoute: (opts: {
     path: string;
     match: string;
@@ -45,8 +49,9 @@ const fileServePlugin = {
 
     // 2. before_tool_call フック
     const beforeToolCallHook = createBeforeToolCallHook(config, api.logger);
-    Object.defineProperty(beforeToolCallHook, "name", { value: "file-serve:before_tool_call" });
-    api.registerHook("before_tool_call", beforeToolCallHook);
+    api.registerHook("before_tool_call", beforeToolCallHook, {
+      name: "file-serve:before_tool_call",
+    });
 
     // 3. クリーンアップサービス
     api.registerService(createCleanupService(config, api.logger));

--- a/packages/file-serve/test/index.test.ts
+++ b/packages/file-serve/test/index.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it, vi } from "vitest";
+
+import fileServePlugin from "../src/index.js";
+
+const mockLogger = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+};
+
+describe("fileServePlugin", () => {
+  it("before_tool_call hook を名前付きで登録する", () => {
+    const api = {
+      pluginConfig: { baseUrl: "https://example.fly.dev" },
+      logger: mockLogger,
+      registerHttpRoute: vi.fn(),
+      registerHook: vi.fn(),
+      registerService: vi.fn(),
+    };
+
+    fileServePlugin.register(api);
+
+    expect(api.registerHook).toHaveBeenCalledWith("before_tool_call", expect.any(Function), {
+      name: "file-serve:before_tool_call",
+    });
+  });
+});


### PR DESCRIPTION
## 概要
- OpenClaw 2026.5.12 で必須になった hook 登録名を file-serve から明示して渡すように修正
- before_tool_call hook の登録引数を固定するテストを追加

## 背景
通常適用中の central-hd-osada-agent で `hook registration missing name` が発生し、file-serve プラグイン登録に失敗していたため。

## 検証
- `npm test -w packages/file-serve`
- `npm run build -w packages/file-serve`
- `npx biome check packages/file-serve`
