### PR TITLE
fix(cost-guard-hello): openclaw.extensions を ./src/index.ts に修正 + README に実機検証で判明した正しい設定パスを反映

### DIFF
--- a/packages/cost-guard-hello/README.md
+++ b/packages/cost-guard-hello/README.md
@@ -31,19 +31,24 @@ openclaw plugins inspect cost-guard-hello --runtime --json
 ```json
 {
   "plugins": {
-    "cost-guard-hello": {
-      "enabled": true,
-      "allowConversationAccess": true,
-      "config": {
-        "logging": true,
-        "verbose": false
+    "allow": ["cost-guard-hello"],
+    "entries": {
+      "cost-guard-hello": {
+        "enabled": true,
+        "hooks": {
+          "allowConversationAccess": true
+        },
+        "config": {
+          "logging": true,
+          "verbose": false
+        }
       }
     }
   }
 }
 ```
 
-`before_agent_run` を外部 plugin から使うため `allowConversationAccess: true` が必須（公式ドキュメント [/plugins/hooks](https://docs.openclaw.ai/plugins/hooks)）。
+`before_agent_run` を外部 plugin から使うため `allowConversationAccess: true` が必須。**正しいパスは `plugins.entries.<id>.hooks.allowConversationAccess`**（`hooks.` を間に挟む）。`plugins.entries.<id>.allowConversationAccess` 直下に書くと `Unrecognized key` で reload に失敗する。2026-05-25 の dev-and-test-agent 実機検証で確定（公式ドキュメント [/plugins/hooks](https://docs.openclaw.ai/plugins/hooks) には明記されていない）。
 
 ## 設定項目
 

--- a/packages/cost-guard-hello/package.json
+++ b/packages/cost-guard-hello/package.json
@@ -13,10 +13,11 @@
   "main": "./cost-guard-hello/index.js",
   "types": "./cost-guard-hello/index.d.ts",
   "openclaw": {
-    "extensions": ["./cost-guard-hello/index.js"]
+    "extensions": ["./src/index.ts"]
   },
   "files": [
     "cost-guard-hello",
+    "src",
     "openclaw.plugin.json"
   ],
   "scripts": {


### PR DESCRIPTION
## 概要

PR #166 で自動修正によって \`openclaw.extensions\` がビルド成果物パス（\`./cost-guard-hello/index.js\`）に変更されていたが、本番運用ではビルド成果物を実機に持ち込まず \`src/index.ts\` を jiti で直読み込みするため、**既存 model-router と同パターン**（\`./src/index.ts\`）に揃えます。

合わせて、2026-05-25 の dev-and-test-agent 実機検証で判明した **`hooks.allowConversationAccess` の正しい設定パス**を README に反映します。

## 背景

2026-05-25 に dev-and-test-agent で cost-guard-hello を実機運用したところ、以下の問題が判明：

1. **\`openclaw.extensions\` がビルド成果物パス**を指していた → 実機に dist がないため手動 patch が必要だった
2. **\`hooks.allowConversationAccess\` の正しいパスが docs に明記されていない**：
   - \`plugins.entries.<id>.allowConversationAccess\` ❌（\`Unrecognized key\` で hot reload 失敗）
   - \`plugins.entries.<id>.hooks.allowConversationAccess\` ✅（\`hooks.\` を間に挟む）

## 変更内容

### package.json

\`\`\`diff
   "openclaw": {
-    "extensions": ["./cost-guard-hello/index.js"]
+    "extensions": ["./src/index.ts"]
   },
   "files": [
     "cost-guard-hello",
+    "src",
     "openclaw.plugin.json"
   ],
\`\`\`

- \`extensions\`: ビルド成果物パスから src パスへ（既存 model-router と同パターン）
- \`files\`: src を npm pack に含める（npm pack テスト pass のため）

### README.md

\`openclaw.json\` 設定例を以下の正しいパスに修正：

\`\`\`json
{
  "plugins": {
    "allow": ["cost-guard-hello"],
    "entries": {
      "cost-guard-hello": {
        "enabled": true,
        "hooks": {
          "allowConversationAccess": true
        },
        "config": { ... }
      }
    }
  }
}
\`\`\`

注記：「公式ドキュメントには明記されていない、実機検証で判明したパス」

## 検証結果

\`\`\`
$ npm test --workspace cost-guard-hello
Tests       14 passed (14)（npm pack テスト含む）

$ npm run lint
Checked 206 files. cost-guard-hello 起因のエラー・警告なし
\`\`\`

## 関連

- 元 PR: estack-inc/easy-flow-agent #166 (Phase 0 実証用 observe-only plugin)
- Phase 0 実証 A 結果: estack-inc/easy-flow #389
- Phase 0 計画書: estack-inc/easy-flow #386, #387
- Issue: estack-inc/easy-flow #360, #376