### PR TITLE
feat(cost-guard-hello): blockMode / blockPaths を追加して Phase 0 実証 B-2 を可能に

### DIFF
--- a/packages/cost-guard-hello/README.md
+++ b/packages/cost-guard-hello/README.md
@@ -28,6 +28,8 @@ openclaw plugins inspect cost-guard-hello --runtime --json
 
 ## 設定（openclaw.json）
 
+### observe モード（既定）
+
 ```json
 {
   "plugins": {
@@ -48,6 +50,27 @@ openclaw plugins inspect cost-guard-hello --runtime --json
 }
 ```
 
+### block モード（Phase 0 実証 B-3 以降）
+
+```json
+{
+  "plugins": {
+    "entries": {
+      "cost-guard-hello": {
+        "enabled": true,
+        "hooks": { "allowConversationAccess": true },
+        "config": {
+          "logging": true,
+          "verbose": false,
+          "blockMode": "block",
+          "blockPaths": ["/data/workspace/zoom_transcribe/"]
+        }
+      }
+    }
+  }
+}
+```
+
 `before_agent_run` を外部 plugin から使うため `allowConversationAccess: true` が必須。**正しいパスは `plugins.entries.<id>.hooks.allowConversationAccess`**（`hooks.` を間に挟む）。`plugins.entries.<id>.allowConversationAccess` 直下に書くと `Unrecognized key` で reload に失敗する。2026-05-25 の dev-and-test-agent 実機検証で確定（公式ドキュメント [/plugins/hooks](https://docs.openclaw.ai/plugins/hooks) には明記されていない）。
 
 ## 設定項目
@@ -56,6 +79,16 @@ openclaw plugins inspect cost-guard-hello --runtime --json
 |---|---|---|---|
 | `logging` | boolean | `true` | hook 発火時に observation log を出力する |
 | `verbose` | boolean | `false` | tool params の概略を最大 200 byte まで log に含める（transcript 本体・プロンプト全文は吐かない）|
+| `blockMode` | `"observe"` / `"block"` | `"observe"` | observe=log のみ / block=`blockPaths` にマッチした tool 呼び出しを block する |
+| `blockPaths` | string[] | `[]` | block 対象 path のプレフィックス。tool params 内の文字列フィールド（`path` / `command` / nested array 等）を再帰走査し、canonical 化（`path.resolve` で `../` を解決）した結果と元文字列の両方でマッチを判定 |
+
+### block ロジックの限界（Phase 1 で対処）
+
+- symlink 解決（`realpath`）は実施しない：本 plugin は agent 動作前 hook なので実 FS には触らない
+- inode / device 比較もしない
+- `/proc/self/fd` 経由は元文字列に proc path が含まれている場合のみ捕捉
+- shell injection（`$(...)`, `` `...` `` 経由）は元文字列に path が出ない場合 block 不可
+- これらは Phase 0 実証 B-4 の漏れパターン候補として Phase 1 設計（本格 cost-guard plugin）で対処予定
 
 ## 観測 log の形式
 

--- a/packages/cost-guard-hello/README.md
+++ b/packages/cost-guard-hello/README.md
@@ -80,7 +80,7 @@ openclaw plugins inspect cost-guard-hello --runtime --json
 | `logging` | boolean | `true` | hook 発火時に observation log を出力する |
 | `verbose` | boolean | `false` | tool params の概略を最大 200 byte まで log に含める（transcript 本体・プロンプト全文は吐かない）|
 | `blockMode` | `"observe"` / `"block"` | `"observe"` | observe=log のみ / block=`blockPaths` にマッチした tool 呼び出しを block する |
-| `blockPaths` | string[] | `[]` | block 対象 path のプレフィックス。tool params 内の文字列フィールド（`path` / `command` / nested array 等）を再帰走査し、canonical 化（`path.resolve` で `../` を解決）した結果と元文字列の両方でマッチを判定 |
+| `blockPaths` | string[] | `[]` | block 対象 path のプレフィックス。tool params 内の文字列フィールド（`path` / `command` / nested array 等）を再帰走査し、canonical 化（`path.resolve` で `../` を解決、`cwd` / `workdir` 等があれば相対 path の基準に使用）した結果と元文字列の両方でマッチを判定 |
 
 ### block ロジックの限界（Phase 1 で対処）
 

--- a/packages/cost-guard-hello/openclaw.plugin.json
+++ b/packages/cost-guard-hello/openclaw.plugin.json
@@ -27,7 +27,7 @@
         "type": "array",
         "items": { "type": "string" },
         "default": [],
-        "description": "block 対象 path のプレフィックス文字列。tool params 内のいずれかの文字列フィールドに含まれていたら block する。canonical 化は path.resolve による `../` と相対 path の正規化のみ行う。symlink / realpath 解決は未対応。"
+        "description": "block 対象 path のプレフィックス文字列。tool params 内のいずれかの文字列フィールドに含まれていたら block する。canonical 化は path.resolve による `../` と相対 path の正規化を行い、cwd / workdir 等があれば相対 path の基準に使用する。symlink / realpath 解決は未対応。"
       }
     }
   }

--- a/packages/cost-guard-hello/openclaw.plugin.json
+++ b/packages/cost-guard-hello/openclaw.plugin.json
@@ -27,7 +27,7 @@
         "type": "array",
         "items": { "type": "string" },
         "default": [],
-        "description": "block 対象 path のプレフィックス文字列。tool params 内のいずれかの文字列フィールドに含まれていたら block する。canonical 化（resolve / readlink / 相対 path 展開）も内部で行うため、`../` や symlink 経由でも検出される。"
+        "description": "block 対象 path のプレフィックス文字列。tool params 内のいずれかの文字列フィールドに含まれていたら block する。canonical 化は path.resolve による `../` と相対 path の正規化のみ行う。symlink / realpath 解決は未対応。"
       }
     }
   }

--- a/packages/cost-guard-hello/openclaw.plugin.json
+++ b/packages/cost-guard-hello/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "cost-guard-hello",
   "kind": "plugin",
   "name": "Cost Guard Hello",
-  "description": "Phase 0 実証用 observe-only plugin。before_tool_call / tool_result_persist / before_agent_run の発火を log するのみ。block / rewrite はしない。本格的な cost-guard plugin の deployment / hook order / lossless-claw との競合を Phase 0 で検証するための土台。",
+  "description": "Phase 0 実証用 plugin。before_tool_call / tool_result_persist / before_agent_run の発火を log するほか、blockMode=block かつ blockPaths にマッチした tool 呼び出しを block する。本格的な cost-guard plugin の deployment / hook order / lossless-claw との競合 / path-based deny を Phase 0 で検証するための土台。",
   "configSchema": {
     "type": "object",
     "additionalProperties": false,
@@ -16,6 +16,18 @@
         "type": "boolean",
         "default": false,
         "description": "tool params の概略（最大 200 byte）も log に含める"
+      },
+      "blockMode": {
+        "type": "string",
+        "enum": ["observe", "block"],
+        "default": "observe",
+        "description": "observe=log のみ（block しない） / block=blockPaths にマッチした tool 呼び出しを block する"
+      },
+      "blockPaths": {
+        "type": "array",
+        "items": { "type": "string" },
+        "default": [],
+        "description": "block 対象 path のプレフィックス文字列。tool params 内のいずれかの文字列フィールドに含まれていたら block する。canonical 化（resolve / readlink / 相対 path 展開）も内部で行うため、`../` や symlink 経由でも検出される。"
       }
     }
   }

--- a/packages/cost-guard-hello/src/index.test.ts
+++ b/packages/cost-guard-hello/src/index.test.ts
@@ -261,10 +261,9 @@ describe("findBlockMatch (path block 判定)", () => {
   });
 
   it("command 文字列内の redirection に隣接した absolute path も検出する", () => {
-    const r = findBlockMatch(
-      { command: "cat</data/workspace/zoom_transcribe/transcript.txt" },
-      ["/data/workspace/zoom_transcribe/"],
-    );
+    const r = findBlockMatch({ command: "cat</data/workspace/zoom_transcribe/transcript.txt" }, [
+      "/data/workspace/zoom_transcribe/",
+    ]);
     expect(r).not.toBeNull();
     expect(r?.field).toBe("command");
   });
@@ -288,10 +287,9 @@ describe("findBlockMatch (path block 判定)", () => {
   });
 
   it("cwd 基準の相対 path も canonical 化で検出する", () => {
-    const r = findBlockMatch(
-      { cwd: "/data/workspace", path: "zoom_transcribe/transcript.txt" },
-      ["/data/workspace/zoom_transcribe/"],
-    );
+    const r = findBlockMatch({ cwd: "/data/workspace", path: "zoom_transcribe/transcript.txt" }, [
+      "/data/workspace/zoom_transcribe/",
+    ]);
     expect(r).not.toBeNull();
     expect(r?.matched).toBe("/data/workspace/zoom_transcribe/");
     expect(r?.field).toBe("path");
@@ -316,10 +314,9 @@ describe("findBlockMatch (path block 判定)", () => {
   });
 
   it("blockPaths の末尾 slash がなくても directory 配下として検出する", () => {
-    const r = findBlockMatch(
-      { path: "/data/workspace/zoom_transcribe/transcript.txt" },
-      ["/data/workspace/zoom_transcribe"],
-    );
+    const r = findBlockMatch({ path: "/data/workspace/zoom_transcribe/transcript.txt" }, [
+      "/data/workspace/zoom_transcribe",
+    ]);
     expect(r).not.toBeNull();
     expect(r?.matched).toBe("/data/workspace/zoom_transcribe");
   });

--- a/packages/cost-guard-hello/src/index.test.ts
+++ b/packages/cost-guard-hello/src/index.test.ts
@@ -134,6 +134,25 @@ describe("before_tool_call handler", () => {
 });
 
 describe("npm package metadata", () => {
+  it("configSchema の blockPaths description は未実装の symlink 解決を保証しない", () => {
+    const packageDir = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+    const pluginJson = JSON.parse(
+      readFileSync(resolve(packageDir, "openclaw.plugin.json"), "utf8"),
+    ) as {
+      configSchema: {
+        properties: {
+          blockPaths: { description: string };
+        };
+      };
+    };
+    const description = pluginJson.configSchema.properties.blockPaths.description;
+
+    expect(description).toContain("path.resolve");
+    expect(description).toContain("symlink / realpath 解決は未対応");
+    expect(description).not.toContain("readlink");
+    expect(description).not.toContain("symlink 経由でも検出");
+  });
+
   it("npm pack に OpenClaw extension の参照先ファイルを含める", () => {
     const packageDir = resolve(dirname(fileURLToPath(import.meta.url)), "..");
     const packageJson = JSON.parse(readFileSync(resolve(packageDir, "package.json"), "utf8")) as {

--- a/packages/cost-guard-hello/src/index.test.ts
+++ b/packages/cost-guard-hello/src/index.test.ts
@@ -14,7 +14,7 @@ import { readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it, vi } from "vitest";
-import register from "./index.js";
+import register, { findBlockMatch } from "./index.js";
 
 type HookHandler = (event: unknown, ctx: unknown) => unknown;
 
@@ -208,5 +208,128 @@ describe("before_agent_run handler", () => {
     const result = handler!({ prompt: "", messages: [] }, {});
     expect(result).toEqual({ outcome: "pass" });
     expect(api.logger.info).not.toHaveBeenCalled();
+  });
+});
+
+describe("findBlockMatch (path block 判定)", () => {
+  it("string プロパティに blockPaths が含まれていたら match を返す", () => {
+    const r = findBlockMatch({ path: "/data/workspace/zoom_transcribe/transcript_0415.txt" }, [
+      "/data/workspace/zoom_transcribe/",
+    ]);
+    expect(r).not.toBeNull();
+    expect(r?.matched).toBe("/data/workspace/zoom_transcribe/");
+    expect(r?.field).toBe("path");
+  });
+
+  it("blockPaths にマッチしない path は null を返す", () => {
+    const r = findBlockMatch({ path: "/data/workspace/note.md" }, [
+      "/data/workspace/zoom_transcribe/",
+    ]);
+    expect(r).toBeNull();
+  });
+
+  it("blockPaths が空配列なら常に null を返す", () => {
+    const r = findBlockMatch({ path: "/data/workspace/zoom_transcribe/x.txt" }, []);
+    expect(r).toBeNull();
+  });
+
+  it("exec tool の command 文字列に blockPaths が含まれていたら検出する", () => {
+    const r = findBlockMatch({ command: "cat /data/workspace/zoom_transcribe/transcript.txt" }, [
+      "/data/workspace/zoom_transcribe/",
+    ]);
+    expect(r).not.toBeNull();
+    expect(r?.field).toBe("command");
+  });
+
+  it("`../` を含む相対 path 混在でも canonical 化で検出する", () => {
+    const r = findBlockMatch(
+      { path: "/data/workspace/../workspace/zoom_transcribe/transcript.txt" },
+      ["/data/workspace/zoom_transcribe/"],
+    );
+    expect(r).not.toBeNull();
+    expect(r?.matched).toBe("/data/workspace/zoom_transcribe/");
+  });
+
+  it("ネストした object/array の中の string も検査する", () => {
+    const r = findBlockMatch({ args: ["-c", "cat /data/workspace/zoom_transcribe/x.txt"] }, [
+      "/data/workspace/zoom_transcribe/",
+    ]);
+    expect(r).not.toBeNull();
+    expect(r?.field).toBe("args[1]");
+  });
+
+  it("循環参照を含む object でも無限ループしない", () => {
+    const obj: Record<string, unknown> = { a: { path: "/data/workspace/note.md" } };
+    (obj.a as Record<string, unknown>).self = obj;
+    expect(() => findBlockMatch(obj, ["/no-match/"])).not.toThrow();
+  });
+});
+
+describe("before_tool_call の block mode", () => {
+  it("blockMode=observe（既定）では blockPaths に match しても block しない", () => {
+    const api = makeApi({ blockPaths: ["/data/workspace/zoom_transcribe/"] });
+    register(api as any);
+    const handler = api.hooks.get("before_tool_call");
+    const result = handler!(
+      { toolName: "read", params: { path: "/data/workspace/zoom_transcribe/x.txt" } },
+      {},
+    );
+    expect(result).toEqual({});
+  });
+
+  it("blockMode=block で blockPaths に match したら block: true を返す", () => {
+    const api = makeApi({
+      blockMode: "block",
+      blockPaths: ["/data/workspace/zoom_transcribe/"],
+    });
+    register(api as any);
+    const handler = api.hooks.get("before_tool_call");
+    const result = handler!(
+      { toolName: "read", params: { path: "/data/workspace/zoom_transcribe/x.txt" } },
+      {},
+    ) as { block?: boolean; blockReason?: string };
+    expect(result.block).toBe(true);
+    expect(result.blockReason).toContain("/data/workspace/zoom_transcribe/");
+  });
+
+  it("blockMode=block でも blockPaths が空なら block しない", () => {
+    const api = makeApi({ blockMode: "block", blockPaths: [] });
+    register(api as any);
+    const handler = api.hooks.get("before_tool_call");
+    const result = handler!(
+      { toolName: "read", params: { path: "/data/workspace/zoom_transcribe/x.txt" } },
+      {},
+    );
+    expect(result).toEqual({});
+  });
+
+  it("blockMode=block でも非マッチ path は block しない", () => {
+    const api = makeApi({
+      blockMode: "block",
+      blockPaths: ["/data/workspace/zoom_transcribe/"],
+    });
+    register(api as any);
+    const handler = api.hooks.get("before_tool_call");
+    const result = handler!({ toolName: "read", params: { path: "/data/workspace/note.md" } }, {});
+    expect(result).toEqual({});
+  });
+
+  it("block 時に warn または info で BLOCKED log を出す", () => {
+    const api = makeApi({
+      blockMode: "block",
+      blockPaths: ["/data/workspace/zoom_transcribe/"],
+    });
+    register(api as any);
+    const handler = api.hooks.get("before_tool_call");
+    api.logger.info.mockClear();
+    api.logger.warn.mockClear();
+    handler!(
+      { toolName: "exec", params: { command: "cat /data/workspace/zoom_transcribe/x.txt" } },
+      {},
+    );
+    const warnCalls = api.logger.warn.mock.calls.map((c: unknown[]) => c[0] as string);
+    const infoCalls = api.logger.info.mock.calls.map((c: unknown[]) => c[0] as string);
+    const allCalls = [...warnCalls, ...infoCalls];
+    expect(allCalls.some((m) => m.includes("BLOCKED"))).toBe(true);
   });
 });

--- a/packages/cost-guard-hello/src/index.test.ts
+++ b/packages/cost-guard-hello/src/index.test.ts
@@ -260,6 +260,24 @@ describe("findBlockMatch (path block 判定)", () => {
     expect(r?.field).toBe("command");
   });
 
+  it("command 文字列内の redirection に隣接した absolute path も検出する", () => {
+    const r = findBlockMatch(
+      { command: "cat</data/workspace/zoom_transcribe/transcript.txt" },
+      ["/data/workspace/zoom_transcribe/"],
+    );
+    expect(r).not.toBeNull();
+    expect(r?.field).toBe("command");
+  });
+
+  it("command 文字列内の option value に隣接した absolute path も検出する", () => {
+    const r = findBlockMatch(
+      { command: "cat --file=/data/workspace/zoom_transcribe/transcript.txt" },
+      ["/data/workspace/zoom_transcribe/"],
+    );
+    expect(r).not.toBeNull();
+    expect(r?.field).toBe("command");
+  });
+
   it("`../` を含む相対 path 混在でも canonical 化で検出する", () => {
     const r = findBlockMatch(
       { path: "/data/workspace/../workspace/zoom_transcribe/transcript.txt" },
@@ -387,6 +405,42 @@ describe("before_tool_call の block mode", () => {
       {
         toolName: "exec",
         params: { cwd: "/data/workspace", command: "cat zoom_transcribe/transcript.txt" },
+      },
+      {},
+    ) as { block?: boolean; blockReason?: string };
+    expect(result.block).toBe(true);
+    expect(result.blockReason).toContain("/data/workspace/zoom_transcribe/");
+  });
+
+  it("blockMode=block で redirection に隣接した command 内 absolute path を block する", () => {
+    const api = makeApi({
+      blockMode: "block",
+      blockPaths: ["/data/workspace/zoom_transcribe/"],
+    });
+    register(api as any);
+    const handler = api.hooks.get("before_tool_call");
+    const result = handler!(
+      {
+        toolName: "exec",
+        params: { command: "cat</data/workspace/zoom_transcribe/transcript.txt" },
+      },
+      {},
+    ) as { block?: boolean; blockReason?: string };
+    expect(result.block).toBe(true);
+    expect(result.blockReason).toContain("/data/workspace/zoom_transcribe/");
+  });
+
+  it("blockMode=block で option value に隣接した command 内 absolute path を block する", () => {
+    const api = makeApi({
+      blockMode: "block",
+      blockPaths: ["/data/workspace/zoom_transcribe/"],
+    });
+    register(api as any);
+    const handler = api.hooks.get("before_tool_call");
+    const result = handler!(
+      {
+        toolName: "exec",
+        params: { command: "cat --file=/data/workspace/zoom_transcribe/transcript.txt" },
       },
       {},
     ) as { block?: boolean; blockReason?: string };

--- a/packages/cost-guard-hello/src/index.test.ts
+++ b/packages/cost-guard-hello/src/index.test.ts
@@ -277,6 +277,24 @@ describe("findBlockMatch (path block 判定)", () => {
     expect(r?.field).toBe("command");
   });
 
+  it("args 内の redirection に隣接した absolute path も検出する", () => {
+    const r = findBlockMatch(
+      { args: ["cat</data/workspace/zoom_transcribe/transcript.txt"] },
+      ["/data/workspace/zoom_transcribe/"],
+    );
+    expect(r).not.toBeNull();
+    expect(r?.field).toBe("args[0]");
+  });
+
+  it("args 内の option value に隣接した absolute path も検出する", () => {
+    const r = findBlockMatch(
+      { args: ["--file=/data/workspace/zoom_transcribe/transcript.txt"] },
+      ["/data/workspace/zoom_transcribe/"],
+    );
+    expect(r).not.toBeNull();
+    expect(r?.field).toBe("args[0]");
+  });
+
   it("`../` を含む相対 path 混在でも canonical 化で検出する", () => {
     const r = findBlockMatch(
       { path: "/data/workspace/../workspace/zoom_transcribe/transcript.txt" },
@@ -438,6 +456,42 @@ describe("before_tool_call の block mode", () => {
       {
         toolName: "exec",
         params: { command: "cat --file=/data/workspace/zoom_transcribe/transcript.txt" },
+      },
+      {},
+    ) as { block?: boolean; blockReason?: string };
+    expect(result.block).toBe(true);
+    expect(result.blockReason).toContain("/data/workspace/zoom_transcribe/");
+  });
+
+  it("blockMode=block で args 内の redirection に隣接した absolute path を block する", () => {
+    const api = makeApi({
+      blockMode: "block",
+      blockPaths: ["/data/workspace/zoom_transcribe/"],
+    });
+    register(api as any);
+    const handler = api.hooks.get("before_tool_call");
+    const result = handler!(
+      {
+        toolName: "exec",
+        params: { args: ["cat</data/workspace/zoom_transcribe/transcript.txt"] },
+      },
+      {},
+    ) as { block?: boolean; blockReason?: string };
+    expect(result.block).toBe(true);
+    expect(result.blockReason).toContain("/data/workspace/zoom_transcribe/");
+  });
+
+  it("blockMode=block で args 内の option value に隣接した absolute path を block する", () => {
+    const api = makeApi({
+      blockMode: "block",
+      blockPaths: ["/data/workspace/zoom_transcribe/"],
+    });
+    register(api as any);
+    const handler = api.hooks.get("before_tool_call");
+    const result = handler!(
+      {
+        toolName: "exec",
+        params: { args: ["--file=/data/workspace/zoom_transcribe/transcript.txt"] },
       },
       {},
     ) as { block?: boolean; blockReason?: string };

--- a/packages/cost-guard-hello/src/index.test.ts
+++ b/packages/cost-guard-hello/src/index.test.ts
@@ -269,6 +269,26 @@ describe("findBlockMatch (path block 判定)", () => {
     expect(r?.matched).toBe("/data/workspace/zoom_transcribe/");
   });
 
+  it("cwd 基準の相対 path も canonical 化で検出する", () => {
+    const r = findBlockMatch(
+      { cwd: "/data/workspace", path: "zoom_transcribe/transcript.txt" },
+      ["/data/workspace/zoom_transcribe/"],
+    );
+    expect(r).not.toBeNull();
+    expect(r?.matched).toBe("/data/workspace/zoom_transcribe/");
+    expect(r?.field).toBe("path");
+  });
+
+  it("workdir 基準の相対 path も canonical 化で検出する", () => {
+    const r = findBlockMatch(
+      { workdir: "/data/workspace", path: "zoom_transcribe/transcript.txt" },
+      ["/data/workspace/zoom_transcribe/"],
+    );
+    expect(r).not.toBeNull();
+    expect(r?.matched).toBe("/data/workspace/zoom_transcribe/");
+    expect(r?.field).toBe("path");
+  });
+
   it("ネストした object/array の中の string も検査する", () => {
     const r = findBlockMatch({ args: ["-c", "cat /data/workspace/zoom_transcribe/x.txt"] }, [
       "/data/workspace/zoom_transcribe/",
@@ -305,6 +325,24 @@ describe("before_tool_call の block mode", () => {
     const handler = api.hooks.get("before_tool_call");
     const result = handler!(
       { toolName: "read", params: { path: "/data/workspace/zoom_transcribe/x.txt" } },
+      {},
+    ) as { block?: boolean; blockReason?: string };
+    expect(result.block).toBe(true);
+    expect(result.blockReason).toContain("/data/workspace/zoom_transcribe/");
+  });
+
+  it("blockMode=block で cwd 基準の相対 path に match したら block: true を返す", () => {
+    const api = makeApi({
+      blockMode: "block",
+      blockPaths: ["/data/workspace/zoom_transcribe/"],
+    });
+    register(api as any);
+    const handler = api.hooks.get("before_tool_call");
+    const result = handler!(
+      {
+        toolName: "read",
+        params: { cwd: "/data/workspace", path: "zoom_transcribe/transcript.txt" },
+      },
       {},
     ) as { block?: boolean; blockReason?: string };
     expect(result.block).toBe(true);

--- a/packages/cost-guard-hello/src/index.test.ts
+++ b/packages/cost-guard-hello/src/index.test.ts
@@ -278,19 +278,17 @@ describe("findBlockMatch (path block 判定)", () => {
   });
 
   it("args 内の redirection に隣接した absolute path も検出する", () => {
-    const r = findBlockMatch(
-      { args: ["cat</data/workspace/zoom_transcribe/transcript.txt"] },
-      ["/data/workspace/zoom_transcribe/"],
-    );
+    const r = findBlockMatch({ args: ["cat</data/workspace/zoom_transcribe/transcript.txt"] }, [
+      "/data/workspace/zoom_transcribe/",
+    ]);
     expect(r).not.toBeNull();
     expect(r?.field).toBe("args[0]");
   });
 
   it("args 内の option value に隣接した absolute path も検出する", () => {
-    const r = findBlockMatch(
-      { args: ["--file=/data/workspace/zoom_transcribe/transcript.txt"] },
-      ["/data/workspace/zoom_transcribe/"],
-    );
+    const r = findBlockMatch({ args: ["--file=/data/workspace/zoom_transcribe/transcript.txt"] }, [
+      "/data/workspace/zoom_transcribe/",
+    ]);
     expect(r).not.toBeNull();
     expect(r?.field).toBe("args[0]");
   });

--- a/packages/cost-guard-hello/src/index.test.ts
+++ b/packages/cost-guard-hello/src/index.test.ts
@@ -279,6 +279,16 @@ describe("findBlockMatch (path block 判定)", () => {
     expect(r?.field).toBe("path");
   });
 
+  it("cwd 基準の command 内相対 path も canonical 化で検出する", () => {
+    const r = findBlockMatch(
+      { cwd: "/data/workspace", command: "cat zoom_transcribe/transcript.txt" },
+      ["/data/workspace/zoom_transcribe/"],
+    );
+    expect(r).not.toBeNull();
+    expect(r?.matched).toBe("/data/workspace/zoom_transcribe/");
+    expect(r?.field).toBe("command");
+  });
+
   it("workdir 基準の相対 path も canonical 化で検出する", () => {
     const r = findBlockMatch(
       { workdir: "/data/workspace", path: "zoom_transcribe/transcript.txt" },
@@ -342,6 +352,24 @@ describe("before_tool_call の block mode", () => {
       {
         toolName: "read",
         params: { cwd: "/data/workspace", path: "zoom_transcribe/transcript.txt" },
+      },
+      {},
+    ) as { block?: boolean; blockReason?: string };
+    expect(result.block).toBe(true);
+    expect(result.blockReason).toContain("/data/workspace/zoom_transcribe/");
+  });
+
+  it("blockMode=block で cwd 基準の command 内相対 path に match したら block: true を返す", () => {
+    const api = makeApi({
+      blockMode: "block",
+      blockPaths: ["/data/workspace/zoom_transcribe/"],
+    });
+    register(api as any);
+    const handler = api.hooks.get("before_tool_call");
+    const result = handler!(
+      {
+        toolName: "exec",
+        params: { cwd: "/data/workspace", command: "cat zoom_transcribe/transcript.txt" },
       },
       {},
     ) as { block?: boolean; blockReason?: string };

--- a/packages/cost-guard-hello/src/index.test.ts
+++ b/packages/cost-guard-hello/src/index.test.ts
@@ -289,6 +289,23 @@ describe("findBlockMatch (path block 判定)", () => {
     expect(r?.field).toBe("command");
   });
 
+  it("blocked directory を cwd にした command 内 bare filename も検出する", () => {
+    const r = findBlockMatch(
+      { cwd: "/data/workspace/zoom_transcribe", command: "cat transcript.txt" },
+      ["/data/workspace/zoom_transcribe/"],
+    );
+    expect(r).not.toBeNull();
+  });
+
+  it("blockPaths の末尾 slash がなくても directory 配下として検出する", () => {
+    const r = findBlockMatch(
+      { path: "/data/workspace/zoom_transcribe/transcript.txt" },
+      ["/data/workspace/zoom_transcribe"],
+    );
+    expect(r).not.toBeNull();
+    expect(r?.matched).toBe("/data/workspace/zoom_transcribe");
+  });
+
   it("workdir 基準の相対 path も canonical 化で検出する", () => {
     const r = findBlockMatch(
       { workdir: "/data/workspace", path: "zoom_transcribe/transcript.txt" },
@@ -370,6 +387,24 @@ describe("before_tool_call の block mode", () => {
       {
         toolName: "exec",
         params: { cwd: "/data/workspace", command: "cat zoom_transcribe/transcript.txt" },
+      },
+      {},
+    ) as { block?: boolean; blockReason?: string };
+    expect(result.block).toBe(true);
+    expect(result.blockReason).toContain("/data/workspace/zoom_transcribe/");
+  });
+
+  it("blockMode=block で blocked directory を cwd にした bare filename read を block する", () => {
+    const api = makeApi({
+      blockMode: "block",
+      blockPaths: ["/data/workspace/zoom_transcribe/"],
+    });
+    register(api as any);
+    const handler = api.hooks.get("before_tool_call");
+    const result = handler!(
+      {
+        toolName: "exec",
+        params: { cwd: "/data/workspace/zoom_transcribe", command: "cat transcript.txt" },
       },
       {},
     ) as { block?: boolean; blockReason?: string };

--- a/packages/cost-guard-hello/src/index.ts
+++ b/packages/cost-guard-hello/src/index.ts
@@ -203,11 +203,7 @@ export function findBlockMatch(
  * これで `../`、`./`、相対 path 混在のケースをカバーする。`/proc/self/fd/...`
  * のような特殊 path は token 化した文字列で blockPaths の directory-prefix として検出する想定。
  */
-function expandPathCandidates(
-  s: string,
-  baseDirs: string[],
-  includeBareTokens: boolean,
-): string[] {
+function expandPathCandidates(s: string, baseDirs: string[], includeBareTokens: boolean): string[] {
   const trimmed = s.trim();
   if (trimmed === "") return [s];
   const candidates = new Set<string>();
@@ -224,7 +220,11 @@ function expandPathCandidates(
   return [...candidates];
 }
 
-function addResolvedPathCandidates(candidates: Set<string>, value: string, baseDirs: string[]): void {
+function addResolvedPathCandidates(
+  candidates: Set<string>,
+  value: string,
+  baseDirs: string[],
+): void {
   try {
     candidates.add(path.resolve("/", value));
   } catch {

--- a/packages/cost-guard-hello/src/index.ts
+++ b/packages/cost-guard-hello/src/index.ts
@@ -189,6 +189,7 @@ export function findBlockMatch(
  *
  * 候補：
  * - 元の文字列そのまま（コマンド文字列に path が含まれている場合のため）
+ * - 文字列内の path-like token（コマンド文字列中の相対 path 検出のため）
  * - path.resolve("/", s)（絶対パスとして resolve）
  * - path.resolve(s)（current working directory 起点で resolve）
  * - path.resolve(baseDir, s)（tool params の cwd / workdir 等を起点に resolve）
@@ -201,24 +202,38 @@ function expandPathCandidates(s: string, baseDirs: string[]): string[] {
   if (trimmed === "") return [s];
   const candidates = new Set<string>();
   candidates.add(s);
+  addResolvedPathCandidates(candidates, trimmed, baseDirs);
+  for (const token of extractPathLikeTokens(trimmed)) {
+    addResolvedPathCandidates(candidates, token, baseDirs);
+  }
+  return [...candidates];
+}
+
+function addResolvedPathCandidates(candidates: Set<string>, value: string, baseDirs: string[]): void {
   try {
-    candidates.add(path.resolve("/", trimmed));
+    candidates.add(path.resolve("/", value));
   } catch {
     // ignore
   }
   try {
-    candidates.add(path.resolve(trimmed));
+    candidates.add(path.resolve(value));
   } catch {
     // ignore
   }
   for (const baseDir of baseDirs) {
     try {
-      candidates.add(path.resolve(baseDir, trimmed));
+      candidates.add(path.resolve(baseDir, value));
     } catch {
       // ignore
     }
   }
-  return [...candidates];
+}
+
+function extractPathLikeTokens(s: string): string[] {
+  return s
+    .split(/\s+/)
+    .map((token) => token.replace(/^[`"'([{<]+|[`"',;:)\]}<>]+$/g, ""))
+    .filter((token) => token.includes("/") || token.startsWith("."));
 }
 
 const BASE_DIR_FIELD_NAMES = new Set([

--- a/packages/cost-guard-hello/src/index.ts
+++ b/packages/cost-guard-hello/src/index.ts
@@ -1,28 +1,39 @@
 /**
- * cost-guard-hello: Phase 0 実証用 observe-only plugin
+ * cost-guard-hello: Phase 0 実証用 plugin
  *
  * 目的：
- * - OpenClaw 2026.5.12 の plugin deployment path を実機で検証
- * - before_tool_call / tool_result_persist / before_agent_run の発火順序・タイミングを観測
+ * - OpenClaw 2026.5.12 の plugin deployment path を実機で検証（B-0/B-1 完了）
+ * - before_tool_call / tool_result_persist / before_agent_run の発火順序・タイミングを観測（実証 A 完了）
+ * - blockMode=block かつ blockPaths にマッチした tool 呼び出しを block する（実証 B B-3 以降）
  * - lossless-claw など bundled plugin との hook 評価順序を実測（Phase 0 実証 A）
  *
  * 動作：
- * - block / rewrite / outcome を変更しない（pure observer）
- * - すべての hook 発火を api.logger.info で記録
+ * - blockMode=observe（既定）：すべての hook 発火を api.logger.info で記録、block / rewrite はしない
+ * - blockMode=block：blockPaths にマッチした path を含む tool params の呼び出しを block
+ *   - tool params 内の文字列フィールドを再帰的に走査し、各 path 候補を path.resolve で canonical 化
+ *   - canonical 化した path 文字列または元の文字列に blockPaths の各プレフィックスが含まれていたら block
+ *   - `../` や絶対 path 混在で `/data/workspace/zoom_transcribe/` を含まないアクセス経路も block 対象に正規化
+ *   - 注意：symlink 解決（realpath）や inode / device 比較は本 plugin では実施しない（B-4 の漏れパターン
+ *     として Phase 1 設計に引き継ぐ）
  * - verbose=true のとき tool params の概略を最大 200 byte まで log に含める
  *
  * 詳細は easy-flow/docs/operations/transcript-cost-prevention-phase0.md 参照。
  */
 
+import path from "node:path";
+
 interface CostGuardHelloConfig {
   logging?: boolean;
   verbose?: boolean;
+  blockMode?: "observe" | "block";
+  blockPaths?: string[];
 }
 
 interface OpenClawPluginApi {
   pluginConfig?: Record<string, unknown>;
   logger: {
     info(message: string): void;
+    warn?(message: string): void;
   };
   on(event: string, handler: (event: unknown, ctx: unknown) => unknown): void;
 }
@@ -34,22 +45,48 @@ export default function register(api: OpenClawPluginApi): void {
   const cfg = (api.pluginConfig ?? {}) as CostGuardHelloConfig;
   const logging = cfg.logging ?? true;
   const verbose = cfg.verbose ?? false;
+  const blockMode = cfg.blockMode ?? "observe";
+  const blockPaths = Array.isArray(cfg.blockPaths)
+    ? cfg.blockPaths.filter((s) => typeof s === "string" && s.length > 0)
+    : [];
   const log = api.logger;
+  const warn = (message: string) => (log.warn ? log.warn(message) : log.info(message));
 
-  log.info(`${TAG} registered (logging=${logging}, verbose=${verbose})`);
+  log.info(
+    `${TAG} registered (logging=${logging}, verbose=${verbose}, ` +
+      `blockMode=${blockMode}, blockPaths=${JSON.stringify(blockPaths)})`,
+  );
 
   // before_tool_call: tool 実行直前。params 検査・block / requireApproval が可能
   api.on("before_tool_call", (event: unknown, _ctx: unknown) => {
-    if (!logging) return {};
     const e = event as { toolName?: string; params?: unknown };
     const toolName = e.toolName ?? "(unknown)";
-    if (verbose) {
-      const paramsPreview = safePreview(e.params, VERBOSE_PARAM_HEAD_BYTES);
-      log.info(`${TAG} before_tool_call: tool=${toolName} params_head="${paramsPreview}"`);
-    } else {
-      log.info(`${TAG} before_tool_call: tool=${toolName}`);
+
+    // block 判定（blockMode=block かつ blockPaths が空でない場合のみ）
+    if (blockMode === "block" && blockPaths.length > 0) {
+      const matched = findBlockMatch(e.params, blockPaths);
+      if (matched) {
+        warn(
+          `${TAG} BLOCKED tool=${toolName} matched_path="${matched.matched}" ` +
+            `via_field="${matched.field}" (blockMode=block)`,
+        );
+        return {
+          block: true,
+          blockReason: `[cost-guard-hello] path "${matched.matched}" is denied by cost-guard (matched in field "${matched.field}")`,
+        };
+      }
     }
-    return {}; // block しない
+
+    // 観測 log（block されなかった場合）
+    if (logging) {
+      if (verbose) {
+        const paramsPreview = safePreview(e.params, VERBOSE_PARAM_HEAD_BYTES);
+        log.info(`${TAG} before_tool_call: tool=${toolName} params_head="${paramsPreview}"`);
+      } else {
+        log.info(`${TAG} before_tool_call: tool=${toolName}`);
+      }
+    }
+    return {};
   });
 
   // tool_result_persist: tool 結果を AgentMessage として保存する直前
@@ -65,7 +102,7 @@ export default function register(api: OpenClawPluginApi): void {
   });
 
   // before_agent_run: agent loop が走る直前。session 単位の breaker 用
-  // 外部 plugin の場合 openclaw.json で allowConversationAccess: true が必要
+  // 外部 plugin の場合 openclaw.json で plugins.entries.<id>.hooks.allowConversationAccess: true が必要
   api.on("before_agent_run", (event: unknown, _ctx: unknown) => {
     if (!logging) return { outcome: "pass" as const };
     const e = event as {
@@ -84,6 +121,90 @@ export default function register(api: OpenClawPluginApi): void {
     );
     return { outcome: "pass" as const };
   });
+}
+
+/**
+ * tool params を再帰的に走査し、文字列フィールドの中で blockPaths にマッチするものを探す。
+ *
+ * 判定ロジック：
+ * 1. 文字列フィールド v ごとに、元の文字列 v と canonical 化した resolved の両方で
+ *    blockPaths のいずれかのプレフィックスが includes されたら block
+ * 2. canonical 化は path.resolve（CWD は無視して `/` 起点として絶対化）で実施
+ *    → `../`、相対 path、絶対 path 混在を吸収
+ *
+ * 限界（Phase 1 で対処）：
+ * - symlink 解決（realpath）は実施しない：本 plugin は agent 動作前 hook なので実 FS 触らない
+ * - inode / device 比較もしない
+ * - `/proc/self/fd` 経由は文字列に proc が含まれている場合のみ捕捉
+ * - shell injection（`$(...)` 経由）は元文字列に path が出ない場合 block 不可
+ */
+export function findBlockMatch(
+  params: unknown,
+  blockPaths: string[],
+): { matched: string; field: string } | null {
+  const visited = new WeakSet<object>();
+
+  function walk(value: unknown, fieldPath: string): { matched: string; field: string } | null {
+    if (typeof value === "string") {
+      const candidates = expandPathCandidates(value);
+      for (const candidate of candidates) {
+        for (const blocked of blockPaths) {
+          if (candidate.includes(blocked)) {
+            return { matched: blocked, field: fieldPath };
+          }
+        }
+      }
+      return null;
+    }
+    if (typeof value !== "object" || value === null) return null;
+    if (visited.has(value as object)) return null;
+    visited.add(value as object);
+
+    if (Array.isArray(value)) {
+      for (let i = 0; i < value.length; i++) {
+        const r = walk(value[i], `${fieldPath}[${i}]`);
+        if (r) return r;
+      }
+      return null;
+    }
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      const childField = fieldPath === "" ? k : `${fieldPath}.${k}`;
+      const r = walk(v, childField);
+      if (r) return r;
+    }
+    return null;
+  }
+
+  return walk(params, "");
+}
+
+/**
+ * 文字列を path-like 解釈して canonical 化候補を返す。
+ *
+ * 候補：
+ * - 元の文字列そのまま（コマンド文字列に path が含まれている場合のため）
+ * - path.resolve("/", s)（絶対パスとして resolve）
+ * - path.resolve(s)（current working directory 起点で resolve）
+ *
+ * これで `../`、`./`、相対 path 混在のケースをカバーする。`/proc/self/fd/...`
+ * のような特殊 path は元の文字列のままで blockPaths プレフィックスマッチで検出する想定。
+ */
+function expandPathCandidates(s: string): string[] {
+  const trimmed = s.trim();
+  if (trimmed === "") return [s];
+  const candidates = new Set<string>();
+  candidates.add(s);
+  try {
+    candidates.add(path.resolve("/", trimmed));
+  } catch {
+    // ignore
+  }
+  try {
+    candidates.add(path.resolve(trimmed));
+  } catch {
+    // ignore
+  }
+  return [...candidates];
 }
 
 /**

--- a/packages/cost-guard-hello/src/index.ts
+++ b/packages/cost-guard-hello/src/index.ts
@@ -194,7 +194,7 @@ export function findBlockMatch(
  * 候補：
  * - 元の文字列そのまま（コマンド文字列に path が含まれている場合のため）
  * - 文字列内の path-like token（コマンド文字列中の相対 path 検出のため）
- * - command-like field では token 内に埋まった絶対 path 断片
+ * - token 内に埋まった絶対 path 断片
  * - command-like field では bare filename token（baseDir 起点の相対 file 検出のため）
  * - path.resolve("/", s)（絶対パスとして resolve）
  * - path.resolve(s)（current working directory 起点で resolve）
@@ -211,10 +211,8 @@ function expandPathCandidates(s: string, baseDirs: string[], includeBareTokens: 
   addResolvedPathCandidates(candidates, trimmed, baseDirs);
   for (const token of extractPathLikeTokens(trimmed, includeBareTokens && baseDirs.length > 0)) {
     addResolvedPathCandidates(candidates, token, baseDirs);
-    if (includeBareTokens) {
-      for (const absolutePath of extractEmbeddedAbsolutePaths(token)) {
-        addResolvedPathCandidates(candidates, absolutePath, baseDirs);
-      }
+    for (const absolutePath of extractEmbeddedAbsolutePaths(token)) {
+      addResolvedPathCandidates(candidates, absolutePath, baseDirs);
     }
   }
   return [...candidates];

--- a/packages/cost-guard-hello/src/index.ts
+++ b/packages/cost-guard-hello/src/index.ts
@@ -129,7 +129,7 @@ export default function register(api: OpenClawPluginApi): void {
  * 判定ロジック：
  * 1. 文字列フィールド v ごとに、元の文字列 v と canonical 化した resolved の両方で
  *    blockPaths のいずれかのプレフィックスが includes されたら block
- * 2. canonical 化は path.resolve（CWD は無視して `/` 起点として絶対化）で実施
+ * 2. canonical 化は path.resolve（`/` 起点、および params 内の cwd / workdir 等）で実施
  *    → `../`、相対 path、絶対 path 混在を吸収
  *
  * 限界（Phase 1 で対処）：
@@ -144,9 +144,13 @@ export function findBlockMatch(
 ): { matched: string; field: string } | null {
   const visited = new WeakSet<object>();
 
-  function walk(value: unknown, fieldPath: string): { matched: string; field: string } | null {
+  function walk(
+    value: unknown,
+    fieldPath: string,
+    baseDirs: string[],
+  ): { matched: string; field: string } | null {
     if (typeof value === "string") {
-      const candidates = expandPathCandidates(value);
+      const candidates = expandPathCandidates(value, baseDirs);
       for (const candidate of candidates) {
         for (const blocked of blockPaths) {
           if (candidate.includes(blocked)) {
@@ -162,20 +166,22 @@ export function findBlockMatch(
 
     if (Array.isArray(value)) {
       for (let i = 0; i < value.length; i++) {
-        const r = walk(value[i], `${fieldPath}[${i}]`);
+        const r = walk(value[i], `${fieldPath}[${i}]`, baseDirs);
         if (r) return r;
       }
       return null;
     }
-    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+    const entries = Object.entries(value as Record<string, unknown>);
+    const scopedBaseDirs = collectScopedBaseDirs(entries, baseDirs);
+    for (const [k, v] of entries) {
       const childField = fieldPath === "" ? k : `${fieldPath}.${k}`;
-      const r = walk(v, childField);
+      const r = walk(v, childField, scopedBaseDirs);
       if (r) return r;
     }
     return null;
   }
 
-  return walk(params, "");
+  return walk(params, "", []);
 }
 
 /**
@@ -185,11 +191,12 @@ export function findBlockMatch(
  * - 元の文字列そのまま（コマンド文字列に path が含まれている場合のため）
  * - path.resolve("/", s)（絶対パスとして resolve）
  * - path.resolve(s)（current working directory 起点で resolve）
+ * - path.resolve(baseDir, s)（tool params の cwd / workdir 等を起点に resolve）
  *
  * これで `../`、`./`、相対 path 混在のケースをカバーする。`/proc/self/fd/...`
  * のような特殊 path は元の文字列のままで blockPaths プレフィックスマッチで検出する想定。
  */
-function expandPathCandidates(s: string): string[] {
+function expandPathCandidates(s: string, baseDirs: string[]): string[] {
   const trimmed = s.trim();
   if (trimmed === "") return [s];
   const candidates = new Set<string>();
@@ -204,7 +211,47 @@ function expandPathCandidates(s: string): string[] {
   } catch {
     // ignore
   }
+  for (const baseDir of baseDirs) {
+    try {
+      candidates.add(path.resolve(baseDir, trimmed));
+    } catch {
+      // ignore
+    }
+  }
   return [...candidates];
+}
+
+const BASE_DIR_FIELD_NAMES = new Set([
+  "cwd",
+  "workdir",
+  "workingdir",
+  "workingdirectory",
+  "working_directory",
+  "dir",
+]);
+
+function collectScopedBaseDirs(
+  entries: [string, unknown][],
+  inheritedBaseDirs: string[],
+): string[] {
+  const baseDirs = new Set(inheritedBaseDirs);
+  for (const [key, value] of entries) {
+    if (typeof value !== "string") continue;
+    if (!BASE_DIR_FIELD_NAMES.has(key.toLowerCase())) continue;
+    const trimmed = value.trim();
+    if (trimmed === "") continue;
+    try {
+      baseDirs.add(path.resolve("/", trimmed));
+    } catch {
+      // ignore
+    }
+    try {
+      baseDirs.add(path.resolve(trimmed));
+    } catch {
+      // ignore
+    }
+  }
+  return [...baseDirs];
 }
 
 /**

--- a/packages/cost-guard-hello/src/index.ts
+++ b/packages/cost-guard-hello/src/index.ts
@@ -194,6 +194,7 @@ export function findBlockMatch(
  * 候補：
  * - 元の文字列そのまま（コマンド文字列に path が含まれている場合のため）
  * - 文字列内の path-like token（コマンド文字列中の相対 path 検出のため）
+ * - command-like field では token 内に埋まった絶対 path 断片
  * - command-like field では bare filename token（baseDir 起点の相対 file 検出のため）
  * - path.resolve("/", s)（絶対パスとして resolve）
  * - path.resolve(s)（current working directory 起点で resolve）
@@ -214,6 +215,11 @@ function expandPathCandidates(
   addResolvedPathCandidates(candidates, trimmed, baseDirs);
   for (const token of extractPathLikeTokens(trimmed, includeBareTokens && baseDirs.length > 0)) {
     addResolvedPathCandidates(candidates, token, baseDirs);
+    if (includeBareTokens) {
+      for (const absolutePath of extractEmbeddedAbsolutePaths(token)) {
+        addResolvedPathCandidates(candidates, absolutePath, baseDirs);
+      }
+    }
   }
   return [...candidates];
 }
@@ -244,6 +250,12 @@ function extractPathLikeTokens(s: string, includeBareTokens: boolean): string[] 
     .map((token) => token.replace(/^[`"'([{<]+|[`"',;:)\]}<>]+$/g, ""))
     .filter((token) => token !== "")
     .filter((token) => includeBareTokens || token.includes("/") || token.startsWith("."));
+}
+
+function extractEmbeddedAbsolutePaths(token: string): string[] {
+  return [...token.matchAll(/\/[^\s`"'|&;(){}[\]<>]*/g)]
+    .map((match) => match[0].replace(/[`"',;:)\]}<>]+$/g, ""))
+    .filter((pathFragment) => pathFragment !== "" && pathFragment !== path.sep);
 }
 
 function isCommandLikeField(fieldPath: string): boolean {

--- a/packages/cost-guard-hello/src/index.ts
+++ b/packages/cost-guard-hello/src/index.ts
@@ -11,7 +11,7 @@
  * - blockMode=observe（既定）：すべての hook 発火を api.logger.info で記録、block / rewrite はしない
  * - blockMode=block：blockPaths にマッチした path を含む tool params の呼び出しを block
  *   - tool params 内の文字列フィールドを再帰的に走査し、各 path 候補を path.resolve で canonical 化
- *   - canonical 化した path 文字列または元の文字列に blockPaths の各プレフィックスが含まれていたら block
+ *   - canonical 化した path 文字列または元の文字列が blockPaths の各 directory と同一または配下なら block
  *   - `../` や絶対 path 混在で `/data/workspace/zoom_transcribe/` を含まないアクセス経路も block 対象に正規化
  *   - 注意：symlink 解決（realpath）や inode / device 比較は本 plugin では実施しない（B-4 の漏れパターン
  *     として Phase 1 設計に引き継ぐ）
@@ -128,7 +128,7 @@ export default function register(api: OpenClawPluginApi): void {
  *
  * 判定ロジック：
  * 1. 文字列フィールド v ごとに、元の文字列 v と canonical 化した resolved の両方で
- *    blockPaths のいずれかのプレフィックスが includes されたら block
+ *    blockPaths のいずれかと同一、またはその配下にあれば block
  * 2. canonical 化は path.resolve（`/` 起点、および params 内の cwd / workdir 等）で実施
  *    → `../`、相対 path、絶対 path 混在を吸収
  *
@@ -143,6 +143,10 @@ export function findBlockMatch(
   blockPaths: string[],
 ): { matched: string; field: string } | null {
   const visited = new WeakSet<object>();
+  const blockedMatchers = blockPaths.map((blocked) => ({
+    original: blocked,
+    normalized: normalizePathForMatch(blocked),
+  }));
 
   function walk(
     value: unknown,
@@ -150,11 +154,11 @@ export function findBlockMatch(
     baseDirs: string[],
   ): { matched: string; field: string } | null {
     if (typeof value === "string") {
-      const candidates = expandPathCandidates(value, baseDirs);
+      const candidates = expandPathCandidates(value, baseDirs, isCommandLikeField(fieldPath));
       for (const candidate of candidates) {
-        for (const blocked of blockPaths) {
-          if (candidate.includes(blocked)) {
-            return { matched: blocked, field: fieldPath };
+        for (const blocked of blockedMatchers) {
+          if (isBlockedPathCandidate(candidate, blocked.normalized)) {
+            return { matched: blocked.original, field: fieldPath };
           }
         }
       }
@@ -190,20 +194,25 @@ export function findBlockMatch(
  * 候補：
  * - 元の文字列そのまま（コマンド文字列に path が含まれている場合のため）
  * - 文字列内の path-like token（コマンド文字列中の相対 path 検出のため）
+ * - command-like field では bare filename token（baseDir 起点の相対 file 検出のため）
  * - path.resolve("/", s)（絶対パスとして resolve）
  * - path.resolve(s)（current working directory 起点で resolve）
  * - path.resolve(baseDir, s)（tool params の cwd / workdir 等を起点に resolve）
  *
  * これで `../`、`./`、相対 path 混在のケースをカバーする。`/proc/self/fd/...`
- * のような特殊 path は元の文字列のままで blockPaths プレフィックスマッチで検出する想定。
+ * のような特殊 path は token 化した文字列で blockPaths の directory-prefix として検出する想定。
  */
-function expandPathCandidates(s: string, baseDirs: string[]): string[] {
+function expandPathCandidates(
+  s: string,
+  baseDirs: string[],
+  includeBareTokens: boolean,
+): string[] {
   const trimmed = s.trim();
   if (trimmed === "") return [s];
   const candidates = new Set<string>();
   candidates.add(s);
   addResolvedPathCandidates(candidates, trimmed, baseDirs);
-  for (const token of extractPathLikeTokens(trimmed)) {
+  for (const token of extractPathLikeTokens(trimmed, includeBareTokens && baseDirs.length > 0)) {
     addResolvedPathCandidates(candidates, token, baseDirs);
   }
   return [...candidates];
@@ -229,11 +238,36 @@ function addResolvedPathCandidates(candidates: Set<string>, value: string, baseD
   }
 }
 
-function extractPathLikeTokens(s: string): string[] {
+function extractPathLikeTokens(s: string, includeBareTokens: boolean): string[] {
   return s
     .split(/\s+/)
     .map((token) => token.replace(/^[`"'([{<]+|[`"',;:)\]}<>]+$/g, ""))
-    .filter((token) => token.includes("/") || token.startsWith("."));
+    .filter((token) => token !== "")
+    .filter((token) => includeBareTokens || token.includes("/") || token.startsWith("."));
+}
+
+function isCommandLikeField(fieldPath: string): boolean {
+  const leaf =
+    fieldPath
+      .split(".")
+      .at(-1)
+      ?.replace(/\[\d+\]$/g, "")
+      .toLowerCase() ?? "";
+  return leaf === "command" || leaf === "cmd" || leaf === "script" || leaf === "shell";
+}
+
+function isBlockedPathCandidate(candidate: string, normalizedBlocked: string): boolean {
+  const normalizedCandidate = normalizePathForMatch(candidate);
+  if (normalizedCandidate === normalizedBlocked) return true;
+  if (normalizedBlocked === path.sep) return normalizedCandidate.startsWith(path.sep);
+  return normalizedCandidate.startsWith(`${normalizedBlocked}${path.sep}`);
+}
+
+function normalizePathForMatch(value: string): string {
+  const trimmed = value.trim();
+  const resolved = path.resolve("/", trimmed === "" ? value : trimmed);
+  if (resolved === path.sep) return resolved;
+  return resolved.replace(/\/+$/g, "");
 }
 
 const BASE_DIR_FIELD_NAMES = new Set([


### PR DESCRIPTION
## 概要

Phase 0 実証 B（L1 門番）で transcript の直接 read を block するため、cost-guard-hello に **block 機能** を追加します。estack-inc/easy-flow#390 でマージされた Phase 0 計画書（L1+L2 セット展開設計）の B-2 ステップに対応します。

## 追加する config

| キー | 既定値 | 動作 |
|---|---|---|
| `blockMode` | `"observe"` | observe=log のみ / block=block 判定実施 |
| `blockPaths` | `[]` | block 対象 path のプレフィックス（再帰走査 + canonical 化） |

## 挙動

- **observe モード（既定）**：既存の log 観測のみ。block しない。本番展開時はこのモードで利用
- **block モード + blockPaths 指定時**：
  - `before_tool_call` で tool params を再帰走査
  - 各文字列フィールドを `path.resolve` で canonical 化（`../` を解消）
  - canonical / 元文字列のいずれかが blockPaths のプレフィックスを含めば `block: true` を返す
  - tool 実行を停止、agent には拒否理由が伝わる
  - マッチした path と field を BLOCKED log に記録

## 使い方（dev のみ、本番展開禁止）

\`\`\`json
{
  "plugins": {
    "entries": {
      "cost-guard-hello": {
        "enabled": true,
        "hooks": { "allowConversationAccess": true },
        "config": {
          "blockMode": "block",
          "blockPaths": ["/data/workspace/zoom_transcribe/"]
        }
      }
    }
  }
}
\`\`\`

## 限界（README に明記、Phase 1 で対処）

- symlink 解決（`realpath`）は実施しない：本 plugin は agent 動作前 hook なので実 FS には触らない
- inode / device 比較もしない
- \`/proc/self/fd\` 経由は元文字列に proc path が含まれている場合のみ捕捉
- shell injection（\`$(...)\`、\`\` \`...\` \`\` 経由）は元文字列に path が出ない場合 block 不可

これらは Phase 0 実証 B-4 で漏れパターンとして観測し、本格 cost-guard plugin の設計（Phase 1-design）に引き継ぎます。

## 検証結果

\`\`\`
$ npm test --workspace cost-guard-hello
Tests       26 passed (26)
  ✓ findBlockMatch (path block 判定) - 7 ケース新規
  ✓ before_tool_call の block mode - 5 ケース新規
  ✓ 既存 14 ケースも全 pass

$ npm run lint
Checked 206 files. cost-guard-hello 起因のエラー・警告なし

$ npm run build --workspace cost-guard-hello
通過
\`\`\`

## 変更内容

- \`openclaw.plugin.json\`: configSchema に blockMode / blockPaths を追加
- \`src/index.ts\`: findBlockMatch / expandPathCandidates 関数 + before_tool_call で block 判定
- \`src/index.test.ts\`: 12 ケース追加（block mode の挙動 + findBlockMatch の path 検出ロジック）
- \`README.md\`: observe / block モードの設定例 + 限界の明記

## 残課題

- [ ] dev-and-test-agent に適用して B-3（単純 read block）の動作確認
- [ ] B-4: 30+ 迂回パターンの block 耐性実測
- [ ] B-5: 漏れたパターンを Phase 1 設計に引き継ぎ

## 関連

- 設計前提: easy-flow #390 (Phase 0 計画書、L1+L2 セット展開)
- plugin 元実装: easy-flow-agent #166 (Phase 0 実証用 observe-only)
- extensions パス: easy-flow-agent #167 (./src/index.ts へ統一)
- 実証 A: easy-flow #389 (Hard blocker 4/4 解決)