### PR TITLE
feat(cost-guard-hello): Phase 0 実証用 observe-only plugin を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ dist/
 pinecone-memory/
 packages/model-router/model-router/
 packages/portal-notify-tool/portal-notify-tool/
+packages/cost-guard-hello/cost-guard-hello/
 build/
 !packages/easyflow-cli/test/fixtures/build/
 *.js.map

--- a/package-lock.json
+++ b/package-lock.json
@@ -1702,6 +1702,10 @@
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "license": "MIT"
     },
+    "node_modules/cost-guard-hello": {
+      "resolved": "packages/cost-guard-hello",
+      "link": true
+    },
     "node_modules/crc-32": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
@@ -3615,6 +3619,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/cost-guard-hello": {
+      "version": "0.1.0",
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      },
+      "peerDependencies": {
+        "openclaw": ">=2026.5.12"
+      },
+      "peerDependenciesMeta": {
+        "openclaw": {
+          "optional": true
+        }
       }
     },
     "packages/easyflow-cli": {

--- a/packages/cost-guard-hello/README.md
+++ b/packages/cost-guard-hello/README.md
@@ -50,7 +50,7 @@ openclaw plugins inspect cost-guard-hello --runtime --json
 | キー | 型 | デフォルト | 説明 |
 |---|---|---|---|
 | `logging` | boolean | `true` | hook 発火時に observation log を出力する |
-| `verbose` | boolean | `false` | tool params の冒頭 200 byte も log に含める（transcript 本体・プロンプト全文は吐かない）|
+| `verbose` | boolean | `false` | tool params の概略を最大 200 byte まで log に含める（transcript 本体・プロンプト全文は吐かない）|
 
 ## 観測 log の形式
 

--- a/packages/cost-guard-hello/README.md
+++ b/packages/cost-guard-hello/README.md
@@ -1,0 +1,76 @@
+# cost-guard-hello
+
+OpenClaw 2026.5.12 向け **Phase 0 実証用** observe-only plugin。
+
+`before_tool_call` / `tool_result_persist` / `before_agent_run` の発火を `api.logger.info` で記録するだけで、block / rewrite / outcome 変更は一切しない。Phase 0 の以下の検証で土台として使う：
+
+| 実証 | 観測対象 |
+|---|---|
+| 実証 A: lossless-claw 実装方式の特定 | bundled plugin との hook 評価順序を log で実測 |
+| 実証 C: before_agent_run block → Slack 配信 | （後続 PR で block 戻り値に切替）|
+
+詳細：[easy-flow リポジトリの transcript-cost-prevention-phase0.md](https://github.com/estack-inc/easy-flow/blob/main/docs/operations/transcript-cost-prevention-phase0.md)
+
+## install（dev-and-test-agent 限定）
+
+```bash
+# ローカル開発：このディレクトリで build
+npm install
+npm run build
+
+# dev-and-test-agent に link install（PR マージ後に npm 公開も可）
+openclaw plugins install --link ./packages/cost-guard-hello
+
+# 確認
+openclaw plugins list
+openclaw plugins inspect cost-guard-hello --runtime --json
+```
+
+## 設定（openclaw.json）
+
+```json
+{
+  "plugins": {
+    "cost-guard-hello": {
+      "enabled": true,
+      "allowConversationAccess": true,
+      "config": {
+        "logging": true,
+        "verbose": false
+      }
+    }
+  }
+}
+```
+
+`before_agent_run` を外部 plugin から使うため `allowConversationAccess: true` が必須（公式ドキュメント [/plugins/hooks](https://docs.openclaw.ai/plugins/hooks)）。
+
+## 設定項目
+
+| キー | 型 | デフォルト | 説明 |
+|---|---|---|---|
+| `logging` | boolean | `true` | hook 発火時に observation log を出力する |
+| `verbose` | boolean | `false` | tool params の冒頭 200 byte も log に含める（transcript 本体・プロンプト全文は吐かない）|
+
+## 観測 log の形式
+
+```
+[cost-guard-hello] registered (logging=true, verbose=false)
+[cost-guard-hello] before_tool_call: tool=read
+[cost-guard-hello] tool_result_persist: tool=read call_id=tcid_xxx synthetic=false
+[cost-guard-hello] before_agent_run: prompt_len=1234 messages=8 account=Uxxx channel=Cxxx owner=true
+```
+
+## 注意事項
+
+- **observe-only**：本 plugin は出力を観察するだけで cost 削減効果はない
+- **本番禁止**：Phase 0 検証用。dev-and-test-agent 以外には install しない
+- **Phase 1 で置換**：Phase 0 完了後、本格的な `cost-guard` plugin（block / rewrite 機能あり）に置き換える前提
+
+## 削除（Phase 0 完了後）
+
+```bash
+openclaw plugins uninstall cost-guard-hello
+```
+
+そして本ディレクトリも削除する（PR ベースで）。

--- a/packages/cost-guard-hello/openclaw.plugin.json
+++ b/packages/cost-guard-hello/openclaw.plugin.json
@@ -1,0 +1,22 @@
+{
+  "id": "cost-guard-hello",
+  "kind": "plugin",
+  "name": "Cost Guard Hello",
+  "description": "Phase 0 実証用 observe-only plugin。before_tool_call / tool_result_persist / before_agent_run の発火を log するのみ。block / rewrite はしない。本格的な cost-guard plugin の deployment / hook order / lossless-claw との競合を Phase 0 で検証するための土台。",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "logging": {
+        "type": "boolean",
+        "default": true,
+        "description": "hook 発火時に api.logger.info で観測情報を出力するか"
+      },
+      "verbose": {
+        "type": "boolean",
+        "default": false,
+        "description": "tool params の概略（先頭 200 文字）も log に含める"
+      }
+    }
+  }
+}

--- a/packages/cost-guard-hello/openclaw.plugin.json
+++ b/packages/cost-guard-hello/openclaw.plugin.json
@@ -15,7 +15,7 @@
       "verbose": {
         "type": "boolean",
         "default": false,
-        "description": "tool params の概略（先頭 200 文字）も log に含める"
+        "description": "tool params の概略（最大 200 byte）も log に含める"
       }
     }
   }

--- a/packages/cost-guard-hello/package.json
+++ b/packages/cost-guard-hello/package.json
@@ -13,7 +13,7 @@
   "main": "./cost-guard-hello/index.js",
   "types": "./cost-guard-hello/index.d.ts",
   "openclaw": {
-    "extensions": ["./src/index.ts"]
+    "extensions": ["./cost-guard-hello/index.js"]
   },
   "files": [
     "cost-guard-hello",

--- a/packages/cost-guard-hello/package.json
+++ b/packages/cost-guard-hello/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "cost-guard-hello",
+  "version": "0.1.0",
+  "description": "Phase 0 実証用 observe-only plugin（before_tool_call / tool_result_persist / before_agent_run を log するのみ。block / rewrite しない）",
+  "type": "module",
+  "exports": {
+    ".": {
+      "import": "./cost-guard-hello/index.js",
+      "types": "./cost-guard-hello/index.d.ts",
+      "default": "./cost-guard-hello/index.js"
+    }
+  },
+  "main": "./cost-guard-hello/index.js",
+  "types": "./cost-guard-hello/index.d.ts",
+  "openclaw": {
+    "extensions": ["./src/index.ts"]
+  },
+  "files": [
+    "cost-guard-hello",
+    "openclaw.plugin.json"
+  ],
+  "scripts": {
+    "build": "tsc && cp openclaw.plugin.json cost-guard-hello/openclaw.plugin.json",
+    "test": "vitest run"
+  },
+  "peerDependencies": {
+    "openclaw": ">=2026.5.12"
+  },
+  "peerDependenciesMeta": {
+    "openclaw": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.0.0",
+    "vitest": "^3.0.0"
+  }
+}

--- a/packages/cost-guard-hello/src/index.test.ts
+++ b/packages/cost-guard-hello/src/index.test.ts
@@ -136,9 +136,7 @@ describe("before_tool_call handler", () => {
 describe("npm package metadata", () => {
   it("npm pack に OpenClaw extension の参照先ファイルを含める", () => {
     const packageDir = resolve(dirname(fileURLToPath(import.meta.url)), "..");
-    const packageJson = JSON.parse(
-      readFileSync(resolve(packageDir, "package.json"), "utf8"),
-    ) as {
+    const packageJson = JSON.parse(readFileSync(resolve(packageDir, "package.json"), "utf8")) as {
       openclaw: { extensions: string[] };
     };
     execFileSync("npm", ["run", "build"], { cwd: packageDir, stdio: "pipe" });

--- a/packages/cost-guard-hello/src/index.test.ts
+++ b/packages/cost-guard-hello/src/index.test.ts
@@ -1,0 +1,163 @@
+/**
+ * cost-guard-hello の register / hook handler の単体テスト
+ *
+ * 検証点：
+ * - register(api) で 3 つの hook が登録される
+ * - logging=false のとき log が出ない
+ * - block / rewrite / outcome を変更しない（observe-only 性質）
+ * - safePreview が長文を切り詰める
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import register from "./index.js";
+
+type HookHandler = (event: unknown, ctx: unknown) => unknown;
+
+interface MockApi {
+  pluginConfig: Record<string, unknown>;
+  logger: {
+    info: ReturnType<typeof vi.fn>;
+    debug: ReturnType<typeof vi.fn>;
+    warn: ReturnType<typeof vi.fn>;
+    error: ReturnType<typeof vi.fn>;
+  };
+  on: ReturnType<typeof vi.fn>;
+  hooks: Map<string, HookHandler>;
+}
+
+function makeApi(config: Record<string, unknown> = {}): MockApi {
+  const hooks = new Map<string, HookHandler>();
+  return {
+    pluginConfig: config,
+    logger: { info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    on: vi.fn((event: string, handler: HookHandler) => {
+      hooks.set(event, handler);
+    }),
+    hooks,
+  };
+}
+
+describe("cost-guard-hello register", () => {
+  it("3 つの hook（before_tool_call / tool_result_persist / before_agent_run）を登録する", () => {
+    const api = makeApi();
+    register(api as any);
+    expect(api.hooks.has("before_tool_call")).toBe(true);
+    expect(api.hooks.has("tool_result_persist")).toBe(true);
+    expect(api.hooks.has("before_agent_run")).toBe(true);
+  });
+
+  it("起動時に register log を出力する", () => {
+    const api = makeApi();
+    register(api as any);
+    expect(api.logger.info).toHaveBeenCalledWith(
+      expect.stringContaining("[cost-guard-hello] registered"),
+    );
+  });
+});
+
+describe("before_tool_call handler", () => {
+  it("空オブジェクトを返して block しない", () => {
+    const api = makeApi();
+    register(api as any);
+    const handler = api.hooks.get("before_tool_call");
+    expect(handler).toBeDefined();
+    const result = handler!({ toolName: "read", params: { path: "/data/workspace/x.txt" } }, {});
+    expect(result).toEqual({});
+  });
+
+  it("logging=true のときに log を出す", () => {
+    const api = makeApi({ logging: true });
+    register(api as any);
+    const handler = api.hooks.get("before_tool_call");
+    api.logger.info.mockClear();
+    handler!({ toolName: "read", params: { path: "/data/x.txt" } }, {});
+    expect(api.logger.info).toHaveBeenCalledWith(
+      expect.stringContaining("before_tool_call: tool=read"),
+    );
+  });
+
+  it("logging=false のときは log を出さない", () => {
+    const api = makeApi({ logging: false });
+    register(api as any);
+    const handler = api.hooks.get("before_tool_call");
+    api.logger.info.mockClear();
+    handler!({ toolName: "read", params: {} }, {});
+    expect(api.logger.info).not.toHaveBeenCalled();
+  });
+
+  it("verbose=true のときに params の冒頭を log に含める", () => {
+    const api = makeApi({ verbose: true });
+    register(api as any);
+    const handler = api.hooks.get("before_tool_call");
+    api.logger.info.mockClear();
+    handler!({ toolName: "read", params: { path: "/data/workspace/x.txt" } }, {});
+    expect(api.logger.info).toHaveBeenCalledWith(expect.stringContaining('params_head="'));
+  });
+
+  it("verbose=true で巨大な params は 200 byte で切り詰める", () => {
+    const api = makeApi({ verbose: true });
+    register(api as any);
+    const handler = api.hooks.get("before_tool_call");
+    api.logger.info.mockClear();
+    const hugeParams = { content: "x".repeat(1000) };
+    handler!({ toolName: "write", params: hugeParams }, {});
+    const call = api.logger.info.mock.calls[0][0] as string;
+    // params_head="..." の中身は 200 文字 + "..." で切れている
+    expect(call).toMatch(/params_head=".{200,}\.\.\."/);
+  });
+});
+
+describe("tool_result_persist handler", () => {
+  it("空オブジェクトを返して rewrite しない", () => {
+    const api = makeApi();
+    register(api as any);
+    const handler = api.hooks.get("tool_result_persist");
+    const result = handler!({ toolName: "read", toolCallId: "tcid_1", isSynthetic: false }, {});
+    expect(result).toEqual({});
+  });
+
+  it("logging=true で log を出力する", () => {
+    const api = makeApi({ logging: true });
+    register(api as any);
+    const handler = api.hooks.get("tool_result_persist");
+    api.logger.info.mockClear();
+    handler!({ toolName: "read", toolCallId: "tcid_1", isSynthetic: false }, {});
+    expect(api.logger.info).toHaveBeenCalledWith(
+      expect.stringContaining("tool_result_persist: tool=read"),
+    );
+  });
+});
+
+describe("before_agent_run handler", () => {
+  it("常に { outcome: 'pass' } を返す（pure observer）", () => {
+    const api = makeApi();
+    register(api as any);
+    const handler = api.hooks.get("before_agent_run");
+    const result = handler!(
+      { prompt: "hello", messages: [], accountId: "U1", channelId: "C1", senderIsOwner: true },
+      {},
+    );
+    expect(result).toEqual({ outcome: "pass" });
+  });
+
+  it("prompt_len と message count を log に含める", () => {
+    const api = makeApi({ logging: true });
+    register(api as any);
+    const handler = api.hooks.get("before_agent_run");
+    api.logger.info.mockClear();
+    handler!({ prompt: "hello world", messages: [1, 2, 3], accountId: "U1", channelId: "C1" }, {});
+    expect(api.logger.info).toHaveBeenCalledWith(
+      expect.stringContaining("before_agent_run: prompt_len=11 messages=3"),
+    );
+  });
+
+  it("logging=false でも pass は返す（block ではない）", () => {
+    const api = makeApi({ logging: false });
+    register(api as any);
+    const handler = api.hooks.get("before_agent_run");
+    api.logger.info.mockClear();
+    const result = handler!({ prompt: "", messages: [] }, {});
+    expect(result).toEqual({ outcome: "pass" });
+    expect(api.logger.info).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cost-guard-hello/src/index.test.ts
+++ b/packages/cost-guard-hello/src/index.test.ts
@@ -5,9 +5,14 @@
  * - register(api) で 3 つの hook が登録される
  * - logging=false のとき log が出ない
  * - block / rewrite / outcome を変更しない（observe-only 性質）
- * - safePreview が長文を切り詰める
+ * - safePreview が長文を byte 上限で切り詰める
+ * - npm pack 対象に OpenClaw extension が含まれる
  */
 
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { describe, expect, it, vi } from "vitest";
 import register from "./index.js";
 
@@ -35,6 +40,12 @@ function makeApi(config: Record<string, unknown> = {}): MockApi {
     }),
     hooks,
   };
+}
+
+function extractParamsHead(logLine: string): string {
+  const match = logLine.match(/params_head="(.*)"/);
+  expect(match).not.toBeNull();
+  return match![1];
 }
 
 describe("cost-guard-hello register", () => {
@@ -102,8 +113,48 @@ describe("before_tool_call handler", () => {
     const hugeParams = { content: "x".repeat(1000) };
     handler!({ toolName: "write", params: hugeParams }, {});
     const call = api.logger.info.mock.calls[0][0] as string;
-    // params_head="..." の中身は 200 文字 + "..." で切れている
-    expect(call).toMatch(/params_head=".{200,}\.\.\."/);
+    const paramsHead = extractParamsHead(call);
+    expect(Buffer.byteLength(paramsHead, "utf8")).toBeLessThanOrEqual(200);
+    expect(paramsHead.endsWith("...")).toBe(true);
+  });
+
+  it("verbose=true でマルチバイト params も 200 byte 以内に切り詰める", () => {
+    const api = makeApi({ verbose: true });
+    register(api as any);
+    const handler = api.hooks.get("before_tool_call");
+    api.logger.info.mockClear();
+    const multibyteParams = { content: "日本語".repeat(100) };
+    handler!({ toolName: "write", params: multibyteParams }, {});
+    const call = api.logger.info.mock.calls[0][0] as string;
+    const paramsHead = extractParamsHead(call);
+    expect(Buffer.byteLength(paramsHead, "utf8")).toBeLessThanOrEqual(200);
+    expect(paramsHead.endsWith("...")).toBe(true);
+    expect(paramsHead).not.toContain("\uFFFD");
+  });
+});
+
+describe("npm package metadata", () => {
+  it("npm pack に OpenClaw extension の参照先ファイルを含める", () => {
+    const packageDir = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+    const packageJson = JSON.parse(
+      readFileSync(resolve(packageDir, "package.json"), "utf8"),
+    ) as {
+      openclaw: { extensions: string[] };
+    };
+    execFileSync("npm", ["run", "build"], { cwd: packageDir, stdio: "pipe" });
+    const output = execFileSync("npm", ["pack", "--dry-run", "--json"], {
+      cwd: packageDir,
+      encoding: "utf8",
+    });
+    const [pack] = JSON.parse(output) as Array<{
+      files: Array<{ path: string }>;
+    }>;
+    const files = new Set(pack.files.map((file) => file.path));
+
+    expect(files.has("package.json")).toBe(true);
+    for (const extension of packageJson.openclaw.extensions) {
+      expect(files.has(extension.replace(/^\.\//, ""))).toBe(true);
+    }
   });
 });
 

--- a/packages/cost-guard-hello/src/index.ts
+++ b/packages/cost-guard-hello/src/index.ts
@@ -14,11 +14,17 @@
  * 詳細は easy-flow/docs/operations/transcript-cost-prevention-phase0.md 参照。
  */
 
-import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
-
 interface CostGuardHelloConfig {
   logging?: boolean;
   verbose?: boolean;
+}
+
+interface OpenClawPluginApi {
+  pluginConfig?: Record<string, unknown>;
+  logger: {
+    info(message: string): void;
+  };
+  on(event: string, handler: (event: unknown, ctx: unknown) => unknown): void;
 }
 
 const TAG = "[cost-guard-hello]";

--- a/packages/cost-guard-hello/src/index.ts
+++ b/packages/cost-guard-hello/src/index.ts
@@ -9,7 +9,7 @@
  * 動作：
  * - block / rewrite / outcome を変更しない（pure observer）
  * - すべての hook 発火を api.logger.info で記録
- * - verbose=true のとき tool params の冒頭 200 文字を log に含める
+ * - verbose=true のとき tool params の概略を最大 200 byte まで log に含める
  *
  * 詳細は easy-flow/docs/operations/transcript-cost-prevention-phase0.md 参照。
  */
@@ -88,9 +88,9 @@ export default function register(api: OpenClawPluginApi): void {
  * - 失敗時 → "(unserializable)"
  *
  * Phase 0 観測ログ専用。プロンプト本体や transcript 全文を吐かないため
- * VERBOSE_PARAM_HEAD_BYTES（200 byte）で切る。
+ * VERBOSE_PARAM_HEAD_BYTES（最大 200 byte）で切る。
  */
-function safePreview(v: unknown, maxLen: number): string {
+function safePreview(v: unknown, maxBytes: number): string {
   if (v === undefined || v === null) return "(empty)";
   let s: string;
   try {
@@ -99,5 +99,24 @@ function safePreview(v: unknown, maxLen: number): string {
     return "(unserializable)";
   }
   s = s.replace(/\s+/g, " ").trim();
-  return s.length > maxLen ? `${s.slice(0, maxLen)}...` : s;
+  return truncateUtf8(s, maxBytes);
+}
+
+function truncateUtf8(s: string, maxBytes: number): string {
+  if (Buffer.byteLength(s, "utf8") <= maxBytes) return s;
+
+  const suffix = "...";
+  const suffixBytes = Buffer.byteLength(suffix, "utf8");
+  const headLimit = Math.max(0, maxBytes - suffixBytes);
+  let head = "";
+  let headBytes = 0;
+
+  for (const char of s) {
+    const charBytes = Buffer.byteLength(char, "utf8");
+    if (headBytes + charBytes > headLimit) break;
+    head += char;
+    headBytes += charBytes;
+  }
+
+  return `${head}${suffix}`;
 }

--- a/packages/cost-guard-hello/src/index.ts
+++ b/packages/cost-guard-hello/src/index.ts
@@ -1,0 +1,103 @@
+/**
+ * cost-guard-hello: Phase 0 実証用 observe-only plugin
+ *
+ * 目的：
+ * - OpenClaw 2026.5.12 の plugin deployment path を実機で検証
+ * - before_tool_call / tool_result_persist / before_agent_run の発火順序・タイミングを観測
+ * - lossless-claw など bundled plugin との hook 評価順序を実測（Phase 0 実証 A）
+ *
+ * 動作：
+ * - block / rewrite / outcome を変更しない（pure observer）
+ * - すべての hook 発火を api.logger.info で記録
+ * - verbose=true のとき tool params の冒頭 200 文字を log に含める
+ *
+ * 詳細は easy-flow/docs/operations/transcript-cost-prevention-phase0.md 参照。
+ */
+
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+
+interface CostGuardHelloConfig {
+  logging?: boolean;
+  verbose?: boolean;
+}
+
+const TAG = "[cost-guard-hello]";
+const VERBOSE_PARAM_HEAD_BYTES = 200;
+
+export default function register(api: OpenClawPluginApi): void {
+  const cfg = (api.pluginConfig ?? {}) as CostGuardHelloConfig;
+  const logging = cfg.logging ?? true;
+  const verbose = cfg.verbose ?? false;
+  const log = api.logger;
+
+  log.info(`${TAG} registered (logging=${logging}, verbose=${verbose})`);
+
+  // before_tool_call: tool 実行直前。params 検査・block / requireApproval が可能
+  api.on("before_tool_call", (event: unknown, _ctx: unknown) => {
+    if (!logging) return {};
+    const e = event as { toolName?: string; params?: unknown };
+    const toolName = e.toolName ?? "(unknown)";
+    if (verbose) {
+      const paramsPreview = safePreview(e.params, VERBOSE_PARAM_HEAD_BYTES);
+      log.info(`${TAG} before_tool_call: tool=${toolName} params_head="${paramsPreview}"`);
+    } else {
+      log.info(`${TAG} before_tool_call: tool=${toolName}`);
+    }
+    return {}; // block しない
+  });
+
+  // tool_result_persist: tool 結果を AgentMessage として保存する直前
+  // 公式 docs: "run before the final persistence cap" = prompt cache 注入前に走る
+  api.on("tool_result_persist", (event: unknown, _ctx: unknown) => {
+    if (!logging) return {};
+    const e = event as { toolName?: string; toolCallId?: string; isSynthetic?: boolean };
+    log.info(
+      `${TAG} tool_result_persist: tool=${e.toolName ?? "(unknown)"} ` +
+        `call_id=${e.toolCallId ?? "(none)"} synthetic=${e.isSynthetic ?? false}`,
+    );
+    return {}; // rewrite しない（message を返さない）
+  });
+
+  // before_agent_run: agent loop が走る直前。session 単位の breaker 用
+  // 外部 plugin の場合 openclaw.json で allowConversationAccess: true が必要
+  api.on("before_agent_run", (event: unknown, _ctx: unknown) => {
+    if (!logging) return { outcome: "pass" as const };
+    const e = event as {
+      prompt?: string;
+      messages?: unknown[];
+      accountId?: string;
+      channelId?: string;
+      senderIsOwner?: boolean;
+    };
+    const promptLen = typeof e.prompt === "string" ? e.prompt.length : 0;
+    const msgCount = Array.isArray(e.messages) ? e.messages.length : 0;
+    log.info(
+      `${TAG} before_agent_run: prompt_len=${promptLen} messages=${msgCount} ` +
+        `account=${e.accountId ?? "(none)"} channel=${e.channelId ?? "(none)"} ` +
+        `owner=${e.senderIsOwner ?? false}`,
+    );
+    return { outcome: "pass" as const };
+  });
+}
+
+/**
+ * 任意の value を安全に短く文字列化する。
+ * - object/array → JSON.stringify
+ * - string → そのまま
+ * - undefined/null → "(empty)"
+ * - 失敗時 → "(unserializable)"
+ *
+ * Phase 0 観測ログ専用。プロンプト本体や transcript 全文を吐かないため
+ * VERBOSE_PARAM_HEAD_BYTES（200 byte）で切る。
+ */
+function safePreview(v: unknown, maxLen: number): string {
+  if (v === undefined || v === null) return "(empty)";
+  let s: string;
+  try {
+    s = typeof v === "string" ? v : JSON.stringify(v);
+  } catch {
+    return "(unserializable)";
+  }
+  s = s.replace(/\s+/g, " ").trim();
+  return s.length > maxLen ? `${s.slice(0, maxLen)}...` : s;
+}

--- a/packages/cost-guard-hello/tsconfig.json
+++ b/packages/cost-guard-hello/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./cost-guard-hello",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
+}


### PR DESCRIPTION
## 概要

OpenClaw 2026.5.12 向けの **Phase 0 実証用** observe-only plugin を追加します。\`before_tool_call\` / \`tool_result_persist\` / \`before_agent_run\` の発火を \`api.logger.info\` で記録するだけで、block / rewrite / outcome 変更は一切しません。

## 背景

[estack-inc/easy-flow PR #386](https://github.com/estack-inc/easy-flow/pull/386) / [PR #387](https://github.com/estack-inc/easy-flow/pull/387)（Phase 0 計画書）の続編。OpenClaw 2026.5.12 公式ドキュメントで Hard blocker 3/4 が事前解決済みとなり、残る実機検証（実証 A-D）を進めるための **土台 plugin** です。

| 実証 | 観測対象 |
|---|---|
| 実証 A: lossless-claw 実装方式の特定 | bundled plugin との hook 評価順序を log で実測 |
| 実証 C: before_agent_run block → Slack 配信 | 後続 PR で block 戻り値に切替 |

## 変更内容

\`packages/cost-guard-hello/\` 新規追加：

| ファイル | 内容 |
|---|---|
| \`openclaw.plugin.json\` | plugin manifest（id, kind, configSchema）|
| \`package.json\` | workspaces 規約・openclaw.extensions 宣言・peerDeps |
| \`tsconfig.json\` | model-router と同設定（ES2022 / NodeNext / strict）|
| \`src/index.ts\` | 3 hook を api.on() で登録、observe-only |
| \`src/index.test.ts\` | vitest 12 ケース（register / 各 hook の挙動 / verbose 切り詰め）|
| \`README.md\` | install 手順・openclaw.json 設定例・観測 log 形式 |

\`.gitignore\` に \`packages/cost-guard-hello/cost-guard-hello/\`（dist 相当）を追加。

## 検証結果

\`\`\`
$ npm test --workspace cost-guard-hello
Test Files  1 passed (1)
Tests       12 passed (12)
\`\`\`

\`\`\`
$ npm run lint    # biome
Checked 206 files. Found 5 warnings (既存 / cost-guard-hello 起因なし).
\`\`\`

| 項目 | 結果 |
|---|---|
| vitest | ✅ 12/12 pass |
| biome lint | ✅ cost-guard-hello 起因のエラー・警告なし |
| tsc build | ⚠️ \`openclaw/plugin-sdk\` 型解決不可（peerDeps optional のため CI build 対象外、model-router と同じ）|

## 設計上のポイント

- **observe-only**：cost 削減効果は **ない**。Phase 0 検証専用
- **既存 model-router と同構成**：\`openclaw.extensions: ["./src/index.ts"]\` で runtime に tsx で直接ロード、CI build 対象外
- **\`api.on()\` 使用**：\`api.registerHook()\` ではなく推奨 API（priority / merge / block セマンティクス）
- **verbose=false がデフォルト**：tool params を log に吐かない（transcript / プロンプト本体の漏洩防止）

## install / 使い方

dev-and-test-agent 限定：

\`\`\`bash
# install
openclaw plugins install --link ./packages/cost-guard-hello

# 確認
openclaw plugins list
openclaw plugins inspect cost-guard-hello --runtime --json
\`\`\`

openclaw.json の plugin 設定で \`allowConversationAccess: true\` が必要（\`before_agent_run\` を外部 plugin から使うため。詳細は README 参照）。

## 残課題

- [ ] dev-and-test-agent に install して動作確認
- [ ] container restart 後の自動ロード確認
- [ ] lossless-claw など bundled plugin との hook 順序を log で実測（実証 A）
- [ ] Phase 0 完了後に本格 \`cost-guard\` plugin（block / rewrite 機能）へ置き換え、本 plugin は削除

## 関連

- estack-inc/easy-flow PR #386: transcript コスト爆発の構造対策 Phase 0 実証フェーズ設計書
- estack-inc/easy-flow PR #387: Phase 0 進捗 — Hard blocker 3/4 が docs で解決済を反映
- estack-inc/easy-flow Issue #360, #376