### PR TITLE
feat(cost-guard): Phase 1 cost-guard plugin の本格版を実装（default deny + tool allowlist + 2 段 breaker）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ pinecone-memory/
 packages/model-router/model-router/
 packages/portal-notify-tool/portal-notify-tool/
 packages/cost-guard-hello/cost-guard-hello/
+packages/cost-guard/cost-guard/
 build/
 !packages/easyflow-cli/test/fixtures/build/
 *.js.map

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,80 @@
         "tsx": "^4.21.0"
       }
     },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@biomejs/biome": {
       "version": "2.4.7",
       "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.7.tgz",
@@ -634,6 +708,49 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@isaacs/cliui/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@isaacs/fs-minipass": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
@@ -655,12 +772,54 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
     },
     "node_modules/@napi-rs/canvas": {
       "version": "0.1.80",
@@ -861,6 +1020,17 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -1309,6 +1479,40 @@
       "integrity": "sha512-yXsWKeuHNYyH72BcSZd3bV5ZD5MybAoTvKxkMaeV2UzuGfNzbHBVh5eO+ysTWTFAf8I9XcOueF4tZfAGjCa4Iw==",
       "license": "MIT"
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.4.tgz",
+      "integrity": "sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^1.0.2",
+        "ast-v8-to-istanbul": "^0.3.3",
+        "debug": "^4.4.1",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.17",
+        "magicast": "^0.3.5",
+        "std-env": "^3.9.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "3.2.4",
+        "vitest": "3.2.4"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
@@ -1487,6 +1691,19 @@
         "url": "https://github.com/chalk/ansi-regex?sponsor=1"
       }
     },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -1504,6 +1721,35 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.12.tgz",
+      "integrity": "sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/base64-js": {
@@ -1537,6 +1783,19 @@
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
       "license": "ISC"
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
     },
     "node_modules/cac": {
       "version": "6.7.14",
@@ -1687,6 +1946,26 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/commander": {
       "version": "13.1.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
@@ -1701,6 +1980,10 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "license": "MIT"
+    },
+    "node_modules/cost-guard": {
+      "resolved": "packages/cost-guard",
+      "link": true
     },
     "node_modules/cost-guard-hello": {
       "resolved": "packages/cost-guard-hello",
@@ -1869,6 +2152,13 @@
       "dependencies": {
         "underscore": "^1.13.1"
       }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/emoji-regex": {
       "version": "10.6.0",
@@ -2050,6 +2340,23 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/frac": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/frac/-/frac-1.1.2.tgz",
@@ -2112,6 +2419,88 @@
       "funding": {
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
+    },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob/node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/htmlparser2": {
       "version": "10.1.0",
@@ -2177,6 +2566,16 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-interactive": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
@@ -2236,6 +2635,76 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
     },
     "node_modules/js-tokens": {
       "version": "9.0.1",
@@ -2335,6 +2804,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -2343,6 +2819,34 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/mammoth": {
@@ -2379,6 +2883,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/minipass": {
@@ -2526,6 +3046,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
     "node_modules/pako": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
@@ -2609,6 +3136,33 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/pathe": {
@@ -2980,6 +3534,19 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
+    "node_modules/semver": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/setimmediate": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
@@ -3115,6 +3682,52 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-ansi": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
@@ -3128,6 +3741,30 @@
       },
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-final-newline": {
@@ -3155,6 +3792,19 @@
         "url": "https://github.com/sponsors/antfu"
       }
     },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/tar": {
       "version": "7.5.13",
       "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.13.tgz",
@@ -3178,6 +3828,21 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/tinybench": {
@@ -3561,6 +4226,129 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/xlsx": {
       "version": "0.18.5",
       "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.18.5.tgz",
@@ -3619,6 +4407,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/cost-guard": {
+      "version": "0.1.0",
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "@vitest/coverage-v8": "^3.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      },
+      "peerDependencies": {
+        "openclaw": ">=2026.5.12"
+      },
+      "peerDependenciesMeta": {
+        "openclaw": {
+          "optional": true
+        }
       }
     },
     "packages/cost-guard-hello": {

--- a/packages/cost-guard/README.md
+++ b/packages/cost-guard/README.md
@@ -1,0 +1,230 @@
+# cost-guard
+
+OpenClaw 2026.5.12 以降向け **Phase 1 本格版 cost-guard plugin**。`hongmong-ochi-agent` の transcript コスト爆発（$1990/月）への構造対策として、`denyPaths` 配下への汎用 file access を **default deny + tool allowlist** で遮断する。
+
+## 概要
+
+3 hook で agent コストを多層防御する：
+
+| hook | 役割 |
+|---|---|
+| `before_tool_call` | `denyPaths` 配下への汎用 tool 呼び出しを block。`allowlistedToolsForDenyPaths` のみ通過。`commandDenylist` の AST 検査で shell injection 経由の迂回を捕捉 |
+| `tool_result_persist` | tool result の合計 byte 数が `rewriteThresholdBytes` を超えた場合に sentinel 文字列で置換。`tool_call_id` を保持して LLM 入力構築の整合性を保つ |
+| `before_agent_run` | 段 1: per-turn prompt input gate → 段 2: session 単位 token budget breaker → 段 3: `cleanupOnSessionStart=true` 時に過去 messages の `denyPaths` 参照を sentinel 置換 |
+
+詳細設計：[Phase 1 設計 v6（estack-inc/easy-flow#398）](https://github.com/estack-inc/easy-flow/pull/398)
+契約：本案件の `contracts.md`（同 case 配下）
+
+## install（OpenClaw extension として）
+
+```bash
+# ローカル開発：build
+cd packages/cost-guard
+npm install
+npm run build
+
+# OpenClaw に link install
+openclaw plugins install --link ./packages/cost-guard
+
+# 確認
+openclaw plugins list
+openclaw plugins inspect cost-guard --runtime --json
+```
+
+## 設定（openclaw.json）
+
+### 本番既定（Phase 1）
+
+```json
+{
+  "plugins": {
+    "allow": ["cost-guard"],
+    "entries": {
+      "cost-guard": {
+        "enabled": true,
+        "hooks": { "allowConversationAccess": true },
+        "config": {
+          "blockMode": "block",
+          "denyPaths": ["/data/workspace/zoom_transcribe/"],
+          "allowlistedToolsForDenyPaths": [
+            "transcript-analyzer.list_transcripts",
+            "transcript-analyzer.search_transcripts",
+            "transcript-analyzer.analyze_transcript"
+          ],
+          "rewriteThresholdBytes": 50000,
+          "sessionTokenBudget": 500000,
+          "perTurnPromptInputThreshold": 50000,
+          "denyHardlinkTraversal": true,
+          "cleanupOnSessionStart": true
+        }
+      }
+    }
+  }
+}
+```
+
+### dev 検証用（observe モード）
+
+`blockMode: "observe"` は **dev / staging instance 限定**。本 plugin が hook を log するだけで戻り値で block / rewrite しない。metric は本番と同じく発行されるため、影響予測の dry-run として使う。
+
+```json
+{
+  "plugins": {
+    "entries": {
+      "cost-guard": {
+        "enabled": true,
+        "hooks": { "allowConversationAccess": true },
+        "config": {
+          "blockMode": "observe",
+          "denyPaths": ["/data/workspace/zoom_transcribe/"]
+        }
+      }
+    }
+  }
+}
+```
+
+`before_agent_run` を外部 plugin から使うため `hooks.allowConversationAccess: true` が必須。**正しい場所は `plugins.entries.<id>.hooks.allowConversationAccess`**（`hooks.` を間に挟む）。
+
+## 設定項目（contracts.md §9.1）
+
+| キー | 型 | 既定値 | 説明 |
+|---|---|---|---|
+| `logging` | boolean | `true` | hook 発火時に `api.logger` で観測 log を出力 |
+| `verbose` | boolean | `false` | tool params の概略を最大 200 byte まで log に含める |
+| `blockMode` | `"observe"` / `"block"` | `"block"` | Phase 1 本番既定は `block`。`observe` は dev 検証専用 |
+| `denyPaths` | string[] | `["/data/workspace/zoom_transcribe/"]` | default deny する path のプレフィックス |
+| `allowlistedToolsForDenyPaths` | string[] | `transcript-analyzer.*` の 3 件 | `denyPaths` 配下にアクセス可能な tool id allowlist |
+| `rewriteThresholdBytes` | number | `50000` | `tool_result_persist` で sentinel 置換する閾値 |
+| `sessionTokenBudget` | number | `500000` | session 単位の cumulative token 上限 |
+| `perTurnPromptInputThreshold` | number | `50000` | 次ターン prompt input 上限（推論直前 gate） |
+| `commandDenylist` | string[] | `["eval", "bash -c $", "sh -c $", "<(", "$(", "`"]` | command の AST 検査での deny パターン |
+| `denyHardlinkTraversal` | boolean | `true` | hardlink 経由で `denyPaths` に到達する path を inode 一致で検出 |
+| `cleanupOnSessionStart` | boolean | `true` | 過去 messages の `denyPaths` 参照を sentinel 置換 |
+| `suspendAgent` | boolean | `false` | rollback Mode A：agent 一時停止 |
+
+## block 応答（contracts.md §7.1）
+
+`before_tool_call` が block を返す際の戻り値は contracts.md §2.1 の `BeforeToolCallResult` 準拠：
+
+```ts
+{
+  block: true,
+  blockReason: "deny_path_match" | "deny_path_match_inode" | "deny_path_match_symlink" | "command_denylist_match" | "tool_not_in_allowlist",
+  message: "/data/workspace/zoom_transcribe/ 配下は専用 tool 経由でのみアクセスできます。transcript-analyzer.* を使ってください。"
+}
+```
+
+`before_agent_run` の block も同様に contracts.md §7.2 準拠：
+
+```ts
+// 段 1
+{ outcome: "block", reason: "per_turn_input_too_large", message: "次ターンの入力サイズが大きすぎるため処理できません..." }
+
+// 段 2
+{ outcome: "block", reason: "session_token_budget_exceeded", message: "このセッションのトークン上限を超えたため..." }
+```
+
+## metric（contracts.md §10.1）
+
+OpenClaw runtime の `api.metrics.incrementCounter` 経由で以下を発行する。`api.metrics` 未提供の OpenClaw バージョンでも plugin は動作する：
+
+| metric 名 | 型 | 発火タイミング |
+|---|---|---|
+| `cost_guard.tool_call_blocked` | counter | `before_tool_call` で block / observe 通知 |
+| `cost_guard.tool_result_rewritten` | counter | `tool_result_persist` で sentinel 置換 |
+| `cost_guard.per_turn_input_blocked` | counter | `before_agent_run` 段 1 で block |
+| `cost_guard.session_budget_exceeded` | counter | `before_agent_run` 段 2 で block |
+| `cost_guard.transcript_pollution_detected` | counter | 過去 messages の sentinel 置換 |
+
+## 30+ 迂回パターン耐性
+
+`packages/cost-guard/src/path-checker.ts` で以下の迂回パターンを構造的に塞ぐ：
+
+1. 絶対 path 直書き
+2. `../` 経由
+3. `./` 経由
+4. 二重 slash `//`
+5. 末尾 slash 有無
+6. URL-encoded (`%2F`, `%2E`)
+7. cwd 起点の相対 path
+8. workdir 起点の相対 path
+9. dir 起点の相対 path
+10. bare filename + cwd（command-like field）
+11. command 内 redirection `<`
+12. command 内 redirection `>`
+13. command 内 option value `--file=`
+14. command 内 pipe `|`
+15. command 内空白区切り
+16. args 配列の各要素
+17. ネスト object
+18. ネスト array
+19. base64 偽装 → 元 string で検出（補助）
+20. symlink 経由（`realpath` で解決）
+21. hardlink 経由（inode 一致で検出）
+22. `/proc/self/fd`, `/proc/<pid>/root/...`
+23. 自己参照 `./.`
+24. 連続 `../../..`
+25. 不可視文字（ZWSP, NBSP, BOM）
+26. 改行混入（CR / LF / CRLF）
+27. tab 混入
+28. 末尾空白
+29. 先頭空白
+30. args 内 option value
+31. args 内 redirection
+32. NFKC 正規化（全角 → 半角）
+
+詳細は `src/path-checker.test.ts` の各テストケース参照。
+
+## アーキテクチャ
+
+```
+packages/cost-guard/
+├── openclaw.plugin.json    # OpenClaw plugin metadata（id / configSchema）
+├── package.json            # npm package + openclaw.extensions
+├── tsconfig.json
+├── README.md               # 本ファイル
+└── src/
+    ├── index.ts            # register(api) entry point + 3 hook implementation
+    ├── index.test.ts       # hook unit test（block / sentinel / breaker / metric）
+    ├── path-checker.ts     # 30+ 迂回パターン path canonical 化 + realpath + inode
+    ├── path-checker.test.ts
+    ├── command-checker.ts  # commandDenylist AST 検査
+    ├── command-checker.test.ts
+    ├── token-estimator.ts  # token 数の軽量近似（utf8_bytes / 4）
+    ├── token-estimator.test.ts
+    ├── sentinel.ts         # sentinel 文字列生成 + byte 計算
+    └── sentinel.test.ts
+```
+
+## test / build / lint
+
+```bash
+# 単体テスト（vitest, coverage ≥ 90%）
+npm test
+
+# 監視モード
+npm run test:watch
+
+# TypeScript 型チェック
+npm run typecheck
+
+# Biome lint
+npm run lint
+
+# build（cost-guard/ 配下に .js / .d.ts 出力）
+npm run build
+```
+
+## 注意事項（運用）
+
+- **Phase 1 本番既定は `blockMode: "block"`**。`observe` は dev / staging instance のみで使う
+- **Sonnet 全文 fallback は禁止**：本 plugin の block により transcript 全文 read が遮断された場合、agent は `transcript-analyzer.*` 経由で要約取得すること（block 応答の `message` に明示）
+- **rollback Mode A**：`suspendAgent: true` 設定で agent run 自体を停止できる。緊急時の運用用
+- **leaf_node: false**：本 plugin は denyPaths + allowlist で全 tool 呼び出しを判定する critical path のため、変更時は Owner 目視確認推奨
+
+## 関連 Issue / PR
+
+- 案件：[transcript-cost-prevention-phase1-impl](https://github.com/estack-inc/easy-flow/tree/main/docs/operations/multi-agent-cases/transcript-cost-prevention-phase1-impl)
+- 関連 Issue：[estack-inc/easy-flow#360](https://github.com/estack-inc/easy-flow/issues/360) / [estack-inc/easy-flow#376](https://github.com/estack-inc/easy-flow/issues/376)
+- Phase 0 実証用 plugin：`packages/cost-guard-hello/`（Phase 1 完了後に削除 PR）

--- a/packages/cost-guard/README.md
+++ b/packages/cost-guard/README.md
@@ -99,7 +99,7 @@ openclaw plugins inspect cost-guard --runtime --json
 | `sessionTokenBudget` | number | `500000` | session 単位の cumulative token 上限 |
 | `perTurnPromptInputThreshold` | number | `50000` | 次ターン prompt input 上限（推論直前 gate） |
 | `commandDenylist` | string[] | `["eval", "bash -c $", "sh -c $", "<(", "$(", "`"]` | command の AST 検査での deny パターン |
-| `denyHardlinkTraversal` | boolean | `true` | hardlink 経由で `denyPaths` に到達する path を inode 一致で検出。directory は配下 10,000 entry まで走査 |
+| `denyHardlinkTraversal` | boolean | `true` | hardlink 経由で `denyPaths` に到達する path を inode 一致で検出。directory は配下を再帰走査 |
 | `cleanupOnSessionStart` | boolean | `true` | 過去 messages の `denyPaths` 参照を sentinel 置換 |
 | `suspendAgent` | boolean | `false` | rollback Mode A：agent 一時停止 |
 

--- a/packages/cost-guard/README.md
+++ b/packages/cost-guard/README.md
@@ -99,7 +99,7 @@ openclaw plugins inspect cost-guard --runtime --json
 | `sessionTokenBudget` | number | `500000` | session 単位の cumulative token 上限 |
 | `perTurnPromptInputThreshold` | number | `50000` | 次ターン prompt input 上限（推論直前 gate） |
 | `commandDenylist` | string[] | `["eval", "bash -c $", "sh -c $", "<(", "$(", "`"]` | command の AST 検査での deny パターン |
-| `denyHardlinkTraversal` | boolean | `true` | hardlink 経由で `denyPaths` に到達する path を inode 一致で検出 |
+| `denyHardlinkTraversal` | boolean | `true` | hardlink 経由で `denyPaths` に到達する path を inode 一致で検出。directory は配下 10,000 entry まで走査 |
 | `cleanupOnSessionStart` | boolean | `true` | 過去 messages の `denyPaths` 参照を sentinel 置換 |
 | `suspendAgent` | boolean | `false` | rollback Mode A：agent 一時停止 |
 

--- a/packages/cost-guard/README.md
+++ b/packages/cost-guard/README.md
@@ -99,7 +99,7 @@ openclaw plugins inspect cost-guard --runtime --json
 | `sessionTokenBudget` | number | `500000` | session 単位の cumulative token 上限 |
 | `perTurnPromptInputThreshold` | number | `50000` | 次ターン prompt input 上限（推論直前 gate） |
 | `commandDenylist` | string[] | `["eval", "bash -c $", "sh -c $", "<(", "$(", "`"]` | command の AST 検査での deny パターン |
-| `denyHardlinkTraversal` | boolean | `true` | hardlink 経由で `denyPaths` に到達する path を inode 一致で検出。通常 path では directory 走査せず、hardlink 候補のみ短時間 cache 付きで確認 |
+| `denyHardlinkTraversal` | boolean | `true` | hardlink 経由で `denyPaths` に到達する path を inode 一致で検出。通常 path では directory 走査せず、hardlink 候補のみ確認 |
 | `cleanupOnSessionStart` | boolean | `true` | 過去 messages の `denyPaths` 参照を sentinel 置換 |
 | `suspendAgent` | boolean | `false` | rollback Mode A：agent 一時停止 |
 

--- a/packages/cost-guard/README.md
+++ b/packages/cost-guard/README.md
@@ -99,7 +99,7 @@ openclaw plugins inspect cost-guard --runtime --json
 | `sessionTokenBudget` | number | `500000` | session 単位の cumulative token 上限 |
 | `perTurnPromptInputThreshold` | number | `50000` | 次ターン prompt input 上限（推論直前 gate） |
 | `commandDenylist` | string[] | `["eval", "bash -c $", "sh -c $", "<(", "$(", "`"]` | command の AST 検査での deny パターン |
-| `denyHardlinkTraversal` | boolean | `true` | hardlink 経由で `denyPaths` に到達する path を inode 一致で検出。directory は配下を再帰走査 |
+| `denyHardlinkTraversal` | boolean | `true` | hardlink 経由で `denyPaths` に到達する path を inode 一致で検出。通常 path では directory 走査せず、hardlink 候補のみ短時間 cache 付きで確認 |
 | `cleanupOnSessionStart` | boolean | `true` | 過去 messages の `denyPaths` 参照を sentinel 置換 |
 | `suspendAgent` | boolean | `false` | rollback Mode A：agent 一時停止 |
 

--- a/packages/cost-guard/openclaw.plugin.json
+++ b/packages/cost-guard/openclaw.plugin.json
@@ -1,0 +1,80 @@
+{
+  "id": "cost-guard",
+  "kind": "plugin",
+  "name": "Cost Guard",
+  "description": "Phase 1 cost-guard plugin。default deny + tool allowlist + 2 段 breaker（per-turn input gate + session budget breaker）で transcript コスト爆発を構造的に遮断する。before_tool_call で denyPaths 配下への汎用 file access を遮断（allowlist の tool のみ通過）、tool_result_persist で 50KB 超の result を sentinel 置換、before_agent_run で per-turn / session 単位の token gate を実施する。",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "logging": {
+        "type": "boolean",
+        "default": true,
+        "description": "hook 発火時に api.logger で観測 log を出力するか"
+      },
+      "verbose": {
+        "type": "boolean",
+        "default": false,
+        "description": "tool params の概略（最大 200 byte）も log に含める"
+      },
+      "blockMode": {
+        "type": "string",
+        "enum": ["observe", "block"],
+        "default": "block",
+        "description": "Phase 1 本番既定は block。observe は dev 検証専用（block 判定を log のみで実施し、戻り値は block しない）"
+      },
+      "denyPaths": {
+        "type": "array",
+        "items": { "type": "string" },
+        "default": ["/data/workspace/zoom_transcribe/"],
+        "description": "default deny する path のプレフィックス。allowlistedToolsForDenyPaths のみ通過。path.resolve + realpath で canonical 化し、symlink / hardlink / `../` 経由のアクセスも検出する"
+      },
+      "allowlistedToolsForDenyPaths": {
+        "type": "array",
+        "items": { "type": "string" },
+        "default": [
+          "transcript-analyzer.list_transcripts",
+          "transcript-analyzer.search_transcripts",
+          "transcript-analyzer.analyze_transcript"
+        ],
+        "description": "denyPaths 配下にアクセス可能な tool id allowlist"
+      },
+      "rewriteThresholdBytes": {
+        "type": "number",
+        "default": 50000,
+        "description": "tool_result_persist で sentinel 置換する閾値（byte 数）。result の content 合計 byte が本値を超えた場合 sentinel 置換する"
+      },
+      "sessionTokenBudget": {
+        "type": "number",
+        "default": 500000,
+        "description": "session 単位の cumulative token 上限。超過時に before_agent_run 段 2 で block する"
+      },
+      "perTurnPromptInputThreshold": {
+        "type": "number",
+        "default": 50000,
+        "description": "次ターン prompt input 上限（推論直前 gate）。超過時に before_agent_run 段 1 で block する"
+      },
+      "commandDenylist": {
+        "type": "array",
+        "items": { "type": "string" },
+        "default": ["eval", "bash -c $", "sh -c $", "<(", "$(", "`"],
+        "description": "command params に対する AST 検査での deny パターン。shell injection 経由の denyPaths アクセス試行を捕捉する"
+      },
+      "denyHardlinkTraversal": {
+        "type": "boolean",
+        "default": true,
+        "description": "hardlink 経由で denyPaths 配下に到達する path を inode 一致で検出するか"
+      },
+      "cleanupOnSessionStart": {
+        "type": "boolean",
+        "default": true,
+        "description": "before_agent_run で session messages を走査し、過去ターンの tool result で denyPaths 配下の path 参照を sentinel 置換するか"
+      },
+      "suspendAgent": {
+        "type": "boolean",
+        "default": false,
+        "description": "rollback Mode A：agent 一時停止。true のとき before_agent_run で全 agent run を block する"
+      }
+    }
+  }
+}

--- a/packages/cost-guard/package.json
+++ b/packages/cost-guard/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "cost-guard",
+  "version": "0.1.0",
+  "description": "Phase 1 cost-guard plugin: default deny + tool allowlist + 2 段 breaker。transcript コスト爆発を構造的に遮断する。",
+  "type": "module",
+  "exports": {
+    ".": {
+      "import": "./cost-guard/index.js",
+      "types": "./cost-guard/index.d.ts",
+      "default": "./cost-guard/index.js"
+    }
+  },
+  "main": "./cost-guard/index.js",
+  "types": "./cost-guard/index.d.ts",
+  "openclaw": {
+    "extensions": ["./src/index.ts"]
+  },
+  "files": [
+    "cost-guard",
+    "src",
+    "openclaw.plugin.json"
+  ],
+  "scripts": {
+    "build": "tsc && cp openclaw.plugin.json cost-guard/openclaw.plugin.json",
+    "test": "vitest run --coverage",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit",
+    "lint": "biome check src/"
+  },
+  "peerDependencies": {
+    "openclaw": ">=2026.5.12"
+  },
+  "peerDependenciesMeta": {
+    "openclaw": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "@vitest/coverage-v8": "^3.0.0",
+    "typescript": "^5.0.0",
+    "vitest": "^3.0.0"
+  }
+}

--- a/packages/cost-guard/src/command-checker.test.ts
+++ b/packages/cost-guard/src/command-checker.test.ts
@@ -2,7 +2,7 @@
  * command-checker の単体テスト
  *
  * 検証点：
- * - containsCommandPattern が substring match で判定
+ * - containsCommandPattern が substring match と shell quote-aware `bash|sh -c` で判定
  * - findCommandDenylistMatch が command-like field のみを検査
  * - command-like field（command / cmd / script / shell / args）の各 alias をカバー
  * - non-command field（path / file / url 等）は検査対象外
@@ -50,6 +50,24 @@ describe("findCommandDenylistMatch", () => {
     it("sh -c $", () => {
       const r = findCommandDenylistMatch(
         { command: "sh -c $PAYLOAD" },
+        { commandDenylist: DEFAULT_DENYLIST },
+      );
+      expect(r).not.toBeNull();
+      expect(r?.matchedPattern).toBe("sh -c $");
+    });
+
+    it("bash -c の二重引用符内 $VAR を検出", () => {
+      const r = findCommandDenylistMatch(
+        { command: 'bash -c "$PAYLOAD"' },
+        { commandDenylist: DEFAULT_DENYLIST },
+      );
+      expect(r).not.toBeNull();
+      expect(r?.matchedPattern).toBe("bash -c $");
+    });
+
+    it("sh -c の一重引用符内 ${VAR} を検出", () => {
+      const r = findCommandDenylistMatch(
+        { command: "sh -c '${PAYLOAD}'" },
         { commandDenylist: DEFAULT_DENYLIST },
       );
       expect(r).not.toBeNull();

--- a/packages/cost-guard/src/command-checker.test.ts
+++ b/packages/cost-guard/src/command-checker.test.ts
@@ -1,0 +1,183 @@
+/**
+ * command-checker の単体テスト
+ *
+ * 検証点：
+ * - containsCommandPattern が substring match で判定
+ * - findCommandDenylistMatch が command-like field のみを検査
+ * - command-like field（command / cmd / script / shell / args）の各 alias をカバー
+ * - non-command field（path / file / url 等）は検査対象外
+ * - 既定 6 パターン（eval / bash -c $ / sh -c $ / <( / $( / `）をすべて検出
+ * - false positive：通常 path には deny pattern を含まない command は通過
+ */
+
+import { describe, expect, it } from "vitest";
+import { containsCommandPattern, findCommandDenylistMatch } from "./command-checker.js";
+
+const DEFAULT_DENYLIST = ["eval", "bash -c $", "sh -c $", "<(", "$(", "`"];
+
+describe("containsCommandPattern", () => {
+  it("substring match で判定", () => {
+    expect(containsCommandPattern("eval $(echo hello)", "eval")).toBe(true);
+    expect(containsCommandPattern("cat file.txt", "eval")).toBe(false);
+  });
+
+  it("空パターンは false", () => {
+    expect(containsCommandPattern("eval", "")).toBe(true); // string.includes("") は true だが
+    // ※ 実装上は filter で空文字列を除外しているため findCommandDenylistMatch 経由では発火しない
+  });
+});
+
+describe("findCommandDenylistMatch", () => {
+  describe("既定 6 パターンの検出", () => {
+    it("eval", () => {
+      const r = findCommandDenylistMatch(
+        { command: "eval $(cat /tmp/x.sh)" },
+        { commandDenylist: DEFAULT_DENYLIST },
+      );
+      expect(r).not.toBeNull();
+      expect(r?.matchedPattern).toBe("eval");
+    });
+
+    it("bash -c $", () => {
+      const r = findCommandDenylistMatch(
+        { command: "bash -c $SCRIPT" },
+        { commandDenylist: DEFAULT_DENYLIST },
+      );
+      expect(r).not.toBeNull();
+      expect(r?.matchedPattern).toBe("bash -c $");
+    });
+
+    it("sh -c $", () => {
+      const r = findCommandDenylistMatch(
+        { command: "sh -c $PAYLOAD" },
+        { commandDenylist: DEFAULT_DENYLIST },
+      );
+      expect(r).not.toBeNull();
+      expect(r?.matchedPattern).toBe("sh -c $");
+    });
+
+    it("process substitution <(", () => {
+      const r = findCommandDenylistMatch(
+        { command: "diff <(cat a) <(cat b)" },
+        { commandDenylist: DEFAULT_DENYLIST },
+      );
+      expect(r).not.toBeNull();
+      expect(r?.matchedPattern).toBe("<(");
+    });
+
+    it("command substitution $(", () => {
+      const r = findCommandDenylistMatch(
+        { command: "echo $(date)" },
+        { commandDenylist: DEFAULT_DENYLIST },
+      );
+      expect(r).not.toBeNull();
+      expect(r?.matchedPattern).toBe("$(");
+    });
+
+    it("backtick `", () => {
+      const r = findCommandDenylistMatch(
+        { command: "echo `date`" },
+        { commandDenylist: DEFAULT_DENYLIST },
+      );
+      expect(r).not.toBeNull();
+      expect(r?.matchedPattern).toBe("`");
+    });
+  });
+
+  describe("command-like field の alias", () => {
+    it("command field を検査", () => {
+      const r = findCommandDenylistMatch(
+        { command: "eval xxx" },
+        { commandDenylist: DEFAULT_DENYLIST },
+      );
+      expect(r).not.toBeNull();
+      expect(r?.field).toBe("command");
+    });
+
+    it("cmd field を検査", () => {
+      const r = findCommandDenylistMatch(
+        { cmd: "eval xxx" },
+        { commandDenylist: DEFAULT_DENYLIST },
+      );
+      expect(r).not.toBeNull();
+      expect(r?.field).toBe("cmd");
+    });
+
+    it("script field を検査", () => {
+      const r = findCommandDenylistMatch(
+        { script: "eval xxx" },
+        { commandDenylist: DEFAULT_DENYLIST },
+      );
+      expect(r).not.toBeNull();
+      expect(r?.field).toBe("script");
+    });
+
+    it("shell field を検査", () => {
+      const r = findCommandDenylistMatch(
+        { shell: "eval xxx" },
+        { commandDenylist: DEFAULT_DENYLIST },
+      );
+      expect(r).not.toBeNull();
+      expect(r?.field).toBe("shell");
+    });
+
+    it("args 配列の要素を検査", () => {
+      const r = findCommandDenylistMatch(
+        { args: ["bash", "-c", "eval xxx"] },
+        { commandDenylist: DEFAULT_DENYLIST },
+      );
+      expect(r).not.toBeNull();
+      expect(r?.field).toBe("args[2]");
+    });
+  });
+
+  describe("non-command field は検査対象外", () => {
+    it("path field は eval が含まれていても通過", () => {
+      const r = findCommandDenylistMatch(
+        { path: "/eval/data.txt" },
+        { commandDenylist: DEFAULT_DENYLIST },
+      );
+      expect(r).toBeNull();
+    });
+
+    it("url field も検査対象外", () => {
+      const r = findCommandDenylistMatch(
+        { url: "https://example.com/eval" },
+        { commandDenylist: DEFAULT_DENYLIST },
+      );
+      expect(r).toBeNull();
+    });
+  });
+
+  describe("非該当 / 境界", () => {
+    it("通常 command は通過", () => {
+      const r = findCommandDenylistMatch(
+        { command: "cat /tmp/file.txt" },
+        { commandDenylist: DEFAULT_DENYLIST },
+      );
+      expect(r).toBeNull();
+    });
+
+    it("commandDenylist が空配列なら null", () => {
+      const r = findCommandDenylistMatch({ command: "eval xxx" }, { commandDenylist: [] });
+      expect(r).toBeNull();
+    });
+
+    it("ネスト object 内の command も検査", () => {
+      const r = findCommandDenylistMatch(
+        { tool: { command: "eval $(date)" } },
+        { commandDenylist: DEFAULT_DENYLIST },
+      );
+      expect(r).not.toBeNull();
+      expect(r?.field).toBe("tool.command");
+    });
+
+    it("循環参照を含む object でも無限ループしない", () => {
+      const o: Record<string, unknown> = { command: "safe cmd" };
+      o.self = o;
+      expect(() =>
+        findCommandDenylistMatch(o, { commandDenylist: DEFAULT_DENYLIST }),
+      ).not.toThrow();
+    });
+  });
+});

--- a/packages/cost-guard/src/command-checker.test.ts
+++ b/packages/cost-guard/src/command-checker.test.ts
@@ -74,6 +74,34 @@ describe("findCommandDenylistMatch", () => {
       expect(r?.matchedPattern).toBe("sh -c $");
     });
 
+    it("args 配列形式の bash -c $VAR を検出", () => {
+      const r = findCommandDenylistMatch(
+        { args: ["bash", "-c", "$PAYLOAD"] },
+        { commandDenylist: DEFAULT_DENYLIST },
+      );
+      expect(r).not.toBeNull();
+      expect(r?.field).toBe("args");
+      expect(r?.matchedPattern).toBe("bash -c $");
+    });
+
+    it("args 配列形式の /bin/sh -c ${VAR} を検出", () => {
+      const r = findCommandDenylistMatch(
+        { args: ["/bin/sh", "-c", "${PAYLOAD}"] },
+        { commandDenylist: DEFAULT_DENYLIST },
+      );
+      expect(r).not.toBeNull();
+      expect(r?.matchedPattern).toBe("sh -c $");
+    });
+
+    it("args 配列形式の bash -lc $VAR を検出", () => {
+      const r = findCommandDenylistMatch(
+        { args: ["bash", "-lc", "$PAYLOAD"] },
+        { commandDenylist: DEFAULT_DENYLIST },
+      );
+      expect(r).not.toBeNull();
+      expect(r?.matchedPattern).toBe("bash -c $");
+    });
+
     it("process substitution <(", () => {
       const r = findCommandDenylistMatch(
         { command: "diff <(cat a) <(cat b)" },

--- a/packages/cost-guard/src/command-checker.ts
+++ b/packages/cost-guard/src/command-checker.ts
@@ -14,8 +14,8 @@
  * - "`"          : backtick command substitution
  *
  * 検査方針：
- * - command 文字列を空白 / `|` / `;` で粗く split し、各 token とその raw string で contains 判定
- * - 全文 substring match と token-level match の OR を取る（false negative より false positive を許容）
+ * - command 文字列を shell quote を考慮して軽く token 化し、`bash|sh -c` の script 引数を検査
+ * - 全文 substring match と shell token match の OR を取る（false negative より false positive を許容）
  * - false positive を避けるため、deny pattern は文字列単純 contains（正規表現ではない）
  */
 
@@ -95,5 +95,63 @@ function leafKey(fieldPath: string): string {
 export function containsCommandPattern(command: string, pattern: string): boolean {
   // 完全 substring match
   if (command.includes(pattern)) return true;
+  if (pattern === "bash -c $" && hasShellCExpansion(command, "bash")) return true;
+  if (pattern === "sh -c $" && hasShellCExpansion(command, "sh")) return true;
   return false;
+}
+
+function hasShellCExpansion(command: string, shellName: "bash" | "sh"): boolean {
+  const tokens = tokenizeShellCommand(command);
+  for (let i = 0; i < tokens.length - 2; i++) {
+    if (pathBasename(tokens[i]) !== shellName) continue;
+    if (tokens[i + 1] !== "-c") continue;
+    if (containsShellExpansion(tokens[i + 2])) return true;
+  }
+  return false;
+}
+
+function tokenizeShellCommand(command: string): string[] {
+  const tokens: string[] = [];
+  let current = "";
+  let quote: "'" | '"' | null = null;
+  let escaped = false;
+
+  for (const ch of command) {
+    if (escaped) {
+      current += ch;
+      escaped = false;
+      continue;
+    }
+    if (ch === "\\" && quote !== "'") {
+      escaped = true;
+      continue;
+    }
+    if ((ch === "'" || ch === '"') && quote === null) {
+      quote = ch;
+      continue;
+    }
+    if (quote === ch) {
+      quote = null;
+      continue;
+    }
+    if (quote === null && /\s|[|;&]/.test(ch)) {
+      if (current !== "") {
+        tokens.push(current);
+        current = "";
+      }
+      continue;
+    }
+    current += ch;
+  }
+  if (escaped) current += "\\";
+  if (current !== "") tokens.push(current);
+  return tokens;
+}
+
+function pathBasename(value: string): string {
+  return value.split("/").at(-1) ?? value;
+}
+
+function containsShellExpansion(script: string): boolean {
+  return /\$(?:[A-Za-z_][A-Za-z0-9_]*|\{[^}]+\}|\()/.test(script) || script.includes("`");
 }

--- a/packages/cost-guard/src/command-checker.ts
+++ b/packages/cost-guard/src/command-checker.ts
@@ -60,16 +60,20 @@ export function findCommandDenylistMatch(
     if (Array.isArray(value)) {
       const leaf = leafKey(fieldPath);
       const isCommandArray = COMMAND_LIKE_FIELDS.has(leaf) || leaf.startsWith("args");
+      // 個別要素を先に検査（具体的 index を優先報告）。
+      // 単一要素内に pattern が完全に含まれる場合は `args[N]` 形式で field を返す。
+      for (let i = 0; i < value.length; i++) {
+        const r = walk(value[i], `${fieldPath}[${i}]`);
+        if (r) return r;
+      }
+      // 個別要素では見つからなかった場合のみ、結合スキャンで要素を跨ぐ pattern を捕捉。
+      // 例: args: ["bash", "-c", "$VAR"] → joined "bash -c $VAR" → "bash -c $" にマッチ → field: "args"
       if (isCommandArray && value.every((item): item is string => typeof item === "string")) {
         for (const pattern of patterns) {
           if (containsCommandPatternInArgs(value, pattern)) {
             return { field: fieldPath, matchedPattern: pattern };
           }
         }
-      }
-      for (let i = 0; i < value.length; i++) {
-        const r = walk(value[i], `${fieldPath}[${i}]`);
-        if (r) return r;
       }
       return null;
     }

--- a/packages/cost-guard/src/command-checker.ts
+++ b/packages/cost-guard/src/command-checker.ts
@@ -58,6 +58,15 @@ export function findCommandDenylistMatch(
     visited.add(value as object);
 
     if (Array.isArray(value)) {
+      const leaf = leafKey(fieldPath);
+      const isCommandArray = COMMAND_LIKE_FIELDS.has(leaf) || leaf.startsWith("args");
+      if (isCommandArray && value.every((item): item is string => typeof item === "string")) {
+        for (const pattern of patterns) {
+          if (containsCommandPatternInArgs(value, pattern)) {
+            return { field: fieldPath, matchedPattern: pattern };
+          }
+        }
+      }
       for (let i = 0; i < value.length; i++) {
         const r = walk(value[i], `${fieldPath}[${i}]`);
         if (r) return r;
@@ -100,14 +109,28 @@ export function containsCommandPattern(command: string, pattern: string): boolea
   return false;
 }
 
+function containsCommandPatternInArgs(args: string[], pattern: string): boolean {
+  if (args.join(" ").includes(pattern)) return true;
+  if (pattern === "bash -c $" && hasShellCExpansionTokens(args, "bash")) return true;
+  if (pattern === "sh -c $" && hasShellCExpansionTokens(args, "sh")) return true;
+  return false;
+}
+
 function hasShellCExpansion(command: string, shellName: "bash" | "sh"): boolean {
-  const tokens = tokenizeShellCommand(command);
+  return hasShellCExpansionTokens(tokenizeShellCommand(command), shellName);
+}
+
+function hasShellCExpansionTokens(tokens: string[], shellName: "bash" | "sh"): boolean {
   for (let i = 0; i < tokens.length - 2; i++) {
     if (pathBasename(tokens[i]) !== shellName) continue;
-    if (tokens[i + 1] !== "-c") continue;
+    if (!isShellCommandOption(tokens[i + 1])) continue;
     if (containsShellExpansion(tokens[i + 2])) return true;
   }
   return false;
+}
+
+function isShellCommandOption(token: string): boolean {
+  return /^-[A-Za-z]*c[A-Za-z]*$/.test(token);
 }
 
 function tokenizeShellCommand(command: string): string[] {

--- a/packages/cost-guard/src/command-checker.ts
+++ b/packages/cost-guard/src/command-checker.ts
@@ -1,0 +1,99 @@
+/**
+ * Command denylist の AST 検査（軽量版）
+ *
+ * shell injection 経由で denyPaths 配下を読みに行く command パターンを捕捉する。
+ * tool params の command-like field（command / cmd / script / shell / args）に対して
+ * commandDenylist の各パターンが含まれているかを検査する。
+ *
+ * 既定パターン（contracts.md §9.1）：
+ * - "eval"       : eval ベースの動的実行
+ * - "bash -c $"  : bash -c $VAR 経由の path 隠蔽
+ * - "sh -c $"    : sh -c $VAR 経由の path 隠蔽
+ * - "<("         : process substitution
+ * - "$("         : command substitution
+ * - "`"          : backtick command substitution
+ *
+ * 検査方針：
+ * - command 文字列を空白 / `|` / `;` で粗く split し、各 token とその raw string で contains 判定
+ * - 全文 substring match と token-level match の OR を取る（false negative より false positive を許容）
+ * - false positive を避けるため、deny pattern は文字列単純 contains（正規表現ではない）
+ */
+
+export interface CommandCheckOptions {
+  commandDenylist: string[];
+}
+
+export interface CommandMatchResult {
+  field: string;
+  matchedPattern: string;
+}
+
+const COMMAND_LIKE_FIELDS = new Set(["command", "cmd", "script", "shell"]);
+
+/**
+ * tool params を再帰走査し、commandDenylist にマッチする command パターンを探す。
+ */
+export function findCommandDenylistMatch(
+  params: unknown,
+  options: CommandCheckOptions,
+): CommandMatchResult | null {
+  const patterns = options.commandDenylist.filter((s) => typeof s === "string" && s.length > 0);
+  if (patterns.length === 0) return null;
+  const visited = new WeakSet<object>();
+
+  function walk(value: unknown, fieldPath: string): CommandMatchResult | null {
+    if (typeof value === "string") {
+      const leaf = leafKey(fieldPath);
+      const isCommand = COMMAND_LIKE_FIELDS.has(leaf) || leaf.startsWith("args");
+      if (!isCommand) return null;
+      for (const pattern of patterns) {
+        if (containsCommandPattern(value, pattern)) {
+          return { field: fieldPath, matchedPattern: pattern };
+        }
+      }
+      return null;
+    }
+    if (typeof value !== "object" || value === null) return null;
+    if (visited.has(value as object)) return null;
+    visited.add(value as object);
+
+    if (Array.isArray(value)) {
+      for (let i = 0; i < value.length; i++) {
+        const r = walk(value[i], `${fieldPath}[${i}]`);
+        if (r) return r;
+      }
+      return null;
+    }
+    const entries = Object.entries(value as Record<string, unknown>);
+    for (const [k, v] of entries) {
+      const childField = fieldPath === "" ? k : `${fieldPath}.${k}`;
+      const r = walk(v, childField);
+      if (r) return r;
+    }
+    return null;
+  }
+
+  return walk(params, "");
+}
+
+function leafKey(fieldPath: string): string {
+  return (
+    fieldPath
+      .split(".")
+      .at(-1)
+      ?.replace(/\[\d+\]$/g, "")
+      .toLowerCase() ?? ""
+  );
+}
+
+/**
+ * command 文字列に deny pattern が含まれているか判定する。
+ *
+ * Phase 1 では正規表現ではなく文字列 contains で判定（false positive を許容しつつ、
+ * 設計書に明記された 6 パターンを確実に捕捉する）。
+ */
+export function containsCommandPattern(command: string, pattern: string): boolean {
+  // 完全 substring match
+  if (command.includes(pattern)) return true;
+  return false;
+}

--- a/packages/cost-guard/src/index.test.ts
+++ b/packages/cost-guard/src/index.test.ts
@@ -406,6 +406,24 @@ describe("tool_result_persist - sentinel boundary", () => {
     expect((result as any).message.content).toContain(SENTINEL_PREFIX);
   });
 
+  it("result.content 配列内の object は text 以外の巨大 field も byte 数に含める", () => {
+    const api = makeApi();
+    register(api as any);
+    const handler = api.hooks.get("tool_result_persist")!;
+    const result = handler(
+      {
+        toolId: "read",
+        toolCallId: "tcid_arr_raw",
+        result: {
+          content: [{ text: "ok", raw: "x".repeat(60_000) }],
+        },
+      },
+      {},
+    ) as ToolResultPersistResult;
+    expect((result as any).message).toBeDefined();
+    expect((result as any).message.content).toContain(SENTINEL_PREFIX);
+  });
+
   it("result.content 配列内の object に text が無い場合は JSON 化 byte 数で計算", () => {
     const api = makeApi();
     register(api as any);
@@ -785,7 +803,7 @@ describe("before_agent_run - 段 2 session token budget", () => {
     expect((result as any).reason).toBe("session_token_budget_exceeded");
   });
 
-  it("同一 sessionId の複数 turn 合計が sessionTokenBudget を超えた時点で block", () => {
+  it("同一 sessionId・同一 messages の再評価では履歴分を二重加算しない", () => {
     const api = makeApi({ perTurnPromptInputThreshold: 10_000, sessionTokenBudget: 90 });
     register(api as any);
     const handler = api.hooks.get("before_agent_run")!;
@@ -793,10 +811,40 @@ describe("before_agent_run - 段 2 session token budget", () => {
 
     const first = handler({ sessionId: "s1", prompt: "", messages }, {}) as BeforeAgentRunResult;
     const second = handler({ sessionId: "s1", prompt: "", messages }, {}) as BeforeAgentRunResult;
+    const third = handler({ sessionId: "s1", prompt: "", messages }, {}) as BeforeAgentRunResult;
 
     expect(first.outcome).toBe("pass");
-    expect(second.outcome).toBe("block");
-    expect((second as any).reason).toBe("session_token_budget_exceeded");
+    expect(second.outcome).toBe("pass");
+    expect(third.outcome).toBe("pass");
+  });
+
+  it("同一 sessionId で message が追加された場合だけ増分を sessionTokenBudget に加算", () => {
+    const api = makeApi({ perTurnPromptInputThreshold: 10_000, sessionTokenBudget: 90 });
+    register(api as any);
+    const handler = api.hooks.get("before_agent_run")!;
+    const firstMessages = [{ role: "user" as const, content: "x".repeat(180) }]; // 50 tokens
+    const secondMessages = [
+      ...firstMessages,
+      { role: "assistant" as const, content: "y".repeat(180) },
+    ];
+
+    const first = handler(
+      { sessionId: "s1", prompt: "", messages: firstMessages },
+      {},
+    ) as BeforeAgentRunResult;
+    const repeated = handler(
+      { sessionId: "s1", prompt: "", messages: firstMessages },
+      {},
+    ) as BeforeAgentRunResult;
+    const appended = handler(
+      { sessionId: "s1", prompt: "", messages: secondMessages },
+      {},
+    ) as BeforeAgentRunResult;
+
+    expect(first.outcome).toBe("pass");
+    expect(repeated.outcome).toBe("pass");
+    expect(appended.outcome).toBe("block");
+    expect((appended as any).reason).toBe("session_token_budget_exceeded");
   });
 
   it("messages が空でも prompt の複数 turn 合計が sessionTokenBudget を超えた時点で block", () => {

--- a/packages/cost-guard/src/index.test.ts
+++ b/packages/cost-guard/src/index.test.ts
@@ -779,6 +779,18 @@ describe("before_agent_run - 段 2 session token budget", () => {
     expect(result.outcome).toBe("pass");
   });
 
+  it("sessionTokenBudget ちょうど（500,000 token）は pass（境界は超過ではない）", () => {
+    const api = makeApi({ perTurnPromptInputThreshold: 10_000_000 });
+    register(api as any);
+    const handler = api.hooks.get("before_agent_run")!;
+    // user(1) + content(499_995) + tool_call_id(0) + overhead(4) = 500,000 token
+    const messages = [{ role: "user" as const, content: "x".repeat(1_999_980) }];
+
+    const result = handler({ sessionId: "s1", prompt: "", messages }, {}) as BeforeAgentRunResult;
+
+    expect(result.outcome).toBe("pass");
+  });
+
   it("sessionTokenBudget 超過は session_token_budget_exceeded で block", () => {
     const api = makeApi({ perTurnPromptInputThreshold: 10_000_000 }); // per-turn gate を緩めて段 2 を確認
     register(api as any);

--- a/packages/cost-guard/src/index.test.ts
+++ b/packages/cost-guard/src/index.test.ts
@@ -12,8 +12,9 @@
  */
 
 import { execFileSync } from "node:child_process";
-import { readFileSync } from "node:fs";
-import { dirname, resolve } from "node:path";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it, vi } from "vitest";
 import register, {
@@ -853,6 +854,31 @@ describe("before_agent_run - cleanup (transcript_pollution_cleanup)", () => {
     expect((result as any).messages[1].tool_call_id).toBe("tcid_p1");
   });
 
+  it("content parts array 内の denyPaths 参照も sentinel 置換", () => {
+    const api = makeApi();
+    register(api as any);
+    const handler = api.hooks.get("before_agent_run")!;
+    const messages = [
+      {
+        role: "tool" as const,
+        content: [
+          {
+            type: "text",
+            text: `Here is content from ${DENY}x.txt\n... raw transcript body ...`,
+          },
+        ],
+        tool_call_id: "tcid_parts",
+      },
+    ];
+    const result = handler(
+      { sessionId: "s1", prompt: "next turn", messages },
+      {},
+    ) as BeforeAgentRunResult;
+    expect(result.outcome).toBe("rewrite");
+    expect((result as any).messages[0].content).toContain(SENTINEL_PREFIX);
+    expect((result as any).messages[0].tool_call_id).toBe("tcid_parts");
+  });
+
   it("cleanupOnSessionStart=false では rewrite しない", () => {
     const api = makeApi({ cleanupOnSessionStart: false });
     register(api as any);
@@ -990,6 +1016,37 @@ describe("metric 発行（contracts.md §10.1 の 5 metric）", () => {
     expect(() => register(api as any)).not.toThrow();
     const handler = api.hooks.get("before_tool_call")!;
     expect(() => handler({ toolId: "read", params: { path: `${DENY}x.txt` } }, {})).not.toThrow();
+  });
+});
+
+describe("before_tool_call - hardlink traversal performance", () => {
+  it("default denyHardlinkTraversal=true でも無関係な既存 path の反復検査で巨大 deny directory を毎回走査しない", () => {
+    const tmpRoot = mkdtempSync(join(tmpdir(), "cost-guard-register-hardlink-perf-"));
+    try {
+      const denyDir = join(tmpRoot, "deny");
+      const allowedDir = join(tmpRoot, "allowed");
+      mkdirSync(denyDir);
+      mkdirSync(allowedDir);
+      for (let i = 0; i < 5000; i++) {
+        writeFileSync(join(denyDir, `f-${i.toString().padStart(5, "0")}.txt`), "x");
+      }
+      const unrelatedPath = join(allowedDir, "unrelated.txt");
+      writeFileSync(unrelatedPath, "public");
+
+      const api = makeApi({ denyPaths: [denyDir] });
+      register(api as any);
+      const handler = api.hooks.get("before_tool_call")!;
+
+      const start = Date.now();
+      for (let i = 0; i < 20; i++) {
+        const result = handler({ toolId: "read", params: { path: unrelatedPath } }, {});
+        expect(result).toEqual({});
+      }
+      const elapsed = Date.now() - start;
+      expect(elapsed).toBeLessThan(500);
+    } finally {
+      rmSync(tmpRoot, { recursive: true, force: true });
+    }
   });
 });
 

--- a/packages/cost-guard/src/index.test.ts
+++ b/packages/cost-guard/src/index.test.ts
@@ -313,6 +313,21 @@ describe("tool_result_persist - sentinel boundary", () => {
     expect((result as any).message.tool_call_id).toBe("tcid_preserve_me");
   });
 
+  it("event.tool_call_id の snake_case 入力も sentinel message に保持", () => {
+    const api = makeApi();
+    register(api as any);
+    const handler = api.hooks.get("tool_result_persist")!;
+    const result = handler(
+      {
+        toolId: "read",
+        tool_call_id: "tcid_x",
+        result: { content: "x".repeat(60_000) },
+      },
+      {},
+    ) as ToolResultPersistResult;
+    expect((result as any).message.tool_call_id).toBe("tcid_x");
+  });
+
   it("string 直結 result でも byte 数計算", () => {
     const api = makeApi();
     register(api as any);

--- a/packages/cost-guard/src/index.test.ts
+++ b/packages/cost-guard/src/index.test.ts
@@ -744,6 +744,20 @@ describe("before_agent_run - 段 2 session token budget", () => {
     expect((result as any).reason).toBe("session_token_budget_exceeded");
   });
 
+  it("同一 sessionId の複数 turn 合計が sessionTokenBudget を超えた時点で block", () => {
+    const api = makeApi({ perTurnPromptInputThreshold: 10_000, sessionTokenBudget: 90 });
+    register(api as any);
+    const handler = api.hooks.get("before_agent_run")!;
+    const messages = [{ role: "user" as const, content: "x".repeat(180) }]; // 50 tokens
+
+    const first = handler({ sessionId: "s1", prompt: "", messages }, {}) as BeforeAgentRunResult;
+    const second = handler({ sessionId: "s1", prompt: "", messages }, {}) as BeforeAgentRunResult;
+
+    expect(first.outcome).toBe("pass");
+    expect(second.outcome).toBe("block");
+    expect((second as any).reason).toBe("session_token_budget_exceeded");
+  });
+
   it("block 時に metric `cost_guard.session_budget_exceeded` を発行", () => {
     const api = makeApi({ perTurnPromptInputThreshold: 10_000_000 });
     register(api as any);

--- a/packages/cost-guard/src/index.test.ts
+++ b/packages/cost-guard/src/index.test.ts
@@ -818,6 +818,23 @@ describe("before_agent_run - 段 2 session token budget", () => {
     expect(third.outcome).toBe("pass");
   });
 
+  it("同一 messages の再評価では prompt 分だけを追加で累積する", () => {
+    const api = makeApi({ perTurnPromptInputThreshold: 10_000, sessionTokenBudget: 100 });
+    register(api as any);
+    const handler = api.hooks.get("before_agent_run")!;
+    const messages = [{ role: "user" as const, content: "x".repeat(180) }]; // 50 tokens
+    const prompt = "p".repeat(80); // 20 tokens
+
+    const first = handler({ sessionId: "s1", prompt, messages }, {}) as BeforeAgentRunResult;
+    const second = handler({ sessionId: "s1", prompt, messages }, {}) as BeforeAgentRunResult;
+    const third = handler({ sessionId: "s1", prompt, messages }, {}) as BeforeAgentRunResult;
+
+    expect(first.outcome).toBe("pass");
+    expect(second.outcome).toBe("pass");
+    expect(third.outcome).toBe("block");
+    expect((third as any).reason).toBe("session_token_budget_exceeded");
+  });
+
   it("同一 sessionId で message が追加された場合だけ増分を sessionTokenBudget に加算", () => {
     const api = makeApi({ perTurnPromptInputThreshold: 10_000, sessionTokenBudget: 90 });
     register(api as any);

--- a/packages/cost-guard/src/index.test.ts
+++ b/packages/cost-guard/src/index.test.ts
@@ -1,0 +1,935 @@
+/**
+ * cost-guard index.ts（hook 登録 + 3 hook 実装）の単体テスト
+ *
+ * 検証点：
+ * - register(api) で 3 hook が登録される
+ * - configSchema のデフォルト値（contracts.md §9.1）が反映される
+ * - before_tool_call：denyPaths block / allowlist 例外 / commandDenylist / observe mode
+ * - tool_result_persist：rewriteThresholdBytes 境界値 / sentinel 置換 / tool_call_id 保持
+ * - before_agent_run：suspendAgent / 段 1 per-turn gate / 段 2 session budget / cleanup
+ * - metric 発行（cost_guard.*）
+ * - npm pack に OpenClaw extension が含まれる
+ */
+
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it, vi } from "vitest";
+import register, {
+  type BeforeAgentRunResult,
+  type BeforeToolCallResult,
+  SENTINEL_PREFIX,
+  type ToolResultPersistResult,
+} from "./index.js";
+
+type HookHandler = (event: unknown, ctx: unknown) => unknown;
+
+interface MockApi {
+  pluginConfig: Record<string, unknown>;
+  logger: {
+    info: ReturnType<typeof vi.fn>;
+    warn: ReturnType<typeof vi.fn>;
+    error: ReturnType<typeof vi.fn>;
+  };
+  metrics: {
+    incrementCounter: ReturnType<typeof vi.fn>;
+    setGauge: ReturnType<typeof vi.fn>;
+  };
+  on: ReturnType<typeof vi.fn>;
+  hooks: Map<string, HookHandler>;
+}
+
+function makeApi(config: Record<string, unknown> = {}): MockApi {
+  const hooks = new Map<string, HookHandler>();
+  return {
+    pluginConfig: config,
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    metrics: { incrementCounter: vi.fn(), setGauge: vi.fn() },
+    on: vi.fn((event: string, handler: HookHandler) => {
+      hooks.set(event, handler);
+    }),
+    hooks,
+  };
+}
+
+const DENY = "/data/workspace/zoom_transcribe/";
+
+// ----------------------------------------------------------------------------
+// register
+// ----------------------------------------------------------------------------
+
+describe("register", () => {
+  it("3 hook（before_tool_call / tool_result_persist / before_agent_run）を登録", () => {
+    const api = makeApi();
+    register(api as any);
+    expect(api.hooks.has("before_tool_call")).toBe(true);
+    expect(api.hooks.has("tool_result_persist")).toBe(true);
+    expect(api.hooks.has("before_agent_run")).toBe(true);
+  });
+
+  it("起動時に register log を出力", () => {
+    const api = makeApi();
+    register(api as any);
+    expect(api.logger.info).toHaveBeenCalledWith(
+      expect.stringContaining("[cost-guard] registered"),
+    );
+  });
+
+  it("既定 config（blockMode=block / denyPaths / allowlist）が反映される", () => {
+    const api = makeApi();
+    register(api as any);
+    const registerLog = api.logger.info.mock.calls[0][0] as string;
+    expect(registerLog).toContain("blockMode=block");
+    expect(registerLog).toContain("/data/workspace/zoom_transcribe");
+  });
+});
+
+// ----------------------------------------------------------------------------
+// before_tool_call: denyPaths + allowlist + commandDenylist
+// ----------------------------------------------------------------------------
+
+describe("before_tool_call - denyPaths block", () => {
+  it("blockMode=block で denyPaths 配下への generic read を block", () => {
+    const api = makeApi();
+    register(api as any);
+    const handler = api.hooks.get("before_tool_call")!;
+    const result = handler(
+      { toolId: "read", params: { path: `${DENY}transcript.txt` } },
+      {},
+    ) as BeforeToolCallResult;
+    expect((result as any).block).toBe(true);
+    expect((result as any).blockReason).toBe("deny_path_match");
+    expect((result as any).message).toContain("transcript-analyzer");
+  });
+
+  it("blockMode=block で denyPaths 配下への generic exec を block", () => {
+    const api = makeApi();
+    register(api as any);
+    const handler = api.hooks.get("before_tool_call")!;
+    const result = handler(
+      { toolId: "exec", params: { command: `cat ${DENY}transcript.txt` } },
+      {},
+    ) as BeforeToolCallResult;
+    expect((result as any).block).toBe(true);
+  });
+
+  it("allowlist 内 tool（transcript-analyzer.list_transcripts）は通過", () => {
+    const api = makeApi();
+    register(api as any);
+    const handler = api.hooks.get("before_tool_call")!;
+    const result = handler(
+      {
+        toolId: "transcript-analyzer.list_transcripts",
+        params: { path: `${DENY}transcript.txt` },
+      },
+      {},
+    ) as BeforeToolCallResult;
+    expect(result).toEqual({});
+  });
+
+  it("allowlist 内 tool（transcript-analyzer.search_transcripts）は通過", () => {
+    const api = makeApi();
+    register(api as any);
+    const handler = api.hooks.get("before_tool_call")!;
+    const result = handler(
+      {
+        toolId: "transcript-analyzer.search_transcripts",
+        params: { query: "hello", dir: DENY },
+      },
+      {},
+    ) as BeforeToolCallResult;
+    expect(result).toEqual({});
+  });
+
+  it("allowlist 内 tool（transcript-analyzer.analyze_transcript）は通過", () => {
+    const api = makeApi();
+    register(api as any);
+    const handler = api.hooks.get("before_tool_call")!;
+    const result = handler(
+      {
+        toolId: "transcript-analyzer.analyze_transcript",
+        params: { transcript_id: "xx", query: "hello" },
+      },
+      {},
+    ) as BeforeToolCallResult;
+    expect(result).toEqual({});
+  });
+
+  it("denyPaths 外の path は通過", () => {
+    const api = makeApi();
+    register(api as any);
+    const handler = api.hooks.get("before_tool_call")!;
+    const result = handler({ toolId: "read", params: { path: "/data/workspace/note.md" } }, {});
+    expect(result).toEqual({});
+  });
+
+  it("blockMode=observe では block しないが metric は発行", () => {
+    const api = makeApi({ blockMode: "observe" });
+    register(api as any);
+    const handler = api.hooks.get("before_tool_call")!;
+    const result = handler({ toolId: "read", params: { path: `${DENY}transcript.txt` } }, {});
+    expect(result).toEqual({});
+    expect(api.metrics.incrementCounter).toHaveBeenCalledWith(
+      "cost_guard.tool_call_blocked",
+      expect.objectContaining({ blockReason: "deny_path_match" }),
+    );
+  });
+
+  it("block 時に metric `cost_guard.tool_call_blocked` を発行", () => {
+    const api = makeApi();
+    register(api as any);
+    const handler = api.hooks.get("before_tool_call")!;
+    handler({ toolId: "read", params: { path: `${DENY}x.txt` } }, {});
+    expect(api.metrics.incrementCounter).toHaveBeenCalledWith(
+      "cost_guard.tool_call_blocked",
+      expect.objectContaining({ blockReason: "deny_path_match", toolId: "read" }),
+    );
+  });
+
+  it("block 時に warn log を出力", () => {
+    const api = makeApi();
+    register(api as any);
+    const handler = api.hooks.get("before_tool_call")!;
+    api.logger.warn.mockClear();
+    handler({ toolId: "read", params: { path: `${DENY}x.txt` } }, {});
+    const warnCalls = api.logger.warn.mock.calls.map((c: unknown[]) => c[0] as string);
+    expect(warnCalls.some((m) => m.includes("BLOCKED"))).toBe(true);
+  });
+});
+
+describe("before_tool_call - commandDenylist", () => {
+  it("eval を含む command を block", () => {
+    const api = makeApi();
+    register(api as any);
+    const handler = api.hooks.get("before_tool_call")!;
+    const result = handler(
+      { toolId: "exec", params: { command: "eval $(cat /tmp/x.sh)" } },
+      {},
+    ) as BeforeToolCallResult;
+    expect((result as any).block).toBe(true);
+    expect((result as any).blockReason).toBe("command_denylist_match");
+  });
+
+  it("commandDenylist match は denyPaths match より優先", () => {
+    const api = makeApi();
+    register(api as any);
+    const handler = api.hooks.get("before_tool_call")!;
+    const result = handler(
+      { toolId: "exec", params: { command: `eval ${DENY}x.txt` } },
+      {},
+    ) as BeforeToolCallResult;
+    expect((result as any).blockReason).toBe("command_denylist_match");
+  });
+
+  it("空の commandDenylist では何も block しない", () => {
+    const api = makeApi({ commandDenylist: [] });
+    register(api as any);
+    const handler = api.hooks.get("before_tool_call")!;
+    const result = handler({ toolId: "exec", params: { command: "eval $(cat /tmp/x.sh)" } }, {});
+    expect(result).toEqual({});
+  });
+});
+
+// ----------------------------------------------------------------------------
+// tool_result_persist: sentinel rewrite boundary
+// ----------------------------------------------------------------------------
+
+describe("tool_result_persist - sentinel boundary", () => {
+  it("rewriteThresholdBytes 未満（49,999 byte）は置換しない", () => {
+    const api = makeApi();
+    register(api as any);
+    const handler = api.hooks.get("tool_result_persist")!;
+    const result = handler(
+      {
+        toolId: "read",
+        toolCallId: "tcid_001",
+        result: { content: "x".repeat(49_999) },
+      },
+      {},
+    ) as ToolResultPersistResult;
+    expect(result).toEqual({});
+  });
+
+  it("rewriteThresholdBytes ちょうど（50,000 byte）は置換しない（境界は超過ではない）", () => {
+    const api = makeApi();
+    register(api as any);
+    const handler = api.hooks.get("tool_result_persist")!;
+    const result = handler(
+      {
+        toolId: "read",
+        toolCallId: "tcid_002",
+        result: { content: "x".repeat(50_000) },
+      },
+      {},
+    ) as ToolResultPersistResult;
+    expect(result).toEqual({});
+  });
+
+  it("rewriteThresholdBytes 超過（50,001 byte）は sentinel 置換", () => {
+    const api = makeApi();
+    register(api as any);
+    const handler = api.hooks.get("tool_result_persist")!;
+    const result = handler(
+      {
+        toolId: "read",
+        toolCallId: "tcid_003",
+        result: { content: "x".repeat(50_001) },
+      },
+      {},
+    ) as ToolResultPersistResult;
+    expect((result as any).message).toBeDefined();
+    expect((result as any).message.role).toBe("tool");
+    expect((result as any).message.tool_call_id).toBe("tcid_003");
+    expect((result as any).message.content).toContain(SENTINEL_PREFIX);
+    expect((result as any).message.content).toContain("50001 bytes");
+  });
+
+  it("sentinel 置換時に tool_call_id を保持", () => {
+    const api = makeApi();
+    register(api as any);
+    const handler = api.hooks.get("tool_result_persist")!;
+    const result = handler(
+      {
+        toolId: "read",
+        toolCallId: "tcid_preserve_me",
+        result: { content: "x".repeat(60_000) },
+      },
+      {},
+    ) as ToolResultPersistResult;
+    expect((result as any).message.tool_call_id).toBe("tcid_preserve_me");
+  });
+
+  it("string 直結 result でも byte 数計算", () => {
+    const api = makeApi();
+    register(api as any);
+    const handler = api.hooks.get("tool_result_persist")!;
+    const result = handler(
+      { toolId: "read", toolCallId: "tcid_str", result: "x".repeat(60_000) },
+      {},
+    ) as ToolResultPersistResult;
+    expect((result as any).message).toBeDefined();
+  });
+
+  it("rewriteThresholdBytes をカスタム値（1000）に設定", () => {
+    const api = makeApi({ rewriteThresholdBytes: 1000 });
+    register(api as any);
+    const handler = api.hooks.get("tool_result_persist")!;
+    const result = handler(
+      { toolId: "read", toolCallId: "tcid_x", result: { content: "x".repeat(1001) } },
+      {},
+    ) as ToolResultPersistResult;
+    expect((result as any).message).toBeDefined();
+  });
+
+  it("置換時に metric `cost_guard.tool_result_rewritten` を発行", () => {
+    const api = makeApi();
+    register(api as any);
+    const handler = api.hooks.get("tool_result_persist")!;
+    handler({ toolId: "read", toolCallId: "tcid_m", result: { content: "x".repeat(60_000) } }, {});
+    expect(api.metrics.incrementCounter).toHaveBeenCalledWith(
+      "cost_guard.tool_result_rewritten",
+      expect.objectContaining({ toolId: "read" }),
+    );
+  });
+
+  it("blockMode=observe では metric は発行するが置換しない", () => {
+    const api = makeApi({ blockMode: "observe" });
+    register(api as any);
+    const handler = api.hooks.get("tool_result_persist")!;
+    const result = handler(
+      { toolId: "read", toolCallId: "tcid_obs", result: { content: "x".repeat(60_000) } },
+      {},
+    );
+    expect(result).toEqual({});
+    expect(api.metrics.incrementCounter).toHaveBeenCalledWith(
+      "cost_guard.tool_result_rewritten",
+      expect.anything(),
+    );
+  });
+
+  it("result.content が配列（[{text: '...'}, ...]）形式でも byte 数を合算", () => {
+    const api = makeApi();
+    register(api as any);
+    const handler = api.hooks.get("tool_result_persist")!;
+    const result = handler(
+      {
+        toolId: "read",
+        toolCallId: "tcid_arr",
+        result: {
+          content: [{ text: "x".repeat(30_000) }, { text: "y".repeat(30_000) }],
+        },
+      },
+      {},
+    ) as ToolResultPersistResult;
+    expect((result as any).message).toBeDefined();
+    expect((result as any).message.content).toContain(SENTINEL_PREFIX);
+  });
+
+  it("result.content 配列内の object に text が無い場合は JSON 化 byte 数で計算", () => {
+    const api = makeApi();
+    register(api as any);
+    const handler = api.hooks.get("tool_result_persist")!;
+    const result = handler(
+      {
+        toolId: "read",
+        toolCallId: "tcid_arr2",
+        result: { content: [{ blob: "x".repeat(100_000) }] },
+      },
+      {},
+    ) as ToolResultPersistResult;
+    expect((result as any).message).toBeDefined();
+  });
+
+  it("result.content 配列内の非 object 要素も byte 数で計算", () => {
+    const api = makeApi({ rewriteThresholdBytes: 100 });
+    register(api as any);
+    const handler = api.hooks.get("tool_result_persist")!;
+    const result = handler(
+      {
+        toolId: "read",
+        toolCallId: "tcid_arr3",
+        result: { content: ["text".repeat(50), 12345, true] },
+      },
+      {},
+    ) as ToolResultPersistResult;
+    expect((result as any).message).toBeDefined();
+  });
+
+  it("result が undefined / null の場合は 0 byte 扱いで置換しない", () => {
+    const api = makeApi();
+    register(api as any);
+    const handler = api.hooks.get("tool_result_persist")!;
+    const result1 = handler({ toolId: "read", toolCallId: "n1", result: null }, {});
+    const result2 = handler({ toolId: "read", toolCallId: "n2", result: undefined }, {});
+    expect(result1).toEqual({});
+    expect(result2).toEqual({});
+  });
+
+  it("result が plain object（content なし）の場合は JSON 化 byte 数で計算", () => {
+    const api = makeApi({ rewriteThresholdBytes: 50 });
+    register(api as any);
+    const handler = api.hooks.get("tool_result_persist")!;
+    const result = handler(
+      {
+        toolId: "read",
+        toolCallId: "tcid_plain",
+        result: { other: "x".repeat(200) },
+      },
+      {},
+    ) as ToolResultPersistResult;
+    expect((result as any).message).toBeDefined();
+  });
+});
+
+describe("verbose mode（safePreview / truncateUtf8）", () => {
+  it("verbose=true で tool params の概略を log に含める", () => {
+    const api = makeApi({ verbose: true });
+    register(api as any);
+    const handler = api.hooks.get("before_tool_call")!;
+    api.logger.info.mockClear();
+    handler({ toolId: "read", params: { path: "/data/workspace/note.md" } }, {});
+    const infoCalls = api.logger.info.mock.calls.map((c: unknown[]) => c[0] as string);
+    expect(infoCalls.some((m) => m.includes("params_head="))).toBe(true);
+  });
+
+  it("verbose=true で巨大 params を 200 byte で切り詰める", () => {
+    const api = makeApi({ verbose: true });
+    register(api as any);
+    const handler = api.hooks.get("before_tool_call")!;
+    api.logger.info.mockClear();
+    handler({ toolId: "read", params: { content: "x".repeat(1000) } }, {});
+    const infoCalls = api.logger.info.mock.calls.map((c: unknown[]) => c[0] as string);
+    const headLog = infoCalls.find((m) => m.includes("params_head="));
+    expect(headLog).toBeDefined();
+    expect(headLog!.length).toBeLessThan(500);
+  });
+
+  it("verbose=true で undefined params も `(empty)` で扱う", () => {
+    const api = makeApi({ verbose: true });
+    register(api as any);
+    const handler = api.hooks.get("before_tool_call")!;
+    api.logger.info.mockClear();
+    handler({ toolId: "read", params: undefined }, {});
+    const infoCalls = api.logger.info.mock.calls.map((c: unknown[]) => c[0] as string);
+    expect(infoCalls.some((m) => m.includes('params_head="(empty)"'))).toBe(true);
+  });
+
+  it("logging=false のときは log を出さない", () => {
+    const api = makeApi({ logging: false });
+    register(api as any);
+    const handler = api.hooks.get("before_tool_call")!;
+    api.logger.info.mockClear();
+    handler({ toolId: "read", params: { path: "/data/workspace/note.md" } }, {});
+    // registered log は出たが、handler 内の log は出ない
+    const handlerLogs = api.logger.info.mock.calls.filter((c: unknown[]) =>
+      (c[0] as string).includes("before_tool_call"),
+    );
+    expect(handlerLogs).toHaveLength(0);
+  });
+});
+
+describe("config 解決ロジック", () => {
+  it("不正な blockMode 値は既定の `block` にフォールバック", () => {
+    const api = makeApi({ blockMode: "invalid" as any });
+    register(api as any);
+    const registerLog = api.logger.info.mock.calls[0][0] as string;
+    expect(registerLog).toContain("blockMode=block");
+  });
+
+  it("負の rewriteThresholdBytes は既定値にフォールバック", () => {
+    const api = makeApi({ rewriteThresholdBytes: -100 });
+    register(api as any);
+    const registerLog = api.logger.info.mock.calls[0][0] as string;
+    expect(registerLog).toContain("rewrite=50000b");
+  });
+
+  it("非 array の denyPaths は既定値にフォールバック", () => {
+    const api = makeApi({ denyPaths: "not-array" as any });
+    register(api as any);
+    const registerLog = api.logger.info.mock.calls[0][0] as string;
+    expect(registerLog).toContain("/data/workspace/zoom_transcribe");
+  });
+
+  it("null pluginConfig も既定値で起動", () => {
+    const api = makeApi();
+    (api as any).pluginConfig = undefined;
+    expect(() => register(api as any)).not.toThrow();
+  });
+});
+
+describe("session state 累積（cumulative budget tracking）", () => {
+  it("同一 session で max(累積) を保持（後続呼び出しで小さい messages でも budget 超過状態を維持）", () => {
+    const api = makeApi({ perTurnPromptInputThreshold: 10_000_000 });
+    register(api as any);
+    const handler = api.hooks.get("before_agent_run")!;
+    // 第 1 turn: messages が budget を超える
+    handler(
+      {
+        sessionId: "session_sticky",
+        prompt: "",
+        messages: [{ role: "user", content: "x".repeat(2_500_000) }],
+      },
+      {},
+    );
+    // 第 2 turn: messages を小さくしても session 状態は維持される
+    const result = handler(
+      {
+        sessionId: "session_sticky",
+        prompt: "",
+        messages: [{ role: "user", content: "small" }],
+      },
+      {},
+    ) as BeforeAgentRunResult;
+    expect(result.outcome).toBe("block");
+    expect((result as any).reason).toBe("session_token_budget_exceeded");
+  });
+
+  it("別 session ID は累積を共有しない", () => {
+    const api = makeApi({ perTurnPromptInputThreshold: 10_000_000 });
+    register(api as any);
+    const handler = api.hooks.get("before_agent_run")!;
+    handler(
+      {
+        sessionId: "session_A",
+        prompt: "",
+        messages: [{ role: "user", content: "x".repeat(2_500_000) }],
+      },
+      {},
+    );
+    const result = handler(
+      {
+        sessionId: "session_B",
+        prompt: "",
+        messages: [{ role: "user", content: "small" }],
+      },
+      {},
+    ) as BeforeAgentRunResult;
+    expect(result.outcome).toBe("pass");
+  });
+
+  it("sessionId 未指定時は channelId / accountId / 'default' に fallback", () => {
+    const api = makeApi();
+    register(api as any);
+    const handler = api.hooks.get("before_agent_run")!;
+    const result1 = handler({ channelId: "C1", prompt: "", messages: [] }, {});
+    const result2 = handler({ accountId: "U1", prompt: "", messages: [] }, {});
+    const result3 = handler({ prompt: "", messages: [] }, {});
+    expect((result1 as BeforeAgentRunResult).outcome).toBe("pass");
+    expect((result2 as BeforeAgentRunResult).outcome).toBe("pass");
+    expect((result3 as BeforeAgentRunResult).outcome).toBe("pass");
+  });
+});
+
+describe("before_tool_call - block reason variants", () => {
+  it("toolId 未指定時は (unknown) で表示", () => {
+    const api = makeApi();
+    register(api as any);
+    const handler = api.hooks.get("before_tool_call")!;
+    const result = handler({ params: { path: `${DENY}x.txt` } }, {}) as BeforeToolCallResult;
+    expect((result as any).block).toBe(true);
+  });
+
+  it("toolName のみ指定（toolId なし）でも動作", () => {
+    const api = makeApi();
+    register(api as any);
+    const handler = api.hooks.get("before_tool_call")!;
+    const result = handler(
+      { toolName: "read", params: { path: `${DENY}x.txt` } },
+      {},
+    ) as BeforeToolCallResult;
+    expect((result as any).block).toBe(true);
+  });
+});
+
+// ----------------------------------------------------------------------------
+// before_agent_run: suspendAgent / 段 1 per-turn / 段 2 session / cleanup
+// ----------------------------------------------------------------------------
+
+describe("before_agent_run - suspendAgent (rollback Mode A)", () => {
+  it("suspendAgent=true で agent run 自体を block", () => {
+    const api = makeApi({ suspendAgent: true });
+    register(api as any);
+    const handler = api.hooks.get("before_agent_run")!;
+    const result = handler(
+      { sessionId: "s1", prompt: "hi", messages: [] },
+      {},
+    ) as BeforeAgentRunResult;
+    expect(result.outcome).toBe("block");
+    expect((result as any).reason).toBe("agent_suspended");
+  });
+
+  it("suspendAgent=false（既定）では block しない", () => {
+    const api = makeApi();
+    register(api as any);
+    const handler = api.hooks.get("before_agent_run")!;
+    const result = handler(
+      { sessionId: "s2", prompt: "hi", messages: [] },
+      {},
+    ) as BeforeAgentRunResult;
+    expect(result.outcome).toBe("pass");
+  });
+});
+
+describe("before_agent_run - 段 1 per-turn input gate", () => {
+  it("perTurnPromptInputThreshold 未満（49,999 token）は pass", () => {
+    const api = makeApi();
+    register(api as any);
+    const handler = api.hooks.get("before_agent_run")!;
+    const prompt = "x".repeat(199_996); // 49,999 tokens
+    const result = handler({ sessionId: "s1", prompt, messages: [] }, {}) as BeforeAgentRunResult;
+    expect(result.outcome).toBe("pass");
+  });
+
+  it("perTurnPromptInputThreshold ちょうど（50,000 token）は pass（境界は超過ではない）", () => {
+    const api = makeApi();
+    register(api as any);
+    const handler = api.hooks.get("before_agent_run")!;
+    const prompt = "x".repeat(200_000); // 50,000 tokens
+    const result = handler({ sessionId: "s1", prompt, messages: [] }, {}) as BeforeAgentRunResult;
+    expect(result.outcome).toBe("pass");
+  });
+
+  it("perTurnPromptInputThreshold 超過（50,001 token）は block", () => {
+    const api = makeApi();
+    register(api as any);
+    const handler = api.hooks.get("before_agent_run")!;
+    const prompt = "x".repeat(200_004); // 50,001 tokens
+    const result = handler({ sessionId: "s1", prompt, messages: [] }, {}) as BeforeAgentRunResult;
+    expect(result.outcome).toBe("block");
+    expect((result as any).reason).toBe("per_turn_input_too_large");
+    expect((result as any).message).toContain("入力サイズ");
+  });
+
+  it("block 時に metric `cost_guard.per_turn_input_blocked` を発行", () => {
+    const api = makeApi();
+    register(api as any);
+    const handler = api.hooks.get("before_agent_run")!;
+    handler({ sessionId: "s1", prompt: "x".repeat(300_000), messages: [] }, {});
+    expect(api.metrics.incrementCounter).toHaveBeenCalledWith(
+      "cost_guard.per_turn_input_blocked",
+      expect.anything(),
+    );
+  });
+
+  it("blockMode=observe では per-turn gate でも block しない", () => {
+    const api = makeApi({ blockMode: "observe" });
+    register(api as any);
+    const handler = api.hooks.get("before_agent_run")!;
+    const result = handler(
+      { sessionId: "s1", prompt: "x".repeat(300_000), messages: [] },
+      {},
+    ) as BeforeAgentRunResult;
+    expect(result.outcome).toBe("pass");
+  });
+});
+
+describe("before_agent_run - 段 2 session token budget", () => {
+  it("sessionTokenBudget 未満（499,994 token）は pass", () => {
+    // 段 2 単独を検証するため per-turn gate を緩める（大きい messages は per-turn gate を必ず超える）
+    const api = makeApi({ perTurnPromptInputThreshold: 10_000_000 });
+    register(api as any);
+    const handler = api.hooks.get("before_agent_run")!;
+    // user(1) + content(499_988) + tool_call_id(0) + overhead(4) = 499_993 token < 500_000 budget
+    const messages = [{ role: "user" as const, content: "x".repeat(1_999_952) }];
+    const result = handler({ sessionId: "s1", prompt: "", messages }, {}) as BeforeAgentRunResult;
+    expect(result.outcome).toBe("pass");
+  });
+
+  it("sessionTokenBudget 超過は session_token_budget_exceeded で block", () => {
+    const api = makeApi({ perTurnPromptInputThreshold: 10_000_000 }); // per-turn gate を緩めて段 2 を確認
+    register(api as any);
+    const handler = api.hooks.get("before_agent_run")!;
+    const messages = [{ role: "user" as const, content: "x".repeat(2_005_000) }]; // > 500_000 tokens
+    const result = handler({ sessionId: "s1", prompt: "", messages }, {}) as BeforeAgentRunResult;
+    expect(result.outcome).toBe("block");
+    expect((result as any).reason).toBe("session_token_budget_exceeded");
+  });
+
+  it("block 時に metric `cost_guard.session_budget_exceeded` を発行", () => {
+    const api = makeApi({ perTurnPromptInputThreshold: 10_000_000 });
+    register(api as any);
+    const handler = api.hooks.get("before_agent_run")!;
+    handler(
+      { sessionId: "s1", prompt: "", messages: [{ role: "user", content: "x".repeat(2_500_000) }] },
+      {},
+    );
+    expect(api.metrics.incrementCounter).toHaveBeenCalledWith(
+      "cost_guard.session_budget_exceeded",
+      expect.anything(),
+    );
+  });
+});
+
+describe("before_agent_run - cleanup (transcript_pollution_cleanup)", () => {
+  it("cleanupOnSessionStart=true で過去 messages の denyPaths 参照を sentinel 置換", () => {
+    const api = makeApi();
+    register(api as any);
+    const handler = api.hooks.get("before_agent_run")!;
+    const messages = [
+      { role: "user" as const, content: "please read" },
+      {
+        role: "tool" as const,
+        content: `Here is content from ${DENY}transcript.txt\n... raw transcript body ...`,
+        tool_call_id: "tcid_p1",
+      },
+    ];
+    const result = handler(
+      { sessionId: "s1", prompt: "next turn", messages },
+      {},
+    ) as BeforeAgentRunResult;
+    expect(result.outcome).toBe("rewrite");
+    expect((result as any).reason).toBe("transcript_pollution_cleanup");
+    expect((result as any).messages[1].content).toContain(SENTINEL_PREFIX);
+    expect((result as any).messages[1].role).toBe("tool");
+    expect((result as any).messages[1].tool_call_id).toBe("tcid_p1");
+  });
+
+  it("cleanupOnSessionStart=false では rewrite しない", () => {
+    const api = makeApi({ cleanupOnSessionStart: false });
+    register(api as any);
+    const handler = api.hooks.get("before_agent_run")!;
+    const messages = [{ role: "tool" as const, content: `${DENY}x.txt`, tool_call_id: "tcid_x" }];
+    const result = handler(
+      { sessionId: "s1", prompt: "next", messages },
+      {},
+    ) as BeforeAgentRunResult;
+    expect(result.outcome).toBe("pass");
+  });
+
+  it("既に sentinel 化されている message は再置換しない", () => {
+    const api = makeApi();
+    register(api as any);
+    const handler = api.hooks.get("before_agent_run")!;
+    const messages = [
+      {
+        role: "tool" as const,
+        content: `${SENTINEL_PREFIX} (50001 bytes). Use analyze_transcript or specific tool to access content.`,
+        tool_call_id: "tcid_already",
+      },
+    ];
+    const result = handler(
+      { sessionId: "s1", prompt: "next", messages },
+      {},
+    ) as BeforeAgentRunResult;
+    // sentinel は denyPaths を含まないので rewrite しない（pass）
+    expect(result.outcome).toBe("pass");
+  });
+
+  it("非 tool role の message は cleanup 対象外", () => {
+    const api = makeApi();
+    register(api as any);
+    const handler = api.hooks.get("before_agent_run")!;
+    const messages = [
+      { role: "user" as const, content: `please read ${DENY}x.txt` },
+      { role: "assistant" as const, content: "ok" },
+    ];
+    const result = handler(
+      { sessionId: "s1", prompt: "next", messages },
+      {},
+    ) as BeforeAgentRunResult;
+    expect(result.outcome).toBe("pass");
+  });
+
+  it("cleanup 時に metric `cost_guard.transcript_pollution_detected` を発行", () => {
+    const api = makeApi();
+    register(api as any);
+    const handler = api.hooks.get("before_agent_run")!;
+    const messages = [
+      { role: "tool" as const, content: `${DENY}x.txt content`, tool_call_id: "tcid_m" },
+    ];
+    handler({ sessionId: "s1", prompt: "next", messages }, {});
+    expect(api.metrics.incrementCounter).toHaveBeenCalledWith(
+      "cost_guard.transcript_pollution_detected",
+      expect.anything(),
+    );
+  });
+});
+
+// ----------------------------------------------------------------------------
+// metric 発行の総合確認
+// ----------------------------------------------------------------------------
+
+describe("metric 発行（contracts.md §10.1 の 5 metric）", () => {
+  it("`cost_guard.tool_call_blocked` を発行", () => {
+    const api = makeApi();
+    register(api as any);
+    const handler = api.hooks.get("before_tool_call")!;
+    handler({ toolId: "read", params: { path: `${DENY}x.txt` } }, {});
+    expect(api.metrics.incrementCounter).toHaveBeenCalledWith(
+      "cost_guard.tool_call_blocked",
+      expect.anything(),
+    );
+  });
+
+  it("`cost_guard.tool_result_rewritten` を発行", () => {
+    const api = makeApi();
+    register(api as any);
+    const handler = api.hooks.get("tool_result_persist")!;
+    handler({ toolId: "read", toolCallId: "tcid_a", result: { content: "x".repeat(60_000) } }, {});
+    expect(api.metrics.incrementCounter).toHaveBeenCalledWith(
+      "cost_guard.tool_result_rewritten",
+      expect.anything(),
+    );
+  });
+
+  it("`cost_guard.per_turn_input_blocked` を発行", () => {
+    const api = makeApi();
+    register(api as any);
+    const handler = api.hooks.get("before_agent_run")!;
+    handler({ sessionId: "s1", prompt: "x".repeat(300_000), messages: [] }, {});
+    expect(api.metrics.incrementCounter).toHaveBeenCalledWith(
+      "cost_guard.per_turn_input_blocked",
+      expect.anything(),
+    );
+  });
+
+  it("`cost_guard.session_budget_exceeded` を発行", () => {
+    const api = makeApi({ perTurnPromptInputThreshold: 10_000_000 });
+    register(api as any);
+    const handler = api.hooks.get("before_agent_run")!;
+    handler(
+      { sessionId: "s1", prompt: "", messages: [{ role: "user", content: "x".repeat(2_500_000) }] },
+      {},
+    );
+    expect(api.metrics.incrementCounter).toHaveBeenCalledWith(
+      "cost_guard.session_budget_exceeded",
+      expect.anything(),
+    );
+  });
+
+  it("`cost_guard.transcript_pollution_detected` を発行", () => {
+    const api = makeApi();
+    register(api as any);
+    const handler = api.hooks.get("before_agent_run")!;
+    handler(
+      {
+        sessionId: "s1",
+        prompt: "next",
+        messages: [{ role: "tool", content: `${DENY}x.txt content`, tool_call_id: "tcid_p" }],
+      },
+      {},
+    );
+    expect(api.metrics.incrementCounter).toHaveBeenCalledWith(
+      "cost_guard.transcript_pollution_detected",
+      expect.anything(),
+    );
+  });
+
+  it("metrics API 未提供（OpenClaw 古いバージョン）でも throw しない", () => {
+    const api = makeApi();
+    (api as any).metrics = undefined;
+    expect(() => register(api as any)).not.toThrow();
+    const handler = api.hooks.get("before_tool_call")!;
+    expect(() => handler({ toolId: "read", params: { path: `${DENY}x.txt` } }, {})).not.toThrow();
+  });
+});
+
+// ----------------------------------------------------------------------------
+// npm package metadata
+// ----------------------------------------------------------------------------
+
+describe("npm package metadata", () => {
+  it("openclaw.plugin.json の id が cost-guard", () => {
+    const packageDir = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+    const pluginJson = JSON.parse(
+      readFileSync(resolve(packageDir, "openclaw.plugin.json"), "utf8"),
+    ) as { id: string; configSchema: { properties: Record<string, unknown> } };
+    expect(pluginJson.id).toBe("cost-guard");
+  });
+
+  it("configSchema が contracts.md §9.1 の全 11 property を持つ", () => {
+    const packageDir = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+    const pluginJson = JSON.parse(
+      readFileSync(resolve(packageDir, "openclaw.plugin.json"), "utf8"),
+    ) as { configSchema: { properties: Record<string, unknown> } };
+    const props = Object.keys(pluginJson.configSchema.properties);
+    for (const required of [
+      "logging",
+      "verbose",
+      "blockMode",
+      "denyPaths",
+      "allowlistedToolsForDenyPaths",
+      "rewriteThresholdBytes",
+      "sessionTokenBudget",
+      "perTurnPromptInputThreshold",
+      "commandDenylist",
+      "denyHardlinkTraversal",
+      "cleanupOnSessionStart",
+      "suspendAgent",
+    ]) {
+      expect(props).toContain(required);
+    }
+  });
+
+  it("blockMode のデフォルトが `block`（Phase 1 本番既定）", () => {
+    const packageDir = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+    const pluginJson = JSON.parse(
+      readFileSync(resolve(packageDir, "openclaw.plugin.json"), "utf8"),
+    ) as {
+      configSchema: {
+        properties: { blockMode: { default: string; enum: string[] } };
+      };
+    };
+    expect(pluginJson.configSchema.properties.blockMode.default).toBe("block");
+    expect(pluginJson.configSchema.properties.blockMode.enum).toEqual(["observe", "block"]);
+  });
+
+  it("npm pack に OpenClaw extension の参照先ファイルを含める", () => {
+    const packageDir = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+    const packageJson = JSON.parse(readFileSync(resolve(packageDir, "package.json"), "utf8")) as {
+      openclaw: { extensions: string[] };
+    };
+    execFileSync("npm", ["run", "build"], { cwd: packageDir, stdio: "pipe" });
+    const output = execFileSync("npm", ["pack", "--dry-run", "--json"], {
+      cwd: packageDir,
+      encoding: "utf8",
+    });
+    const [pack] = JSON.parse(output) as Array<{ files: Array<{ path: string }> }>;
+    const files = new Set(pack.files.map((file) => file.path));
+    expect(files.has("package.json")).toBe(true);
+    for (const extension of packageJson.openclaw.extensions) {
+      expect(files.has(extension.replace(/^\.\//, ""))).toBe(true);
+    }
+  });
+});

--- a/packages/cost-guard/src/index.test.ts
+++ b/packages/cost-guard/src/index.test.ts
@@ -711,6 +711,20 @@ describe("before_agent_run - 段 1 per-turn input gate", () => {
     expect((result as any).message).toContain("入力サイズ");
   });
 
+  it("配列 content の巨大 message は per_turn_input_too_large で block", () => {
+    const api = makeApi();
+    register(api as any);
+    const handler = api.hooks.get("before_agent_run")!;
+    const messages = [
+      { role: "user" as const, content: [{ type: "text", text: "x".repeat(200_004) }] },
+    ];
+
+    const result = handler({ sessionId: "s1", prompt: "", messages }, {}) as BeforeAgentRunResult;
+
+    expect(result.outcome).toBe("block");
+    expect((result as any).reason).toBe("per_turn_input_too_large");
+  });
+
   it("block 時に metric `cost_guard.per_turn_input_blocked` を発行", () => {
     const api = makeApi();
     register(api as any);
@@ -752,6 +766,20 @@ describe("before_agent_run - 段 2 session token budget", () => {
     const handler = api.hooks.get("before_agent_run")!;
     const messages = [{ role: "user" as const, content: "x".repeat(2_005_000) }]; // > 500_000 tokens
     const result = handler({ sessionId: "s1", prompt: "", messages }, {}) as BeforeAgentRunResult;
+    expect(result.outcome).toBe("block");
+    expect((result as any).reason).toBe("session_token_budget_exceeded");
+  });
+
+  it("配列 content の巨大 message は session_token_budget_exceeded で block", () => {
+    const api = makeApi({ perTurnPromptInputThreshold: 10_000_000 });
+    register(api as any);
+    const handler = api.hooks.get("before_agent_run")!;
+    const messages = [
+      { role: "user" as const, content: [{ type: "text", text: "x".repeat(2_005_000) }] },
+    ];
+
+    const result = handler({ sessionId: "s1", prompt: "", messages }, {}) as BeforeAgentRunResult;
+
     expect(result.outcome).toBe("block");
     expect((result as any).reason).toBe("session_token_budget_exceeded");
   });

--- a/packages/cost-guard/src/index.test.ts
+++ b/packages/cost-guard/src/index.test.ts
@@ -765,6 +765,25 @@ describe("before_agent_run - 段 1 per-turn input gate", () => {
     ) as BeforeAgentRunResult;
     expect(result.outcome).toBe("pass");
   });
+
+  it("per-turn gate で block された入力は session 累積に加算しない", () => {
+    const api = makeApi({ perTurnPromptInputThreshold: 10, sessionTokenBudget: 20 });
+    register(api as any);
+    const handler = api.hooks.get("before_agent_run")!;
+
+    const blocked = handler(
+      { sessionId: "s_per_turn_first", prompt: "x".repeat(44), messages: [] },
+      {},
+    ) as BeforeAgentRunResult;
+    const accepted = handler(
+      { sessionId: "s_per_turn_first", prompt: "y".repeat(40), messages: [] },
+      {},
+    ) as BeforeAgentRunResult;
+
+    expect(blocked.outcome).toBe("block");
+    expect((blocked as any).reason).toBe("per_turn_input_too_large");
+    expect(accepted.outcome).toBe("pass");
+  });
 });
 
 describe("before_agent_run - 段 2 session token budget", () => {
@@ -828,6 +847,32 @@ describe("before_agent_run - 段 2 session token budget", () => {
     expect(first.outcome).toBe("pass");
     expect(second.outcome).toBe("pass");
     expect(third.outcome).toBe("pass");
+  });
+
+  it("messages が一度短くなってから増えても過去に観測済みの履歴分は二重加算しない", () => {
+    const api = makeApi({ perTurnPromptInputThreshold: 10_000, sessionTokenBudget: 60 });
+    register(api as any);
+    const handler = api.hooks.get("before_agent_run")!;
+    const largeMessages = [{ role: "user" as const, content: "x".repeat(180) }]; // 50 tokens
+    const smallMessages = [{ role: "user" as const, content: "" }]; // 5 tokens
+    const grownMessages = [{ role: "user" as const, content: "y".repeat(100) }]; // 30 tokens
+
+    const first = handler(
+      { sessionId: "s_shrink_grow", prompt: "", messages: largeMessages },
+      {},
+    ) as BeforeAgentRunResult;
+    const shrink = handler(
+      { sessionId: "s_shrink_grow", prompt: "", messages: smallMessages },
+      {},
+    ) as BeforeAgentRunResult;
+    const grown = handler(
+      { sessionId: "s_shrink_grow", prompt: "", messages: grownMessages },
+      {},
+    ) as BeforeAgentRunResult;
+
+    expect(first.outcome).toBe("pass");
+    expect(shrink.outcome).toBe("pass");
+    expect(grown.outcome).toBe("pass");
   });
 
   it("同一 messages の再評価では prompt 分だけを追加で累積する", () => {

--- a/packages/cost-guard/src/index.test.ts
+++ b/packages/cost-guard/src/index.test.ts
@@ -348,6 +348,33 @@ describe("tool_result_persist - sentinel boundary", () => {
     );
   });
 
+  it("blockMode=observe では log 文言が `tool_result_would_be_rewritten`（実 rewrite との混同回避）", () => {
+    const api = makeApi({ blockMode: "observe" });
+    register(api as any);
+    const handler = api.hooks.get("tool_result_persist")!;
+    api.logger.info.mockClear();
+    handler(
+      { toolId: "read", toolCallId: "tcid_obs_log", result: { content: "x".repeat(60_000) } },
+      {},
+    );
+    const infoCalls = api.logger.info.mock.calls.map((c: unknown[]) => c[0] as string);
+    expect(infoCalls.some((m) => m.includes("tool_result_would_be_rewritten"))).toBe(true);
+    expect(infoCalls.some((m) => m.includes("tool_result_rewritten:"))).toBe(false);
+  });
+
+  it("blockMode=block では log 文言が `tool_result_rewritten`", () => {
+    const api = makeApi();
+    register(api as any);
+    const handler = api.hooks.get("tool_result_persist")!;
+    api.logger.info.mockClear();
+    handler(
+      { toolId: "read", toolCallId: "tcid_block_log", result: { content: "x".repeat(60_000) } },
+      {},
+    );
+    const infoCalls = api.logger.info.mock.calls.map((c: unknown[]) => c[0] as string);
+    expect(infoCalls.some((m) => m.includes("tool_result_rewritten:"))).toBe(true);
+  });
+
   it("result.content が配列（[{text: '...'}, ...]）形式でも byte 数を合算", () => {
     const api = makeApi();
     register(api as any);
@@ -608,6 +635,37 @@ describe("before_agent_run - suspendAgent (rollback Mode A)", () => {
       {},
     ) as BeforeAgentRunResult;
     expect(result.outcome).toBe("pass");
+  });
+
+  it("suspendAgent block 時に専用 metric `cost_guard.agent_suspended_block` を発行（session_budget_exceeded には混ぜない）", () => {
+    const api = makeApi({ suspendAgent: true });
+    register(api as any);
+    const handler = api.hooks.get("before_agent_run")!;
+    handler({ sessionId: "s1", prompt: "hi", messages: [] }, {});
+    expect(api.metrics.incrementCounter).toHaveBeenCalledWith(
+      "cost_guard.agent_suspended_block",
+      expect.objectContaining({ sessionId: "s1" }),
+    );
+    // session_budget_exceeded は発行しない（混ぜない）
+    expect(api.metrics.incrementCounter).not.toHaveBeenCalledWith(
+      "cost_guard.session_budget_exceeded",
+      expect.anything(),
+    );
+  });
+
+  it("suspendAgent + blockMode=observe では log と metric は発行するが pass を返す", () => {
+    const api = makeApi({ suspendAgent: true, blockMode: "observe" });
+    register(api as any);
+    const handler = api.hooks.get("before_agent_run")!;
+    const result = handler(
+      { sessionId: "s_obs", prompt: "hi", messages: [] },
+      {},
+    ) as BeforeAgentRunResult;
+    expect(result.outcome).toBe("pass");
+    expect(api.metrics.incrementCounter).toHaveBeenCalledWith(
+      "cost_guard.agent_suspended_block",
+      expect.anything(),
+    );
   });
 });
 

--- a/packages/cost-guard/src/index.test.ts
+++ b/packages/cost-guard/src/index.test.ts
@@ -222,6 +222,18 @@ describe("before_tool_call - commandDenylist", () => {
     expect((result as any).blockReason).toBe("command_denylist_match");
   });
 
+  it("args 配列形式の bash -c $VAR を command_denylist_match で block", () => {
+    const api = makeApi();
+    register(api as any);
+    const handler = api.hooks.get("before_tool_call")!;
+    const result = handler(
+      { toolId: "exec", params: { args: ["bash", "-c", "$PAYLOAD"] } },
+      {},
+    ) as BeforeToolCallResult;
+    expect((result as any).block).toBe(true);
+    expect((result as any).blockReason).toBe("command_denylist_match");
+  });
+
   it("空の commandDenylist では何も block しない", () => {
     const api = makeApi({ commandDenylist: [] });
     register(api as any);

--- a/packages/cost-guard/src/index.test.ts
+++ b/packages/cost-guard/src/index.test.ts
@@ -758,6 +758,22 @@ describe("before_agent_run - 段 2 session token budget", () => {
     expect((second as any).reason).toBe("session_token_budget_exceeded");
   });
 
+  it("messages が空でも prompt の複数 turn 合計が sessionTokenBudget を超えた時点で block", () => {
+    const api = makeApi({ perTurnPromptInputThreshold: 100, sessionTokenBudget: 90 });
+    register(api as any);
+    const handler = api.hooks.get("before_agent_run")!;
+    const prompt = "x".repeat(180); // 45 tokens
+
+    const first = handler({ sessionId: "s1", prompt, messages: [] }, {}) as BeforeAgentRunResult;
+    const second = handler({ sessionId: "s1", prompt, messages: [] }, {}) as BeforeAgentRunResult;
+    const third = handler({ sessionId: "s1", prompt, messages: [] }, {}) as BeforeAgentRunResult;
+
+    expect(first.outcome).toBe("pass");
+    expect(second.outcome).toBe("pass");
+    expect(third.outcome).toBe("block");
+    expect((third as any).reason).toBe("session_token_budget_exceeded");
+  });
+
   it("block 時に metric `cost_guard.session_budget_exceeded` を発行", () => {
     const api = makeApi({ perTurnPromptInputThreshold: 10_000_000 });
     register(api as any);

--- a/packages/cost-guard/src/index.ts
+++ b/packages/cost-guard/src/index.ts
@@ -514,11 +514,12 @@ function cleanupSessionMessages(
   const rewritten: SessionMessage[] = messages.map((msg) => {
     if (!msg || typeof msg !== "object") return msg;
     if (msg.role !== "tool") return msg;
-    if (isSentinelMessage(msg.content)) return msg;
     const content = msg.content ?? "";
-    if (typeof content !== "string") return msg;
+    const searchableContent = messageContentToSearchText(content);
+    if (searchableContent === "") return msg;
+    if (isSentinelMessage(searchableContent)) return msg;
     // denyPaths のいずれかの prefix が含まれているかを単純 contains で判定
-    const hit = denyPaths.some((p) => content.includes(p));
+    const hit = denyPaths.some((p) => searchableContent.includes(p));
     if (!hit) return msg;
     rewrittenCount++;
     return {
@@ -527,6 +528,46 @@ function cleanupSessionMessages(
     };
   });
   return { messages: rewritten, rewrittenCount };
+}
+
+function messageContentToSearchText(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (content === undefined || content === null) return "";
+  if (Array.isArray(content)) {
+    const parts: string[] = [];
+    for (const item of content) {
+      if (typeof item === "string") {
+        parts.push(item);
+        continue;
+      }
+      if (item && typeof item === "object") {
+        const text = (item as Record<string, unknown>).text;
+        if (typeof text === "string") parts.push(text);
+        else parts.push(safeJsonStringify(item));
+        continue;
+      }
+      parts.push(String(item));
+    }
+    return parts.join("\n");
+  }
+  if (typeof content === "object") return safeJsonStringify(content);
+  return String(content);
+}
+
+function safeJsonStringify(value: unknown): string {
+  const seen = new WeakSet<object>();
+  try {
+    return (
+      JSON.stringify(value, (_key, v: unknown) => {
+        if (typeof v !== "object" || v === null) return v;
+        if (seen.has(v)) return "[Circular]";
+        seen.add(v);
+        return v;
+      }) ?? ""
+    );
+  } catch {
+    return String(value);
+  }
 }
 
 function safePreview(v: unknown, maxBytes: number): string {

--- a/packages/cost-guard/src/index.ts
+++ b/packages/cost-guard/src/index.ts
@@ -27,11 +27,7 @@
 import { findCommandDenylistMatch } from "./command-checker.js";
 import { findDenyPathMatch } from "./path-checker.js";
 import { buildSentinelMessage, computeContentBytes, isSentinelMessage } from "./sentinel.js";
-import {
-  estimateMessagesTokenCount,
-  estimatePromptInputTokens,
-  type SessionMessage,
-} from "./token-estimator.js";
+import { estimatePromptInputTokens, type SessionMessage } from "./token-estimator.js";
 
 const TAG = "[cost-guard]";
 const VERBOSE_PARAM_HEAD_BYTES = 200;
@@ -347,8 +343,8 @@ export default function register(api: OpenClawPluginApi): void {
 
     // 2. 段 2: session cumulative breaker
     const sessionState = getOrCreateSessionState(sessionStateMap, sessionId);
-    // current turn の messages token を session 単位で加算する。
-    const turnTokens = estimateMessagesTokenCount(e.messages);
+    // current turn の prompt + messages token を session 単位で加算する。
+    const turnTokens = perTurnTokens;
     sessionState.cumulativeTokens += turnTokens;
     if (sessionState.cumulativeTokens > cfg.sessionTokenBudget) {
       warn(

--- a/packages/cost-guard/src/index.ts
+++ b/packages/cost-guard/src/index.ts
@@ -277,10 +277,11 @@ export default function register(api: OpenClawPluginApi): void {
       toolName?: string;
       toolId?: string;
       toolCallId?: string;
+      tool_call_id?: string;
       result?: unknown;
     };
     const toolId = e.toolId ?? e.toolName ?? "(unknown)";
-    const toolCallId = e.toolCallId ?? "";
+    const toolCallId = e.toolCallId ?? e.tool_call_id ?? "";
     const contentBytes = extractResultContentBytes(e.result);
 
     if (cfg.logging) {

--- a/packages/cost-guard/src/index.ts
+++ b/packages/cost-guard/src/index.ts
@@ -347,9 +347,9 @@ export default function register(api: OpenClawPluginApi): void {
 
     // 2. 段 2: session cumulative breaker
     const sessionState = getOrCreateSessionState(sessionStateMap, sessionId);
-    // cumulative の更新は messages から推定（current turn の messages 全合計を累積扱い）
-    const cumulativeTokens = estimateMessagesTokenCount(e.messages);
-    sessionState.cumulativeTokens = Math.max(sessionState.cumulativeTokens, cumulativeTokens);
+    // current turn の messages token を session 単位で加算する。
+    const turnTokens = estimateMessagesTokenCount(e.messages);
+    sessionState.cumulativeTokens += turnTokens;
     if (sessionState.cumulativeTokens > cfg.sessionTokenBudget) {
       warn(
         `${TAG} session_token_budget_exceeded: session=${sessionId} cumulative_tokens=${sessionState.cumulativeTokens} budget=${cfg.sessionTokenBudget}`,

--- a/packages/cost-guard/src/index.ts
+++ b/packages/cost-guard/src/index.ts
@@ -1,0 +1,558 @@
+/**
+ * cost-guard: Phase 1 本格版 plugin
+ *
+ * 目的（hongmong-ochi-agent の transcript コスト爆発 $1990/月への構造対策）：
+ * - denyPaths 配下への汎用 file access を default deny で遮断
+ * - transcript-analyzer.* の 3 tool のみを allowlist で通す
+ * - 50KB 超の tool result を sentinel 置換し prompt cache 注入を防止
+ * - per-turn / session 単位の token gate で暴走 prompt を遮断
+ *
+ * 3 hook：
+ * - before_tool_call    : denyPaths 配下への汎用 tool 呼び出しを block（allowlist 例外）
+ * - tool_result_persist : rewriteThresholdBytes 超の result を sentinel 置換（tool_call_id 保持）
+ * - before_agent_run    : 段 1 per-turn input gate → 段 2 session budget breaker
+ *                         → 通過後 cleanupOnSessionStart 時に messages 履歴 sentinel 置換
+ *
+ * 詳細設計：design v6（estack-inc/easy-flow#398 マージ済）
+ * 契約：contracts.md（同 case 配下）
+ *
+ * 本 plugin は cost-guard-hello の基本骨格を踏襲しつつ：
+ * - realpath / inode 一致検査を追加（B-4 漏れパターン対処）
+ * - commandDenylist の AST 検査を追加
+ * - 3 hook 戻り値を contracts.md §2.1 / §2.2 / §2.3 に厳密準拠
+ * - 5 metric（cost_guard.*）を発行
+ * - rollback Mode A（suspendAgent）対応
+ */
+
+import { findCommandDenylistMatch } from "./command-checker.js";
+import { findDenyPathMatch } from "./path-checker.js";
+import { buildSentinelMessage, computeContentBytes, isSentinelMessage } from "./sentinel.js";
+import {
+  estimateMessagesTokenCount,
+  estimatePromptInputTokens,
+  type SessionMessage,
+} from "./token-estimator.js";
+
+const TAG = "[cost-guard]";
+const VERBOSE_PARAM_HEAD_BYTES = 200;
+
+// ============================================================================
+// 型定義（contracts.md §2.1 / §2.2 / §2.3 準拠）
+// ============================================================================
+
+export type BlockReason =
+  | "deny_path_match"
+  | "deny_path_match_inode"
+  | "deny_path_match_symlink"
+  | "command_denylist_match"
+  | "tool_not_in_allowlist";
+
+export type BeforeToolCallResult =
+  | Record<string, never>
+  | { block: true; blockReason: BlockReason; message?: string }
+  | { requireApproval: { approverRole: string; message: string } };
+
+export interface ToolResultMessage {
+  role: "tool";
+  tool_call_id: string;
+  content: string;
+}
+
+export type ToolResultPersistResult = Record<string, never> | { message: ToolResultMessage };
+
+export type BeforeAgentRunBlockReason =
+  | "per_turn_input_too_large"
+  | "session_token_budget_exceeded";
+
+export type BeforeAgentRunResult =
+  | { outcome: "pass" }
+  | { outcome: "block"; reason: BeforeAgentRunBlockReason | "agent_suspended"; message: string }
+  | {
+      outcome: "rewrite";
+      messages: SessionMessage[];
+      reason: "transcript_pollution_cleanup";
+    };
+
+export { SENTINEL_PREFIX } from "./sentinel.js";
+
+// ============================================================================
+// 設定型と OpenClawPluginApi 型
+// ============================================================================
+
+interface CostGuardConfig {
+  logging?: boolean;
+  verbose?: boolean;
+  blockMode?: "observe" | "block";
+  denyPaths?: string[];
+  allowlistedToolsForDenyPaths?: string[];
+  rewriteThresholdBytes?: number;
+  sessionTokenBudget?: number;
+  perTurnPromptInputThreshold?: number;
+  commandDenylist?: string[];
+  denyHardlinkTraversal?: boolean;
+  cleanupOnSessionStart?: boolean;
+  suspendAgent?: boolean;
+}
+
+interface OpenClawLogger {
+  info(message: string): void;
+  warn?(message: string): void;
+  error?(message: string): void;
+}
+
+interface OpenClawMetrics {
+  incrementCounter?(name: string, labels?: Record<string, string>): void;
+  setGauge?(name: string, value: number, labels?: Record<string, string>): void;
+}
+
+export interface OpenClawPluginApi {
+  pluginConfig?: Record<string, unknown>;
+  logger: OpenClawLogger;
+  metrics?: OpenClawMetrics;
+  on(event: string, handler: (event: unknown, ctx: unknown) => unknown): void;
+}
+
+// ============================================================================
+// 既定値（contracts.md §9.1）
+// ============================================================================
+
+const DEFAULTS = {
+  logging: true,
+  verbose: false,
+  blockMode: "block" as const,
+  denyPaths: ["/data/workspace/zoom_transcribe/"],
+  allowlistedToolsForDenyPaths: [
+    "transcript-analyzer.list_transcripts",
+    "transcript-analyzer.search_transcripts",
+    "transcript-analyzer.analyze_transcript",
+  ],
+  rewriteThresholdBytes: 50000,
+  sessionTokenBudget: 500000,
+  perTurnPromptInputThreshold: 50000,
+  commandDenylist: ["eval", "bash -c $", "sh -c $", "<(", "$(", "`"],
+  denyHardlinkTraversal: true,
+  cleanupOnSessionStart: true,
+  suspendAgent: false,
+};
+
+const BLOCK_MESSAGES: Record<BlockReason, string> = {
+  deny_path_match:
+    "/data/workspace/zoom_transcribe/ 配下は専用 tool 経由でのみアクセスできます。transcript-analyzer.* を使ってください。",
+  deny_path_match_inode:
+    "/data/workspace/zoom_transcribe/ 配下は専用 tool 経由でのみアクセスできます。transcript-analyzer.* を使ってください。",
+  deny_path_match_symlink:
+    "/data/workspace/zoom_transcribe/ 配下は専用 tool 経由でのみアクセスできます。transcript-analyzer.* を使ってください。",
+  command_denylist_match: "この command パターンは禁止されています。",
+  tool_not_in_allowlist: "この path は専用 tool 経由のみアクセス可能です。",
+};
+
+const PER_TURN_BLOCK_MESSAGE =
+  "次ターンの入力サイズが大きすぎるため処理できません。session を /reset するか、長いコンテキストを分割してください。";
+const SESSION_BUDGET_BLOCK_MESSAGE =
+  "このセッションのトークン上限を超えたため新規メッセージを受け付けません。/reset で新規開始してください。";
+const SUSPENDED_BLOCK_MESSAGE =
+  "cost-guard suspendAgent=true により agent 実行を一時停止しています。運用者に確認してください。";
+
+// ============================================================================
+// session 状態（cumulative token tracking）
+// ============================================================================
+
+interface SessionState {
+  cumulativeTokens: number;
+}
+
+// ============================================================================
+// register（OpenClaw plugin entry point）
+// ============================================================================
+
+export default function register(api: OpenClawPluginApi): void {
+  const cfg = resolveConfig((api.pluginConfig ?? {}) as CostGuardConfig);
+  const log = api.logger;
+  const warn = (message: string): void => {
+    if (log.warn) log.warn(message);
+    else log.info(message);
+  };
+  const metrics = api.metrics;
+  const incCounter = (name: string, labels?: Record<string, string>): void => {
+    metrics?.incrementCounter?.(name, labels);
+  };
+  // session 単位の cumulative token tracking（プロセス内 in-memory map）
+  const sessionStateMap = new Map<string, SessionState>();
+
+  log.info(
+    `${TAG} registered (blockMode=${cfg.blockMode}, denyPaths=${JSON.stringify(cfg.denyPaths)}, ` +
+      `allowlist=${cfg.allowlistedToolsForDenyPaths.length}, rewrite=${cfg.rewriteThresholdBytes}b, ` +
+      `perTurnGate=${cfg.perTurnPromptInputThreshold}, sessionBudget=${cfg.sessionTokenBudget}, ` +
+      `denyHardlinkTraversal=${cfg.denyHardlinkTraversal}, suspendAgent=${cfg.suspendAgent})`,
+  );
+
+  // --------------------------------------------------------------------------
+  // before_tool_call: denyPaths block + allowlist + commandDenylist
+  // --------------------------------------------------------------------------
+  api.on("before_tool_call", (event: unknown, _ctx: unknown): BeforeToolCallResult => {
+    const e = event as { toolName?: string; toolId?: string; params?: unknown };
+    const toolId = e.toolId ?? e.toolName ?? "(unknown)";
+
+    // 1. commandDenylist 検査（command-like field のみ）
+    const commandMatch = findCommandDenylistMatch(e.params, {
+      commandDenylist: cfg.commandDenylist,
+    });
+    if (commandMatch) {
+      const result: BeforeToolCallResult = {
+        block: true,
+        blockReason: "command_denylist_match",
+        message: BLOCK_MESSAGES.command_denylist_match,
+      };
+      logBlock(
+        warn,
+        cfg,
+        toolId,
+        "command_denylist_match",
+        commandMatch.matchedPattern,
+        commandMatch.field,
+      );
+      incCounter("cost_guard.tool_call_blocked", {
+        blockReason: "command_denylist_match",
+        toolId,
+      });
+      if (cfg.blockMode === "observe") return {};
+      return result;
+    }
+
+    // 2. denyPaths 検査
+    const pathMatch = findDenyPathMatch(e.params, {
+      denyPaths: cfg.denyPaths,
+      denyHardlinkTraversal: cfg.denyHardlinkTraversal,
+      resolveSymlinks: true,
+    });
+    if (pathMatch) {
+      // 3. allowlist 例外（denyPaths にマッチしても allowlist 内 tool は通過）
+      if (cfg.allowlistedToolsForDenyPaths.includes(toolId)) {
+        if (cfg.logging) {
+          log.info(
+            `${TAG} allowlisted: tool=${toolId} matched_path="${pathMatch.matched}" field="${pathMatch.field}" reason=${pathMatch.reason}`,
+          );
+        }
+        return {};
+      }
+      const blockReason: BlockReason = pathMatch.reason;
+      const result: BeforeToolCallResult = {
+        block: true,
+        blockReason,
+        message: BLOCK_MESSAGES[blockReason],
+      };
+      logBlock(warn, cfg, toolId, blockReason, pathMatch.matched, pathMatch.field);
+      incCounter("cost_guard.tool_call_blocked", { blockReason, toolId });
+      if (cfg.blockMode === "observe") return {};
+      return result;
+    }
+
+    // 観測 log（block されなかった場合）
+    if (cfg.logging) {
+      if (cfg.verbose) {
+        const paramsPreview = safePreview(e.params, VERBOSE_PARAM_HEAD_BYTES);
+        log.info(`${TAG} before_tool_call: tool=${toolId} params_head="${paramsPreview}"`);
+      } else {
+        log.info(`${TAG} before_tool_call: tool=${toolId}`);
+      }
+    }
+    return {};
+  });
+
+  // --------------------------------------------------------------------------
+  // tool_result_persist: rewriteThresholdBytes 超で sentinel 置換
+  // --------------------------------------------------------------------------
+  api.on("tool_result_persist", (event: unknown, _ctx: unknown): ToolResultPersistResult => {
+    const e = event as {
+      toolName?: string;
+      toolId?: string;
+      toolCallId?: string;
+      result?: unknown;
+    };
+    const toolId = e.toolId ?? e.toolName ?? "(unknown)";
+    const toolCallId = e.toolCallId ?? "";
+    const contentBytes = extractResultContentBytes(e.result);
+
+    if (cfg.logging) {
+      log.info(
+        `${TAG} tool_result_persist: tool=${toolId} call_id=${toolCallId || "(none)"} bytes=${contentBytes}`,
+      );
+    }
+
+    if (contentBytes > cfg.rewriteThresholdBytes) {
+      const sentinel = buildSentinelMessage(contentBytes);
+      log.info(
+        `${TAG} tool_result_rewritten: tool=${toolId} call_id=${toolCallId} bytes=${contentBytes} threshold=${cfg.rewriteThresholdBytes}`,
+      );
+      incCounter("cost_guard.tool_result_rewritten", { toolId });
+      if (cfg.blockMode === "observe") return {};
+      return {
+        message: {
+          role: "tool",
+          tool_call_id: toolCallId,
+          content: sentinel,
+        },
+      };
+    }
+    return {};
+  });
+
+  // --------------------------------------------------------------------------
+  // before_agent_run: 段 1 per-turn gate → 段 2 session budget → cleanup
+  // --------------------------------------------------------------------------
+  api.on("before_agent_run", (event: unknown, _ctx: unknown): BeforeAgentRunResult => {
+    const e = event as {
+      prompt?: string;
+      messages?: SessionMessage[];
+      sessionId?: string;
+      accountId?: string;
+      channelId?: string;
+    };
+    const sessionId = e.sessionId ?? e.channelId ?? e.accountId ?? "default";
+
+    // 0. rollback Mode A: suspendAgent
+    if (cfg.suspendAgent) {
+      warn(`${TAG} agent_suspended: session=${sessionId} (suspendAgent=true)`);
+      incCounter("cost_guard.session_budget_exceeded", { reason: "agent_suspended" });
+      if (cfg.blockMode === "observe") return { outcome: "pass" };
+      return {
+        outcome: "block",
+        reason: "agent_suspended",
+        message: SUSPENDED_BLOCK_MESSAGE,
+      };
+    }
+
+    // 1. 段 1: per-turn prompt input gate
+    const perTurnTokens = estimatePromptInputTokens(e.prompt, e.messages);
+    if (perTurnTokens > cfg.perTurnPromptInputThreshold) {
+      warn(
+        `${TAG} per_turn_input_too_large: session=${sessionId} estimated_tokens=${perTurnTokens} threshold=${cfg.perTurnPromptInputThreshold}`,
+      );
+      incCounter("cost_guard.per_turn_input_blocked", { sessionId });
+      if (cfg.blockMode === "observe") {
+        // observe では block しないが log は出す
+      } else {
+        return {
+          outcome: "block",
+          reason: "per_turn_input_too_large",
+          message: PER_TURN_BLOCK_MESSAGE,
+        };
+      }
+    }
+
+    // 2. 段 2: session cumulative breaker
+    const sessionState = getOrCreateSessionState(sessionStateMap, sessionId);
+    // cumulative の更新は messages から推定（current turn の messages 全合計を累積扱い）
+    const cumulativeTokens = estimateMessagesTokenCount(e.messages);
+    sessionState.cumulativeTokens = Math.max(sessionState.cumulativeTokens, cumulativeTokens);
+    if (sessionState.cumulativeTokens > cfg.sessionTokenBudget) {
+      warn(
+        `${TAG} session_token_budget_exceeded: session=${sessionId} cumulative_tokens=${sessionState.cumulativeTokens} budget=${cfg.sessionTokenBudget}`,
+      );
+      incCounter("cost_guard.session_budget_exceeded", { sessionId });
+      if (cfg.blockMode === "observe") {
+        // observe では block しないが log は出す
+      } else {
+        return {
+          outcome: "block",
+          reason: "session_token_budget_exceeded",
+          message: SESSION_BUDGET_BLOCK_MESSAGE,
+        };
+      }
+    }
+
+    // 3. cleanup: 過去 messages の denyPaths 参照を sentinel 置換
+    if (cfg.cleanupOnSessionStart && Array.isArray(e.messages) && e.messages.length > 0) {
+      const cleanupResult = cleanupSessionMessages(e.messages, cfg);
+      if (cleanupResult.rewrittenCount > 0) {
+        log.info(
+          `${TAG} transcript_pollution_detected: session=${sessionId} rewritten=${cleanupResult.rewrittenCount}`,
+        );
+        incCounter("cost_guard.transcript_pollution_detected", {
+          sessionId,
+          rewritten: String(cleanupResult.rewrittenCount),
+        });
+        if (cfg.blockMode === "block") {
+          return {
+            outcome: "rewrite",
+            messages: cleanupResult.messages,
+            reason: "transcript_pollution_cleanup",
+          };
+        }
+      }
+    }
+
+    if (cfg.logging) {
+      const promptLen = typeof e.prompt === "string" ? e.prompt.length : 0;
+      const msgCount = Array.isArray(e.messages) ? e.messages.length : 0;
+      log.info(
+        `${TAG} before_agent_run: session=${sessionId} prompt_len=${promptLen} messages=${msgCount} ` +
+          `per_turn_tokens=${perTurnTokens} session_tokens=${sessionState.cumulativeTokens}`,
+      );
+    }
+    return { outcome: "pass" };
+  });
+}
+
+// ============================================================================
+// helpers
+// ============================================================================
+
+interface ResolvedConfig {
+  logging: boolean;
+  verbose: boolean;
+  blockMode: "observe" | "block";
+  denyPaths: string[];
+  allowlistedToolsForDenyPaths: string[];
+  rewriteThresholdBytes: number;
+  sessionTokenBudget: number;
+  perTurnPromptInputThreshold: number;
+  commandDenylist: string[];
+  denyHardlinkTraversal: boolean;
+  cleanupOnSessionStart: boolean;
+  suspendAgent: boolean;
+}
+
+function resolveConfig(raw: CostGuardConfig): ResolvedConfig {
+  const blockMode =
+    raw.blockMode === "observe" || raw.blockMode === "block" ? raw.blockMode : DEFAULTS.blockMode;
+  return {
+    logging: typeof raw.logging === "boolean" ? raw.logging : DEFAULTS.logging,
+    verbose: typeof raw.verbose === "boolean" ? raw.verbose : DEFAULTS.verbose,
+    blockMode,
+    denyPaths: Array.isArray(raw.denyPaths)
+      ? raw.denyPaths.filter((s) => typeof s === "string" && s.length > 0)
+      : DEFAULTS.denyPaths.slice(),
+    allowlistedToolsForDenyPaths: Array.isArray(raw.allowlistedToolsForDenyPaths)
+      ? raw.allowlistedToolsForDenyPaths.filter((s) => typeof s === "string")
+      : DEFAULTS.allowlistedToolsForDenyPaths.slice(),
+    rewriteThresholdBytes:
+      typeof raw.rewriteThresholdBytes === "number" && raw.rewriteThresholdBytes >= 0
+        ? raw.rewriteThresholdBytes
+        : DEFAULTS.rewriteThresholdBytes,
+    sessionTokenBudget:
+      typeof raw.sessionTokenBudget === "number" && raw.sessionTokenBudget >= 0
+        ? raw.sessionTokenBudget
+        : DEFAULTS.sessionTokenBudget,
+    perTurnPromptInputThreshold:
+      typeof raw.perTurnPromptInputThreshold === "number" && raw.perTurnPromptInputThreshold >= 0
+        ? raw.perTurnPromptInputThreshold
+        : DEFAULTS.perTurnPromptInputThreshold,
+    commandDenylist: Array.isArray(raw.commandDenylist)
+      ? raw.commandDenylist.filter((s) => typeof s === "string" && s.length > 0)
+      : DEFAULTS.commandDenylist.slice(),
+    denyHardlinkTraversal:
+      typeof raw.denyHardlinkTraversal === "boolean"
+        ? raw.denyHardlinkTraversal
+        : DEFAULTS.denyHardlinkTraversal,
+    cleanupOnSessionStart:
+      typeof raw.cleanupOnSessionStart === "boolean"
+        ? raw.cleanupOnSessionStart
+        : DEFAULTS.cleanupOnSessionStart,
+    suspendAgent: typeof raw.suspendAgent === "boolean" ? raw.suspendAgent : DEFAULTS.suspendAgent,
+  };
+}
+
+function logBlock(
+  warn: (m: string) => void,
+  cfg: ResolvedConfig,
+  toolId: string,
+  blockReason: string,
+  matched: string,
+  field: string,
+): void {
+  if (!cfg.logging) return;
+  warn(
+    `${TAG} BLOCKED: tool=${toolId} reason=${blockReason} matched="${matched}" field="${field}" blockMode=${cfg.blockMode}`,
+  );
+}
+
+function extractResultContentBytes(result: unknown): number {
+  if (result === undefined || result === null) return 0;
+  if (typeof result === "string") return computeContentBytes(result);
+  if (typeof result === "object") {
+    const r = result as Record<string, unknown>;
+    if (typeof r.content === "string") return computeContentBytes(r.content);
+    if (Array.isArray(r.content)) {
+      let total = 0;
+      for (const item of r.content) {
+        if (item && typeof item === "object") {
+          const text = (item as Record<string, unknown>).text;
+          if (typeof text === "string") total += computeContentBytes(text);
+          else total += computeContentBytes(item);
+        } else {
+          total += computeContentBytes(item);
+        }
+      }
+      return total;
+    }
+    return computeContentBytes(result);
+  }
+  return computeContentBytes(result);
+}
+
+function getOrCreateSessionState(map: Map<string, SessionState>, sessionId: string): SessionState {
+  let s = map.get(sessionId);
+  if (!s) {
+    s = { cumulativeTokens: 0 };
+    map.set(sessionId, s);
+  }
+  return s;
+}
+
+/**
+ * 過去 messages 内の tool result で denyPaths 配下の path 参照を sentinel 置換する。
+ * tool role かつ既に sentinel 化されていない message のみが対象。
+ */
+function cleanupSessionMessages(
+  messages: SessionMessage[],
+  cfg: ResolvedConfig,
+): { messages: SessionMessage[]; rewrittenCount: number } {
+  let rewrittenCount = 0;
+  const denyPaths = cfg.denyPaths;
+  const rewritten: SessionMessage[] = messages.map((msg) => {
+    if (!msg || typeof msg !== "object") return msg;
+    if (msg.role !== "tool") return msg;
+    if (isSentinelMessage(msg.content)) return msg;
+    const content = msg.content ?? "";
+    if (typeof content !== "string") return msg;
+    // denyPaths のいずれかの prefix が含まれているかを単純 contains で判定
+    const hit = denyPaths.some((p) => content.includes(p));
+    if (!hit) return msg;
+    rewrittenCount++;
+    return {
+      ...msg,
+      content: buildSentinelMessage(computeContentBytes(content)),
+    };
+  });
+  return { messages: rewritten, rewrittenCount };
+}
+
+function safePreview(v: unknown, maxBytes: number): string {
+  if (v === undefined || v === null) return "(empty)";
+  let s: string;
+  try {
+    s = typeof v === "string" ? v : JSON.stringify(v);
+  } catch {
+    return "(unserializable)";
+  }
+  if (typeof s !== "string") return "(unserializable)";
+  s = s.replace(/\s+/g, " ").trim();
+  return truncateUtf8(s, maxBytes);
+}
+
+function truncateUtf8(s: string, maxBytes: number): string {
+  if (Buffer.byteLength(s, "utf8") <= maxBytes) return s;
+  const suffix = "...";
+  const suffixBytes = Buffer.byteLength(suffix, "utf8");
+  const headLimit = Math.max(0, maxBytes - suffixBytes);
+  let head = "";
+  let headBytes = 0;
+  for (const char of s) {
+    const charBytes = Buffer.byteLength(char, "utf8");
+    if (headBytes + charBytes > headLimit) break;
+    head += char;
+    headBytes += charBytes;
+  }
+  return `${head}${suffix}`;
+}

--- a/packages/cost-guard/src/index.ts
+++ b/packages/cost-guard/src/index.ts
@@ -163,6 +163,14 @@ interface SessionState {
   observedMessagesTokens: number;
 }
 
+interface SessionBudgetUpdate {
+  promptTokens: number;
+  messagesTokens: number;
+  messagesDeltaTokens: number;
+  turnTokens: number;
+  cumulativeTokens: number;
+}
+
 // ============================================================================
 // register（OpenClaw plugin entry point）
 // ============================================================================
@@ -349,16 +357,10 @@ export default function register(api: OpenClawPluginApi): void {
 
     // 2. 段 2: session cumulative breaker
     const sessionState = getOrCreateSessionState(sessionStateMap, sessionId);
-    const promptTokens = estimateTokenCount(e.prompt ?? "");
-    const messagesTokens = estimateMessagesTokenCount(e.messages);
-    const messagesDeltaTokens = Math.max(0, messagesTokens - sessionState.observedMessagesTokens);
-    // prompt は current turn 入力として毎回加算し、messages 履歴は前回観測からの増分だけ加算する。
-    const turnTokens = promptTokens + messagesDeltaTokens;
-    sessionState.cumulativeTokens += turnTokens;
-    sessionState.observedMessagesTokens = messagesTokens;
-    if (sessionState.cumulativeTokens > cfg.sessionTokenBudget) {
+    const sessionUpdate = updateSessionBudgetState(sessionState, e.prompt, e.messages);
+    if (sessionUpdate.cumulativeTokens > cfg.sessionTokenBudget) {
       warn(
-        `${TAG} session_token_budget_exceeded: session=${sessionId} cumulative_tokens=${sessionState.cumulativeTokens} budget=${cfg.sessionTokenBudget}`,
+        `${TAG} session_token_budget_exceeded: session=${sessionId} cumulative_tokens=${sessionUpdate.cumulativeTokens} budget=${cfg.sessionTokenBudget}`,
       );
       incCounter("cost_guard.session_budget_exceeded", { sessionId });
       if (cfg.blockMode === "observe") {
@@ -398,7 +400,7 @@ export default function register(api: OpenClawPluginApi): void {
       const msgCount = Array.isArray(e.messages) ? e.messages.length : 0;
       log.info(
         `${TAG} before_agent_run: session=${sessionId} prompt_len=${promptLen} messages=${msgCount} ` +
-          `per_turn_tokens=${perTurnTokens} session_tokens=${sessionState.cumulativeTokens}`,
+          `per_turn_tokens=${perTurnTokens} session_tokens=${sessionUpdate.cumulativeTokens}`,
       );
     }
     return { outcome: "pass" };
@@ -503,6 +505,32 @@ function getOrCreateSessionState(map: Map<string, SessionState>, sessionId: stri
     map.set(sessionId, s);
   }
   return s;
+}
+
+function updateSessionBudgetState(
+  sessionState: SessionState,
+  prompt: string | undefined,
+  messages: SessionMessage[] | undefined,
+): SessionBudgetUpdate {
+  const promptTokens = estimateTokenCount(prompt ?? "");
+  const messagesTokens = estimateMessagesTokenCount(messages);
+  const messagesDeltaTokens = Math.max(0, messagesTokens - sessionState.observedMessagesTokens);
+  // prompt は current turn 入力として毎回加算し、messages 履歴は前回観測からの増分だけ加算する。
+  const turnTokens = promptTokens + messagesDeltaTokens;
+
+  sessionState.cumulativeTokens += turnTokens;
+  sessionState.observedMessagesTokens = Math.max(
+    sessionState.observedMessagesTokens,
+    messagesTokens,
+  );
+
+  return {
+    promptTokens,
+    messagesTokens,
+    messagesDeltaTokens,
+    turnTokens,
+    cumulativeTokens: sessionState.cumulativeTokens,
+  };
 }
 
 /**

--- a/packages/cost-guard/src/index.ts
+++ b/packages/cost-guard/src/index.ts
@@ -27,7 +27,12 @@
 import { findCommandDenylistMatch } from "./command-checker.js";
 import { findDenyPathMatch } from "./path-checker.js";
 import { buildSentinelMessage, computeContentBytes, isSentinelMessage } from "./sentinel.js";
-import { estimatePromptInputTokens, type SessionMessage } from "./token-estimator.js";
+import {
+  estimateMessagesTokenCount,
+  estimatePromptInputTokens,
+  estimateTokenCount,
+  type SessionMessage,
+} from "./token-estimator.js";
 
 const TAG = "[cost-guard]";
 const VERBOSE_PARAM_HEAD_BYTES = 200;
@@ -155,6 +160,7 @@ const SUSPENDED_BLOCK_MESSAGE =
 
 interface SessionState {
   cumulativeTokens: number;
+  observedMessagesTokens: number;
 }
 
 // ============================================================================
@@ -343,9 +349,13 @@ export default function register(api: OpenClawPluginApi): void {
 
     // 2. 段 2: session cumulative breaker
     const sessionState = getOrCreateSessionState(sessionStateMap, sessionId);
-    // current turn の prompt + messages token を session 単位で加算する。
-    const turnTokens = perTurnTokens;
+    const promptTokens = estimateTokenCount(e.prompt ?? "");
+    const messagesTokens = estimateMessagesTokenCount(e.messages);
+    const messagesDeltaTokens = Math.max(0, messagesTokens - sessionState.observedMessagesTokens);
+    // prompt は current turn 入力として毎回加算し、messages 履歴は前回観測からの増分だけ加算する。
+    const turnTokens = promptTokens + messagesDeltaTokens;
     sessionState.cumulativeTokens += turnTokens;
+    sessionState.observedMessagesTokens = messagesTokens;
     if (sessionState.cumulativeTokens > cfg.sessionTokenBudget) {
       warn(
         `${TAG} session_token_budget_exceeded: session=${sessionId} cumulative_tokens=${sessionState.cumulativeTokens} budget=${cfg.sessionTokenBudget}`,
@@ -477,13 +487,7 @@ function extractResultContentBytes(result: unknown): number {
     if (Array.isArray(r.content)) {
       let total = 0;
       for (const item of r.content) {
-        if (item && typeof item === "object") {
-          const text = (item as Record<string, unknown>).text;
-          if (typeof text === "string") total += computeContentBytes(text);
-          else total += computeContentBytes(item);
-        } else {
-          total += computeContentBytes(item);
-        }
+        total += computeContentBytes(item);
       }
       return total;
     }
@@ -495,7 +499,7 @@ function extractResultContentBytes(result: unknown): number {
 function getOrCreateSessionState(map: Map<string, SessionState>, sessionId: string): SessionState {
   let s = map.get(sessionId);
   if (!s) {
-    s = { cumulativeTokens: 0 };
+    s = { cumulativeTokens: 0, observedMessagesTokens: 0 };
     map.set(sessionId, s);
   }
   return s;

--- a/packages/cost-guard/src/index.ts
+++ b/packages/cost-guard/src/index.ts
@@ -281,8 +281,11 @@ export default function register(api: OpenClawPluginApi): void {
 
     if (contentBytes > cfg.rewriteThresholdBytes) {
       const sentinel = buildSentinelMessage(contentBytes);
+      // observe では実際の rewrite を行わないため、log 文言で観測モードを明示する
+      const action =
+        cfg.blockMode === "observe" ? "tool_result_would_be_rewritten" : "tool_result_rewritten";
       log.info(
-        `${TAG} tool_result_rewritten: tool=${toolId} call_id=${toolCallId} bytes=${contentBytes} threshold=${cfg.rewriteThresholdBytes}`,
+        `${TAG} ${action}: tool=${toolId} call_id=${toolCallId} bytes=${contentBytes} threshold=${cfg.rewriteThresholdBytes}`,
       );
       incCounter("cost_guard.tool_result_rewritten", { toolId });
       if (cfg.blockMode === "observe") return {};
@@ -311,9 +314,11 @@ export default function register(api: OpenClawPluginApi): void {
     const sessionId = e.sessionId ?? e.channelId ?? e.accountId ?? "default";
 
     // 0. rollback Mode A: suspendAgent
+    //    本 case は contracts.md §10.1 の 5 metric とは独立した運用イベントのため、
+    //    `cost_guard.session_budget_exceeded` には混ぜず、専用 metric を別途発行する。
     if (cfg.suspendAgent) {
       warn(`${TAG} agent_suspended: session=${sessionId} (suspendAgent=true)`);
-      incCounter("cost_guard.session_budget_exceeded", { reason: "agent_suspended" });
+      incCounter("cost_guard.agent_suspended_block", { sessionId });
       if (cfg.blockMode === "observe") return { outcome: "pass" };
       return {
         outcome: "block",

--- a/packages/cost-guard/src/path-checker.test.ts
+++ b/packages/cost-guard/src/path-checker.test.ts
@@ -504,6 +504,38 @@ describe("findDenyPathMatch - hardlink inode 一致（実 FS）", () => {
     }
   });
 
+  it("large deny directory で非該当 path を複数回検査しても所定時間内に完了", () => {
+    const largeTmpRoot = mkdtempSync(path.join(tmpdir(), "cost-guard-hardlink-large-repeat-"));
+    try {
+      const largeDenyDir = path.join(largeTmpRoot, "deny");
+      const largeAllowedDir = path.join(largeTmpRoot, "allowed");
+      mkdirSync(largeDenyDir);
+      mkdirSync(largeAllowedDir);
+      for (let i = 0; i < 10_050; i++) {
+        writeFileSync(path.join(largeDenyDir, `f-${i.toString().padStart(5, "0")}.txt`), "x");
+      }
+      const unrelatedPath = path.join(largeAllowedDir, "unrelated.txt");
+      writeFileSync(unrelatedPath, "public");
+
+      const start = Date.now();
+      for (let i = 0; i < 20; i++) {
+        const r = findDenyPathMatch(
+          { path: unrelatedPath },
+          {
+            denyPaths: [largeDenyDir],
+            denyHardlinkTraversal: true,
+            resolveSymlinks: false,
+          },
+        );
+        expect(r).toBeNull();
+      }
+      const elapsed = Date.now() - start;
+      expect(elapsed).toBeLessThan(500);
+    } finally {
+      rmSync(largeTmpRoot, { recursive: true, force: true });
+    }
+  });
+
   it("large deny directory の後続 file への hardlink も inode 一致で検出", () => {
     const largeTmpRoot = mkdtempSync(path.join(tmpdir(), "cost-guard-hardlink-large-target-"));
     try {

--- a/packages/cost-guard/src/path-checker.test.ts
+++ b/packages/cost-guard/src/path-checker.test.ts
@@ -444,16 +444,21 @@ describe("findDenyPathMatch - hardlink inode 一致（実 FS）", () => {
       const freshAllowedDir = path.join(freshTmpRoot, "allowed");
       mkdirSync(freshDenyDir);
       mkdirSync(freshAllowedDir);
+      const initialDenyFile = path.join(freshDenyDir, "initial.txt");
+      const initialHardlinkPath = path.join(freshAllowedDir, "initial-link.txt");
+      writeFileSync(initialDenyFile, "initial secret");
+      linkSync(initialDenyFile, initialHardlinkPath);
 
       const first = findDenyPathMatch(
-        { path: path.join(freshAllowedDir, "before-link.txt") },
+        { path: initialHardlinkPath },
         {
           denyPaths: [freshDenyDir],
           denyHardlinkTraversal: true,
           resolveSymlinks: false,
         },
       );
-      expect(first).toBeNull();
+      expect(first).not.toBeNull();
+      expect(first?.reason).toBe("deny_path_match_inode");
 
       const denyFile = path.join(freshDenyDir, "created-after-first-scan.txt");
       const freshHardlinkPath = path.join(freshAllowedDir, "after-link.txt");

--- a/packages/cost-guard/src/path-checker.test.ts
+++ b/packages/cost-guard/src/path-checker.test.ts
@@ -420,6 +420,23 @@ describe("findDenyPathMatch - hardlink inode 一致（実 FS）", () => {
     expect(r?.reason).toBe("deny_path_match_inode");
   });
 
+  it(
+    "denyPaths に directory を含めて denyHardlinkTraversal=true 時、配下 file の hardlink を inode 一致で検出",
+    () => {
+      const r = findDenyPathMatch(
+        { path: hardlinkPath },
+        {
+          denyPaths: [denyDir],
+          denyHardlinkTraversal: true,
+          resolveSymlinks: false,
+        },
+      );
+      expect(r).not.toBeNull();
+      expect(r?.matched).toBe(denyDir);
+      expect(r?.reason).toBe("deny_path_match_inode");
+    },
+  );
+
   it("denyHardlinkTraversal=false なら inode 一致を検査せず通過", () => {
     const denyFile = path.join(denyDir, "secret.txt");
     const r = findDenyPathMatch(

--- a/packages/cost-guard/src/path-checker.test.ts
+++ b/packages/cost-guard/src/path-checker.test.ts
@@ -437,6 +437,37 @@ describe("findDenyPathMatch - hardlink inode 一致（実 FS）", () => {
     },
   );
 
+  it("deny directory 配下が 10,000 件を超えても hardlink を inode 一致で検出", () => {
+    const largeTmpRoot = mkdtempSync(path.join(tmpdir(), "cost-guard-hardlink-large-"));
+    try {
+      const largeDenyDir = path.join(largeTmpRoot, "deny");
+      const largeAllowedDir = path.join(largeTmpRoot, "allowed");
+      mkdirSync(largeDenyDir);
+      mkdirSync(largeAllowedDir);
+      for (let i = 0; i < 10_001; i++) {
+        writeFileSync(path.join(largeDenyDir, `f-${i}.txt`), "x");
+      }
+      const targetDenyFile = path.join(largeDenyDir, "target-after-limit.txt");
+      writeFileSync(targetDenyFile, "secret");
+      const largeHardlinkPath = path.join(largeAllowedDir, "target-link.txt");
+      linkSync(targetDenyFile, largeHardlinkPath);
+
+      const r = findDenyPathMatch(
+        { path: largeHardlinkPath },
+        {
+          denyPaths: [largeDenyDir],
+          denyHardlinkTraversal: true,
+          resolveSymlinks: false,
+        },
+      );
+      expect(r).not.toBeNull();
+      expect(r?.matched).toBe(largeDenyDir);
+      expect(r?.reason).toBe("deny_path_match_inode");
+    } finally {
+      rmSync(largeTmpRoot, { recursive: true, force: true });
+    }
+  });
+
   it("denyHardlinkTraversal=false なら inode 一致を検査せず通過", () => {
     const denyFile = path.join(denyDir, "secret.txt");
     const r = findDenyPathMatch(

--- a/packages/cost-guard/src/path-checker.test.ts
+++ b/packages/cost-guard/src/path-checker.test.ts
@@ -1,0 +1,453 @@
+/**
+ * path-checker の単体テスト（30+ 迂回パターン検証）
+ *
+ * Phase 0 cost-guard-hello の path.resolve canonical 化を継承しつつ：
+ * - realpath（symlink 解決）の検出
+ * - inode 一致（hardlink）の検出
+ * - URL-encoded、不可視文字、NFKC 正規化での迂回試行
+ *
+ * 30+ 迂回パターン（path-checker.ts のコメント参照）の各パターンを test。
+ * 実 FS 不要な文字列ベース canonical 化のテストが大半。symlink / inode は
+ * tmpdir 内に実 FS を構築して検証。
+ *
+ * leaf_node: false（critical path）必須項目：
+ * - 30+ 迂回パターン unit test 全 pass
+ * - sentinel boundary value test 全 pass
+ * - latency benchmark < 500ms（mock benchmark）
+ */
+
+import { linkSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  expandPathCandidates,
+  findDenyPathMatch,
+  isWithinDenyPath,
+  normalizePathForMatch,
+} from "./path-checker.js";
+
+const DENY = "/data/workspace/zoom_transcribe/";
+
+const baseOptions = {
+  denyHardlinkTraversal: false,
+  resolveSymlinks: false,
+};
+
+describe("normalizePathForMatch", () => {
+  it("末尾 slash を取り除いた正規化 path を返す", () => {
+    expect(normalizePathForMatch("/data/workspace/zoom_transcribe/")).toBe(
+      "/data/workspace/zoom_transcribe",
+    );
+  });
+
+  it("`../` を解決", () => {
+    expect(normalizePathForMatch("/data/workspace/../workspace/zoom_transcribe")).toBe(
+      "/data/workspace/zoom_transcribe",
+    );
+  });
+
+  it("二重 slash を 1 つにまとめる", () => {
+    expect(normalizePathForMatch("/data//workspace///zoom_transcribe/")).toBe(
+      "/data/workspace/zoom_transcribe",
+    );
+  });
+
+  it("root path はそのまま `/`", () => {
+    expect(normalizePathForMatch("/")).toBe("/");
+  });
+});
+
+describe("isWithinDenyPath", () => {
+  const deny = normalizePathForMatch(DENY);
+
+  it("deny path 配下は true", () => {
+    expect(isWithinDenyPath("/data/workspace/zoom_transcribe/x.txt", deny)).toBe(true);
+  });
+
+  it("deny path と完全一致も true", () => {
+    expect(isWithinDenyPath("/data/workspace/zoom_transcribe", deny)).toBe(true);
+  });
+
+  it("別 directory は false", () => {
+    expect(isWithinDenyPath("/data/workspace/notes/x.md", deny)).toBe(false);
+  });
+
+  it("prefix 一致だけで配下でない path は false", () => {
+    expect(isWithinDenyPath("/data/workspace/zoom_transcribe_old/x.txt", deny)).toBe(false);
+  });
+});
+
+describe("expandPathCandidates", () => {
+  it("絶対 path はそのまま含まれる", () => {
+    const r = expandPathCandidates("/data/workspace/zoom_transcribe/x.txt", [], false);
+    expect(r).toContain("/data/workspace/zoom_transcribe/x.txt");
+  });
+
+  it("`../` 経由を resolve", () => {
+    const r = expandPathCandidates("/data/workspace/../workspace/zoom_transcribe/x.txt", [], false);
+    expect(r).toContain("/data/workspace/zoom_transcribe/x.txt");
+  });
+
+  it("URL-encoded を decode", () => {
+    const r = expandPathCandidates("/data/workspace/zoom_transcribe%2Fx.txt", [], false);
+    // %2F → /
+    expect(r.some((c) => c.includes("/zoom_transcribe/x.txt"))).toBe(true);
+  });
+
+  it("baseDir 起点の相対 path を resolve", () => {
+    const r = expandPathCandidates("zoom_transcribe/x.txt", ["/data/workspace"], false);
+    expect(r).toContain("/data/workspace/zoom_transcribe/x.txt");
+  });
+
+  it("不可視文字（zero-width space）を除去した変種を含む", () => {
+    const r = expandPathCandidates("/data/workspace/zoom_​transcribe/x.txt", [], false);
+    // ZWSP を除去した版が候補に含まれる
+    expect(r.some((c) => c.includes("zoom_transcribe"))).toBe(true);
+  });
+});
+
+describe("findDenyPathMatch - 30+ 迂回パターン", () => {
+  const opts = { denyPaths: [DENY], ...baseOptions };
+
+  it("01 絶対 path 直書き", () => {
+    const r = findDenyPathMatch({ path: "/data/workspace/zoom_transcribe/x.txt" }, opts);
+    expect(r).not.toBeNull();
+    expect(r?.reason).toBe("deny_path_match");
+  });
+
+  it("02 `../` 経由", () => {
+    const r = findDenyPathMatch(
+      { path: "/data/workspace/../workspace/zoom_transcribe/x.txt" },
+      opts,
+    );
+    expect(r).not.toBeNull();
+  });
+
+  it("03 `./` 経由", () => {
+    const r = findDenyPathMatch({ path: "/data/workspace/./zoom_transcribe/x.txt" }, opts);
+    expect(r).not.toBeNull();
+  });
+
+  it("04 二重 slash `//`", () => {
+    const r = findDenyPathMatch({ path: "/data//workspace//zoom_transcribe/x.txt" }, opts);
+    expect(r).not.toBeNull();
+  });
+
+  it("05 末尾 slash 有", () => {
+    const r = findDenyPathMatch({ path: "/data/workspace/zoom_transcribe/" }, opts);
+    expect(r).not.toBeNull();
+  });
+
+  it("05b 末尾 slash 無 directory", () => {
+    const r = findDenyPathMatch({ path: "/data/workspace/zoom_transcribe" }, opts);
+    expect(r).not.toBeNull();
+  });
+
+  it("06 URL-encoded path (%2F)", () => {
+    const r = findDenyPathMatch({ path: "/data/workspace/zoom_transcribe%2Fx.txt" }, opts);
+    expect(r).not.toBeNull();
+  });
+
+  it("06b URL-encoded path (%2E%2E)", () => {
+    const r = findDenyPathMatch(
+      { path: "/data/workspace/%2E%2E/workspace/zoom_transcribe/x.txt" },
+      opts,
+    );
+    expect(r).not.toBeNull();
+  });
+
+  it("07 cwd 起点の相対 path", () => {
+    const r = findDenyPathMatch({ cwd: "/data/workspace", path: "zoom_transcribe/x.txt" }, opts);
+    expect(r).not.toBeNull();
+  });
+
+  it("08 workdir 起点の相対 path", () => {
+    const r = findDenyPathMatch(
+      { workdir: "/data/workspace", path: "zoom_transcribe/x.txt" },
+      opts,
+    );
+    expect(r).not.toBeNull();
+  });
+
+  it("09 dir 起点の相対 path", () => {
+    const r = findDenyPathMatch({ dir: "/data/workspace", path: "zoom_transcribe/x.txt" }, opts);
+    expect(r).not.toBeNull();
+  });
+
+  it("10 bare filename + cwd（command-like field）", () => {
+    const r = findDenyPathMatch(
+      { cwd: "/data/workspace/zoom_transcribe", command: "cat transcript.txt" },
+      opts,
+    );
+    expect(r).not.toBeNull();
+  });
+
+  it("11 command 内 redirection `<`", () => {
+    const r = findDenyPathMatch({ command: "cat</data/workspace/zoom_transcribe/x.txt" }, opts);
+    expect(r).not.toBeNull();
+  });
+
+  it("12 command 内 redirection `>`", () => {
+    const r = findDenyPathMatch({ command: "cat>/data/workspace/zoom_transcribe/x.txt" }, opts);
+    expect(r).not.toBeNull();
+  });
+
+  it("13 command 内 option value `--file=`", () => {
+    const r = findDenyPathMatch(
+      { command: "cat --file=/data/workspace/zoom_transcribe/x.txt" },
+      opts,
+    );
+    expect(r).not.toBeNull();
+  });
+
+  it("14 command 内 pipe `|`", () => {
+    const r = findDenyPathMatch(
+      { command: "head /data/workspace/zoom_transcribe/x.txt | wc -l" },
+      opts,
+    );
+    expect(r).not.toBeNull();
+  });
+
+  it("15 command 内空白区切り", () => {
+    const r = findDenyPathMatch({ command: "cat /data/workspace/zoom_transcribe/x.txt" }, opts);
+    expect(r).not.toBeNull();
+  });
+
+  it("16 args 配列の各要素（path 要素）", () => {
+    const r = findDenyPathMatch({ args: ["-c", "/data/workspace/zoom_transcribe/x.txt"] }, opts);
+    expect(r).not.toBeNull();
+    expect(r?.field).toBe("args[1]");
+  });
+
+  it("17 ネスト object", () => {
+    const r = findDenyPathMatch(
+      { tool: { params: { path: "/data/workspace/zoom_transcribe/x.txt" } } },
+      opts,
+    );
+    expect(r).not.toBeNull();
+  });
+
+  it("18 ネスト array", () => {
+    const r = findDenyPathMatch(
+      { items: [{ path: "/data/workspace/zoom_transcribe/x.txt" }] },
+      opts,
+    );
+    expect(r).not.toBeNull();
+  });
+
+  it("22 /proc/<pid>/root/... を含む path 文字列", () => {
+    const r = findDenyPathMatch(
+      { path: "/proc/123/root/data/workspace/zoom_transcribe/x.txt" },
+      { ...opts, denyPaths: ["/proc/"] },
+    );
+    expect(r).not.toBeNull();
+  });
+
+  it("23 自己参照 `./.`", () => {
+    const r = findDenyPathMatch({ path: "/data/workspace/./zoom_transcribe/./x.txt" }, opts);
+    expect(r).not.toBeNull();
+  });
+
+  it("24 連続 `../../..`", () => {
+    const r = findDenyPathMatch(
+      { path: "/data/x/../../data/workspace/zoom_transcribe/x.txt" },
+      opts,
+    );
+    expect(r).not.toBeNull();
+  });
+
+  it("25 不可視文字（ZWSP / NBSP / BOM）混入", () => {
+    const r = findDenyPathMatch(
+      { path: "/data/workspace/zoom_​transcribe/x.txt" }, // ZWSP
+      opts,
+    );
+    expect(r).not.toBeNull();
+  });
+
+  it("26 改行（CR / LF）混入", () => {
+    const r = findDenyPathMatch({ path: "/data/workspace/\nzoom_transcribe/x.txt" }, opts);
+    expect(r).not.toBeNull();
+  });
+
+  it("27 tab 混入", () => {
+    const r = findDenyPathMatch({ path: "/data/workspace/\tzoom_transcribe/x.txt" }, opts);
+    expect(r).not.toBeNull();
+  });
+
+  it("28 末尾空白", () => {
+    const r = findDenyPathMatch({ path: "/data/workspace/zoom_transcribe/x.txt   " }, opts);
+    expect(r).not.toBeNull();
+  });
+
+  it("29 先頭空白", () => {
+    const r = findDenyPathMatch({ path: "   /data/workspace/zoom_transcribe/x.txt" }, opts);
+    expect(r).not.toBeNull();
+  });
+
+  it("30 args 内 option value", () => {
+    const r = findDenyPathMatch({ args: ["--file=/data/workspace/zoom_transcribe/x.txt"] }, opts);
+    expect(r).not.toBeNull();
+  });
+
+  it("31 args 内 redirection", () => {
+    const r = findDenyPathMatch({ args: ["cat</data/workspace/zoom_transcribe/x.txt"] }, opts);
+    expect(r).not.toBeNull();
+  });
+
+  it("32 NFKC 正規化（全角 slash → 半角 slash）", () => {
+    // NFKC で全角文字が半角になる典型例
+    const r = findDenyPathMatch(
+      { path: "/data/workspace/zoom_transcribe/x.txt".normalize("NFKC") },
+      opts,
+    );
+    expect(r).not.toBeNull();
+  });
+});
+
+describe("findDenyPathMatch - false positive 回避", () => {
+  const opts = { denyPaths: [DENY], ...baseOptions };
+
+  it("別 directory は通過", () => {
+    const r = findDenyPathMatch({ path: "/data/workspace/note.md" }, opts);
+    expect(r).toBeNull();
+  });
+
+  it("denyPaths が空配列なら null", () => {
+    const r = findDenyPathMatch(
+      { path: "/data/workspace/zoom_transcribe/x.txt" },
+      { denyPaths: [], ...baseOptions },
+    );
+    expect(r).toBeNull();
+  });
+
+  it("prefix 一致だけで配下でない path は null（zoom_transcribe_old）", () => {
+    const r = findDenyPathMatch({ path: "/data/workspace/zoom_transcribe_old/x.txt" }, opts);
+    expect(r).toBeNull();
+  });
+
+  it("循環参照 object でも throw しない", () => {
+    const o: Record<string, unknown> = { path: "/data/workspace/note.md" };
+    o.self = o;
+    expect(() => findDenyPathMatch(o, opts)).not.toThrow();
+  });
+});
+
+describe("findDenyPathMatch - symlink 解決（実 FS）", () => {
+  let tmpRoot: string;
+  let denyDir: string;
+  let allowedDir: string;
+  let symlinkPath: string;
+
+  beforeAll(() => {
+    tmpRoot = mkdtempSync(path.join(tmpdir(), "cost-guard-symlink-"));
+    denyDir = path.join(tmpRoot, "deny");
+    allowedDir = path.join(tmpRoot, "allowed");
+    mkdirSync(denyDir);
+    mkdirSync(allowedDir);
+    writeFileSync(path.join(denyDir, "secret.txt"), "secret");
+    symlinkPath = path.join(allowedDir, "shortcut");
+    symlinkSync(denyDir, symlinkPath);
+  });
+
+  afterAll(() => {
+    rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it("symlink 越えで deny 配下に到達する path を deny_path_match_symlink で検出", () => {
+    const symlinkedFile = path.join(symlinkPath, "secret.txt");
+    const r = findDenyPathMatch(
+      { path: symlinkedFile },
+      {
+        denyPaths: [denyDir],
+        denyHardlinkTraversal: false,
+        resolveSymlinks: true,
+      },
+    );
+    expect(r).not.toBeNull();
+    expect(r?.reason).toBe("deny_path_match_symlink");
+  });
+
+  it("resolveSymlinks=false なら symlink を解決せず通過", () => {
+    const symlinkedFile = path.join(symlinkPath, "secret.txt");
+    const r = findDenyPathMatch(
+      { path: symlinkedFile },
+      {
+        denyPaths: [denyDir],
+        denyHardlinkTraversal: false,
+        resolveSymlinks: false,
+      },
+    );
+    expect(r).toBeNull();
+  });
+});
+
+describe("findDenyPathMatch - hardlink inode 一致（実 FS）", () => {
+  let tmpRoot: string;
+  let denyDir: string;
+  let allowedDir: string;
+  let hardlinkPath: string;
+
+  beforeAll(() => {
+    tmpRoot = mkdtempSync(path.join(tmpdir(), "cost-guard-hardlink-"));
+    denyDir = path.join(tmpRoot, "deny");
+    allowedDir = path.join(tmpRoot, "allowed");
+    mkdirSync(denyDir);
+    mkdirSync(allowedDir);
+    // hardlink は file 単位（directory hardlink は不可）
+    // deny 配下に実 file を置く
+    const denyFile = path.join(denyDir, "secret.txt");
+    writeFileSync(denyFile, "secret");
+    hardlinkPath = path.join(allowedDir, "secret_link.txt");
+    linkSync(denyFile, hardlinkPath);
+  });
+
+  afterAll(() => {
+    rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it("denyPaths に file を含めて denyHardlinkTraversal=true 時、hardlink を inode 一致で検出", () => {
+    const denyFile = path.join(denyDir, "secret.txt");
+    const r = findDenyPathMatch(
+      { path: hardlinkPath },
+      {
+        denyPaths: [denyFile],
+        denyHardlinkTraversal: true,
+        resolveSymlinks: false,
+      },
+    );
+    expect(r).not.toBeNull();
+    expect(r?.reason).toBe("deny_path_match_inode");
+  });
+
+  it("denyHardlinkTraversal=false なら inode 一致を検査せず通過", () => {
+    const denyFile = path.join(denyDir, "secret.txt");
+    const r = findDenyPathMatch(
+      { path: hardlinkPath },
+      {
+        denyPaths: [denyFile],
+        denyHardlinkTraversal: false,
+        resolveSymlinks: false,
+      },
+    );
+    expect(r).toBeNull();
+  });
+});
+
+describe("findDenyPathMatch - latency benchmark", () => {
+  const opts = { denyPaths: [DENY], ...baseOptions };
+
+  it("50 件の path 検査が 500ms 未満で完了", () => {
+    const start = Date.now();
+    for (let i = 0; i < 50; i++) {
+      findDenyPathMatch({ path: `/data/workspace/zoom_transcribe/file_${i}.txt` }, opts);
+      findDenyPathMatch({ path: `/data/workspace/note_${i}.md` }, opts);
+      findDenyPathMatch(
+        { cwd: "/data/workspace", command: `cat zoom_transcribe/file_${i}.txt` },
+        opts,
+      );
+    }
+    const elapsed = Date.now() - start;
+    expect(elapsed).toBeLessThan(500);
+  });
+});

--- a/packages/cost-guard/src/path-checker.test.ts
+++ b/packages/cost-guard/src/path-checker.test.ts
@@ -439,7 +439,7 @@ describe("findDenyPathMatch - hardlink inode 一致（実 FS）", () => {
     },
   );
 
-  it("large deny directory は 10,000 件上限で打ち切り、同一 denyPaths では cache を再利用", () => {
+  it("large deny directory の走査上限到達時は hardlink 判定を fail closed し、cache を再利用", () => {
     clearDenyInodeCacheForTest();
     const largeTmpRoot = mkdtempSync(path.join(tmpdir(), "cost-guard-hardlink-large-"));
     try {
@@ -448,13 +448,15 @@ describe("findDenyPathMatch - hardlink inode 一致（実 FS）", () => {
       mkdirSync(largeDenyDir);
       mkdirSync(largeAllowedDir);
       for (let i = 0; i < 10_050; i++) {
-        writeFileSync(path.join(largeDenyDir, `f-${i}.txt`), "x");
+        writeFileSync(path.join(largeDenyDir, `f-${i.toString().padStart(5, "0")}.txt`), "x");
       }
-      const unrelatedPath = path.join(largeAllowedDir, "unrelated.txt");
-      writeFileSync(unrelatedPath, "safe");
+      const targetAfterLimit = path.join(largeDenyDir, "z-target-after-limit.txt");
+      writeFileSync(targetAfterLimit, "secret");
+      const hardlinkAfterLimit = path.join(largeAllowedDir, "target-link.txt");
+      linkSync(targetAfterLimit, hardlinkAfterLimit);
 
       const first = findDenyPathMatch(
-        { path: unrelatedPath },
+        { path: hardlinkAfterLimit },
         {
           denyPaths: [largeDenyDir],
           denyHardlinkTraversal: true,
@@ -463,7 +465,7 @@ describe("findDenyPathMatch - hardlink inode 一致（実 FS）", () => {
       );
       const firstStats = getDenyInodeCacheStatsForTest();
       const second = findDenyPathMatch(
-        { path: unrelatedPath },
+        { path: hardlinkAfterLimit },
         {
           denyPaths: [largeDenyDir],
           denyHardlinkTraversal: true,
@@ -472,8 +474,10 @@ describe("findDenyPathMatch - hardlink inode 一致（実 FS）", () => {
       );
       const secondStats = getDenyInodeCacheStatsForTest();
 
-      expect(first).toBeNull();
-      expect(second).toBeNull();
+      expect(first).not.toBeNull();
+      expect(first?.matched).toBe(largeDenyDir);
+      expect(first?.reason).toBe("deny_path_match_inode");
+      expect(second).toEqual(first);
       expect(firstStats.size).toBe(1);
       expect(firstStats.entries[0]?.scannedEntries).toBeLessThanOrEqual(10_000);
       expect(firstStats.entries[0]?.truncated).toBe(true);

--- a/packages/cost-guard/src/path-checker.test.ts
+++ b/packages/cost-guard/src/path-checker.test.ts
@@ -21,10 +21,8 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import {
-  clearDenyInodeCacheForTest,
   expandPathCandidates,
   findDenyPathMatch,
-  getDenyInodeCacheStatsForTest,
   isWithinDenyPath,
   normalizePathForMatch,
 } from "./path-checker.js";
@@ -439,8 +437,46 @@ describe("findDenyPathMatch - hardlink inode 一致（実 FS）", () => {
     },
   );
 
-  it("large deny directory の走査上限到達時は hardlink 判定を fail closed し、cache を再利用", () => {
-    clearDenyInodeCacheForTest();
+  it("deny directory の初回走査後に追加された file の hardlink も inode 一致で検出", () => {
+    const freshTmpRoot = mkdtempSync(path.join(tmpdir(), "cost-guard-hardlink-fresh-"));
+    try {
+      const freshDenyDir = path.join(freshTmpRoot, "deny");
+      const freshAllowedDir = path.join(freshTmpRoot, "allowed");
+      mkdirSync(freshDenyDir);
+      mkdirSync(freshAllowedDir);
+
+      const first = findDenyPathMatch(
+        { path: path.join(freshAllowedDir, "before-link.txt") },
+        {
+          denyPaths: [freshDenyDir],
+          denyHardlinkTraversal: true,
+          resolveSymlinks: false,
+        },
+      );
+      expect(first).toBeNull();
+
+      const denyFile = path.join(freshDenyDir, "created-after-first-scan.txt");
+      const freshHardlinkPath = path.join(freshAllowedDir, "after-link.txt");
+      writeFileSync(denyFile, "secret");
+      linkSync(denyFile, freshHardlinkPath);
+
+      const second = findDenyPathMatch(
+        { path: freshHardlinkPath },
+        {
+          denyPaths: [freshDenyDir],
+          denyHardlinkTraversal: true,
+          resolveSymlinks: false,
+        },
+      );
+      expect(second).not.toBeNull();
+      expect(second?.matched).toBe(freshDenyDir);
+      expect(second?.reason).toBe("deny_path_match_inode");
+    } finally {
+      rmSync(freshTmpRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("large deny directory の走査上限到達時も無関係な既存 absolute path は block しない", () => {
     const largeTmpRoot = mkdtempSync(path.join(tmpdir(), "cost-guard-hardlink-large-"));
     try {
       const largeDenyDir = path.join(largeTmpRoot, "deny");
@@ -450,41 +486,21 @@ describe("findDenyPathMatch - hardlink inode 一致（実 FS）", () => {
       for (let i = 0; i < 10_050; i++) {
         writeFileSync(path.join(largeDenyDir, `f-${i.toString().padStart(5, "0")}.txt`), "x");
       }
-      const targetAfterLimit = path.join(largeDenyDir, "z-target-after-limit.txt");
-      writeFileSync(targetAfterLimit, "secret");
-      const hardlinkAfterLimit = path.join(largeAllowedDir, "target-link.txt");
-      linkSync(targetAfterLimit, hardlinkAfterLimit);
+      const unrelatedPath = path.join(largeAllowedDir, "unrelated.txt");
+      writeFileSync(unrelatedPath, "public");
 
-      const first = findDenyPathMatch(
-        { path: hardlinkAfterLimit },
+      const r = findDenyPathMatch(
+        { path: unrelatedPath },
         {
           denyPaths: [largeDenyDir],
           denyHardlinkTraversal: true,
           resolveSymlinks: false,
         },
       );
-      const firstStats = getDenyInodeCacheStatsForTest();
-      const second = findDenyPathMatch(
-        { path: hardlinkAfterLimit },
-        {
-          denyPaths: [largeDenyDir],
-          denyHardlinkTraversal: true,
-          resolveSymlinks: false,
-        },
-      );
-      const secondStats = getDenyInodeCacheStatsForTest();
 
-      expect(first).not.toBeNull();
-      expect(first?.matched).toBe(largeDenyDir);
-      expect(first?.reason).toBe("deny_path_match_inode");
-      expect(second).toEqual(first);
-      expect(firstStats.size).toBe(1);
-      expect(firstStats.entries[0]?.scannedEntries).toBeLessThanOrEqual(10_000);
-      expect(firstStats.entries[0]?.truncated).toBe(true);
-      expect(secondStats).toEqual(firstStats);
+      expect(r).toBeNull();
     } finally {
       rmSync(largeTmpRoot, { recursive: true, force: true });
-      clearDenyInodeCacheForTest();
     }
   });
 

--- a/packages/cost-guard/src/path-checker.test.ts
+++ b/packages/cost-guard/src/path-checker.test.ts
@@ -420,22 +420,19 @@ describe("findDenyPathMatch - hardlink inode 一致（実 FS）", () => {
     expect(r?.reason).toBe("deny_path_match_inode");
   });
 
-  it(
-    "denyPaths に directory を含めて denyHardlinkTraversal=true 時、配下 file の hardlink を inode 一致で検出",
-    () => {
-      const r = findDenyPathMatch(
-        { path: hardlinkPath },
-        {
-          denyPaths: [denyDir],
-          denyHardlinkTraversal: true,
-          resolveSymlinks: false,
-        },
-      );
-      expect(r).not.toBeNull();
-      expect(r?.matched).toBe(denyDir);
-      expect(r?.reason).toBe("deny_path_match_inode");
-    },
-  );
+  it("denyPaths に directory を含めて denyHardlinkTraversal=true 時、配下 file の hardlink を inode 一致で検出", () => {
+    const r = findDenyPathMatch(
+      { path: hardlinkPath },
+      {
+        denyPaths: [denyDir],
+        denyHardlinkTraversal: true,
+        resolveSymlinks: false,
+      },
+    );
+    expect(r).not.toBeNull();
+    expect(r?.matched).toBe(denyDir);
+    expect(r?.reason).toBe("deny_path_match_inode");
+  });
 
   it("deny directory の初回走査後に追加された file の hardlink も inode 一致で検出", () => {
     const freshTmpRoot = mkdtempSync(path.join(tmpdir(), "cost-guard-hardlink-fresh-"));

--- a/packages/cost-guard/src/path-checker.test.ts
+++ b/packages/cost-guard/src/path-checker.test.ts
@@ -21,8 +21,10 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import {
+  clearDenyInodeCacheForTest,
   expandPathCandidates,
   findDenyPathMatch,
+  getDenyInodeCacheStatsForTest,
   isWithinDenyPath,
   normalizePathForMatch,
 } from "./path-checker.js";
@@ -437,34 +439,48 @@ describe("findDenyPathMatch - hardlink inode 一致（実 FS）", () => {
     },
   );
 
-  it("deny directory 配下が 10,000 件を超えても hardlink を inode 一致で検出", () => {
+  it("large deny directory は 10,000 件上限で打ち切り、同一 denyPaths では cache を再利用", () => {
+    clearDenyInodeCacheForTest();
     const largeTmpRoot = mkdtempSync(path.join(tmpdir(), "cost-guard-hardlink-large-"));
     try {
       const largeDenyDir = path.join(largeTmpRoot, "deny");
       const largeAllowedDir = path.join(largeTmpRoot, "allowed");
       mkdirSync(largeDenyDir);
       mkdirSync(largeAllowedDir);
-      for (let i = 0; i < 10_001; i++) {
+      for (let i = 0; i < 10_050; i++) {
         writeFileSync(path.join(largeDenyDir, `f-${i}.txt`), "x");
       }
-      const targetDenyFile = path.join(largeDenyDir, "target-after-limit.txt");
-      writeFileSync(targetDenyFile, "secret");
-      const largeHardlinkPath = path.join(largeAllowedDir, "target-link.txt");
-      linkSync(targetDenyFile, largeHardlinkPath);
+      const unrelatedPath = path.join(largeAllowedDir, "unrelated.txt");
+      writeFileSync(unrelatedPath, "safe");
 
-      const r = findDenyPathMatch(
-        { path: largeHardlinkPath },
+      const first = findDenyPathMatch(
+        { path: unrelatedPath },
         {
           denyPaths: [largeDenyDir],
           denyHardlinkTraversal: true,
           resolveSymlinks: false,
         },
       );
-      expect(r).not.toBeNull();
-      expect(r?.matched).toBe(largeDenyDir);
-      expect(r?.reason).toBe("deny_path_match_inode");
+      const firstStats = getDenyInodeCacheStatsForTest();
+      const second = findDenyPathMatch(
+        { path: unrelatedPath },
+        {
+          denyPaths: [largeDenyDir],
+          denyHardlinkTraversal: true,
+          resolveSymlinks: false,
+        },
+      );
+      const secondStats = getDenyInodeCacheStatsForTest();
+
+      expect(first).toBeNull();
+      expect(second).toBeNull();
+      expect(firstStats.size).toBe(1);
+      expect(firstStats.entries[0]?.scannedEntries).toBeLessThanOrEqual(10_000);
+      expect(firstStats.entries[0]?.truncated).toBe(true);
+      expect(secondStats).toEqual(firstStats);
     } finally {
       rmSync(largeTmpRoot, { recursive: true, force: true });
+      clearDenyInodeCacheForTest();
     }
   });
 

--- a/packages/cost-guard/src/path-checker.test.ts
+++ b/packages/cost-guard/src/path-checker.test.ts
@@ -476,7 +476,7 @@ describe("findDenyPathMatch - hardlink inode 一致（実 FS）", () => {
     }
   });
 
-  it("large deny directory の走査上限到達時も無関係な既存 absolute path は block しない", () => {
+  it("large deny directory でも無関係な既存 absolute path は block しない", () => {
     const largeTmpRoot = mkdtempSync(path.join(tmpdir(), "cost-guard-hardlink-large-"));
     try {
       const largeDenyDir = path.join(largeTmpRoot, "deny");
@@ -499,6 +499,38 @@ describe("findDenyPathMatch - hardlink inode 一致（実 FS）", () => {
       );
 
       expect(r).toBeNull();
+    } finally {
+      rmSync(largeTmpRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("large deny directory の後続 file への hardlink も inode 一致で検出", () => {
+    const largeTmpRoot = mkdtempSync(path.join(tmpdir(), "cost-guard-hardlink-large-target-"));
+    try {
+      const largeDenyDir = path.join(largeTmpRoot, "deny");
+      const largeAllowedDir = path.join(largeTmpRoot, "allowed");
+      mkdirSync(largeDenyDir);
+      mkdirSync(largeAllowedDir);
+      for (let i = 0; i < 10_050; i++) {
+        writeFileSync(path.join(largeDenyDir, `f-${i.toString().padStart(5, "0")}.txt`), "x");
+      }
+      const lateDenyFile = path.join(largeDenyDir, "z-late-secret.txt");
+      const lateHardlinkPath = path.join(largeAllowedDir, "late-secret-link.txt");
+      writeFileSync(lateDenyFile, "secret");
+      linkSync(lateDenyFile, lateHardlinkPath);
+
+      const r = findDenyPathMatch(
+        { path: lateHardlinkPath },
+        {
+          denyPaths: [largeDenyDir],
+          denyHardlinkTraversal: true,
+          resolveSymlinks: false,
+        },
+      );
+
+      expect(r).not.toBeNull();
+      expect(r?.matched).toBe(largeDenyDir);
+      expect(r?.reason).toBe("deny_path_match_inode");
     } finally {
       rmSync(largeTmpRoot, { recursive: true, force: true });
     }

--- a/packages/cost-guard/src/path-checker.ts
+++ b/packages/cost-guard/src/path-checker.ts
@@ -68,8 +68,6 @@ const BASE_DIR_FIELD_NAMES = new Set([
   "dir",
 ]);
 
-const DENY_INODE_SCAN_LIMIT = 10_000;
-
 interface DenyInodeScanResult {
   map: Map<string, string>;
 }
@@ -195,10 +193,8 @@ export function findDenyPathMatch(
 function collectDenyInodes(denyPaths: string[]): DenyInodeScanResult {
   const map = new Map<string, string>();
   const visitedDirs = new Set<string>();
-  const state = { scannedEntries: 0, truncated: false };
   for (const p of denyPaths) {
-    collectDenyPathInodes(p, p, map, visitedDirs, state);
-    if (state.truncated) break;
+    collectDenyPathInodes(p, p, map, visitedDirs);
   }
   return { map };
 }
@@ -208,14 +204,7 @@ function collectDenyPathInodes(
   currentPath: string,
   map: Map<string, string>,
   visitedDirs: Set<string>,
-  state: { scannedEntries: number; truncated: boolean },
 ): void {
-  if (state.truncated) return;
-  if (state.scannedEntries >= DENY_INODE_SCAN_LIMIT) {
-    state.truncated = true;
-    return;
-  }
-  state.scannedEntries++;
   const stat = tryStat(currentPath);
   if (!stat) return;
   const inodeKey = `${stat.dev}:${stat.ino}`;
@@ -227,17 +216,11 @@ function collectDenyPathInodes(
   const entries = tryReadDir(currentPath);
   if (!entries) return;
   for (const entry of entries) {
-    if (state.truncated) return;
     const entryPath = path.join(currentPath, entry.name);
     if (entry.isDirectory()) {
-      collectDenyPathInodes(denyRoot, entryPath, map, visitedDirs, state);
+      collectDenyPathInodes(denyRoot, entryPath, map, visitedDirs);
       continue;
     }
-    if (state.scannedEntries >= DENY_INODE_SCAN_LIMIT) {
-      state.truncated = true;
-      return;
-    }
-    state.scannedEntries++;
     const entryStat = tryStat(entryPath);
     if (entryStat) {
       map.set(`${entryStat.dev}:${entryStat.ino}`, denyRoot);

--- a/packages/cost-guard/src/path-checker.ts
+++ b/packages/cost-guard/src/path-checker.ts
@@ -44,7 +44,7 @@
  * 実 FS 不在時（CI / unit test）は realpath / stat エラーを無視し、文字列ベースの canonical 化のみで判定。
  */
 
-import { realpathSync, type Stats, statSync } from "node:fs";
+import { type Dirent, readdirSync, realpathSync, type Stats, statSync } from "node:fs";
 import path from "node:path";
 
 export interface PathCheckOptions {
@@ -67,6 +67,8 @@ const BASE_DIR_FIELD_NAMES = new Set([
   "working_directory",
   "dir",
 ]);
+
+const MAX_DENY_INODE_ENTRIES = 10_000;
 
 /**
  * tool params を再帰走査し、denyPaths にマッチする path 候補を探す。
@@ -183,17 +185,56 @@ export function findDenyPathMatch(
 
 /**
  * denyPaths 各 entry の inode を収集する。
+ * denyPaths が directory の場合は、運用上限 MAX_DENY_INODE_ENTRIES まで
+ * 配下も収集する。
  * 実 FS に存在しない deny path はスキップ（test 環境で /data/workspace 等が無いケース対応）。
  */
 function collectDenyInodes(denyPaths: string[]): Map<string, string> {
   const map = new Map<string, string>();
+  const budget = { remaining: MAX_DENY_INODE_ENTRIES };
   for (const p of denyPaths) {
-    const stat = tryStat(p);
-    if (stat) {
-      map.set(`${stat.dev}:${stat.ino}`, p);
-    }
+    collectDenyPathInodes(p, p, map, budget);
+    if (budget.remaining <= 0) break;
   }
   return map;
+}
+
+function collectDenyPathInodes(
+  denyRoot: string,
+  currentPath: string,
+  map: Map<string, string>,
+  budget: { remaining: number },
+): void {
+  if (budget.remaining <= 0) return;
+  budget.remaining -= 1;
+  const stat = tryStat(currentPath);
+  if (!stat) return;
+  map.set(`${stat.dev}:${stat.ino}`, denyRoot);
+  if (!stat.isDirectory()) return;
+
+  const entries = tryReadDir(currentPath);
+  if (!entries) return;
+  for (const entry of entries) {
+    if (budget.remaining <= 0) return;
+    const entryPath = path.join(currentPath, entry.name);
+    if (entry.isDirectory()) {
+      collectDenyPathInodes(denyRoot, entryPath, map, budget);
+      continue;
+    }
+    budget.remaining -= 1;
+    const entryStat = tryStat(entryPath);
+    if (entryStat) {
+      map.set(`${entryStat.dev}:${entryStat.ino}`, denyRoot);
+    }
+  }
+}
+
+function tryReadDir(p: string): Dirent[] | null {
+  try {
+    return readdirSync(p, { withFileTypes: true });
+  } catch {
+    return null;
+  }
 }
 
 function tryRealpath(p: string): string | null {

--- a/packages/cost-guard/src/path-checker.ts
+++ b/packages/cost-guard/src/path-checker.ts
@@ -68,8 +68,6 @@ const BASE_DIR_FIELD_NAMES = new Set([
   "dir",
 ]);
 
-const MAX_DENY_INODE_ENTRIES = 10_000;
-
 /**
  * tool params を再帰走査し、denyPaths にマッチする path 候補を探す。
  *
@@ -185,16 +183,14 @@ export function findDenyPathMatch(
 
 /**
  * denyPaths 各 entry の inode を収集する。
- * denyPaths が directory の場合は、運用上限 MAX_DENY_INODE_ENTRIES まで
- * 配下も収集する。
+ * denyPaths が directory の場合は、配下も再帰的に収集する。
  * 実 FS に存在しない deny path はスキップ（test 環境で /data/workspace 等が無いケース対応）。
  */
 function collectDenyInodes(denyPaths: string[]): Map<string, string> {
   const map = new Map<string, string>();
-  const budget = { remaining: MAX_DENY_INODE_ENTRIES };
+  const visitedDirs = new Set<string>();
   for (const p of denyPaths) {
-    collectDenyPathInodes(p, p, map, budget);
-    if (budget.remaining <= 0) break;
+    collectDenyPathInodes(p, p, map, visitedDirs);
   }
   return map;
 }
@@ -203,25 +199,24 @@ function collectDenyPathInodes(
   denyRoot: string,
   currentPath: string,
   map: Map<string, string>,
-  budget: { remaining: number },
+  visitedDirs: Set<string>,
 ): void {
-  if (budget.remaining <= 0) return;
-  budget.remaining -= 1;
   const stat = tryStat(currentPath);
   if (!stat) return;
-  map.set(`${stat.dev}:${stat.ino}`, denyRoot);
+  const inodeKey = `${stat.dev}:${stat.ino}`;
+  map.set(inodeKey, denyRoot);
   if (!stat.isDirectory()) return;
+  if (visitedDirs.has(inodeKey)) return;
+  visitedDirs.add(inodeKey);
 
   const entries = tryReadDir(currentPath);
   if (!entries) return;
   for (const entry of entries) {
-    if (budget.remaining <= 0) return;
     const entryPath = path.join(currentPath, entry.name);
     if (entry.isDirectory()) {
-      collectDenyPathInodes(denyRoot, entryPath, map, budget);
+      collectDenyPathInodes(denyRoot, entryPath, map, visitedDirs);
       continue;
     }
-    budget.remaining -= 1;
     const entryStat = tryStat(entryPath);
     if (entryStat) {
       map.set(`${entryStat.dev}:${entryStat.ino}`, denyRoot);

--- a/packages/cost-guard/src/path-checker.ts
+++ b/packages/cost-guard/src/path-checker.ts
@@ -3,7 +3,7 @@
  *
  * Phase 0 の cost-guard-hello に対し以下を追加：
  * - realpath（symlink 解決）：fs.realpathSync で実 FS の symlink を解消
- * - inode 一致検査：denyHardlinkTraversal=true 時、stat の (dev, ino) が denyPaths 配下のいずれかと一致するか確認
+ * - inode 一致検査：denyHardlinkTraversal=true 時、hardlink 候補のみ stat の (dev, ino) が denyPaths 配下のいずれかと一致するか確認
  * - 30+ 迂回パターン耐性：相対 path、`../`、cwd 起点、command 内 redirection、option value 隣接、bare filename、
  *   symlink、hardlink、/proc/self/fd 経由、URL-encoded、二重 slash、末尾 slash 有無
  *
@@ -72,6 +72,9 @@ interface DenyInodeScanResult {
   map: Map<string, string>;
 }
 
+const DENY_INODE_CACHE_TTL_MS = 1000;
+const denyInodeCache = new Map<string, { expiresAt: number; result: DenyInodeScanResult }>();
+
 /**
  * tool params を再帰走査し、denyPaths にマッチする path 候補を探す。
  *
@@ -101,7 +104,7 @@ export function findDenyPathMatch(
         })
         .filter((x): x is { original: string; normalized: string } => x !== null)
     : [];
-  const denyInodes = options.denyHardlinkTraversal ? collectDenyInodes(denyPaths) : null;
+  let denyInodes: DenyInodeScanResult | null = null;
 
   function walk(value: unknown, fieldPath: string, baseDirs: string[]): PathMatchResult | null {
     if (typeof value === "string") {
@@ -144,9 +147,10 @@ export function findDenyPathMatch(
           }
         }
         // 3. inode 一致（hardlink 経由）
-        if (denyInodes && path.isAbsolute(candidate)) {
+        if (options.denyHardlinkTraversal && path.isAbsolute(candidate)) {
           const stat = tryStat(candidate);
-          if (stat) {
+          if (stat && shouldCheckDenyInodes(stat)) {
+            denyInodes ??= collectDenyInodesCached(denyPaths);
             const key = `${stat.dev}:${stat.ino}`;
             const denyOriginal = denyInodes.map.get(key);
             if (denyOriginal) {
@@ -188,8 +192,19 @@ export function findDenyPathMatch(
 /**
  * denyPaths 各 entry の inode を収集する。
  * denyPaths が directory の場合は、配下も再帰的に収集する。
+ * 呼び出し側は候補 path が hardlink の可能性を持つ場合だけ実行し、結果は短時間 cache する。
  * 実 FS に存在しない deny path はスキップ（test 環境で /data/workspace 等が無いケース対応）。
  */
+function collectDenyInodesCached(denyPaths: string[]): DenyInodeScanResult {
+  const cacheKey = denyPaths.join("\0");
+  const now = Date.now();
+  const cached = denyInodeCache.get(cacheKey);
+  if (cached && cached.expiresAt > now) return cached.result;
+  const result = collectDenyInodes(denyPaths);
+  denyInodeCache.set(cacheKey, { expiresAt: now + DENY_INODE_CACHE_TTL_MS, result });
+  return result;
+}
+
 function collectDenyInodes(denyPaths: string[]): DenyInodeScanResult {
   const map = new Map<string, string>();
   const visitedDirs = new Set<string>();
@@ -226,6 +241,10 @@ function collectDenyPathInodes(
       map.set(`${entryStat.dev}:${entryStat.ino}`, denyRoot);
     }
   }
+}
+
+function shouldCheckDenyInodes(stat: Stats): boolean {
+  return stat.isFile() && stat.nlink > 1;
 }
 
 function tryReadDir(p: string): Dirent[] | null {

--- a/packages/cost-guard/src/path-checker.ts
+++ b/packages/cost-guard/src/path-checker.ts
@@ -68,18 +68,11 @@ const BASE_DIR_FIELD_NAMES = new Set([
   "dir",
 ]);
 
-const DENY_INODE_CACHE_TTL_MS = 60_000;
 const DENY_INODE_SCAN_LIMIT = 10_000;
 
-interface DenyInodeCacheEntry {
-  createdAt: number;
+interface DenyInodeScanResult {
   map: Map<string, string>;
-  scannedEntries: number;
-  truncated: boolean;
-  truncatedDenyRoot: string | null;
 }
-
-const denyInodeCache = new Map<string, DenyInodeCacheEntry>();
 
 /**
  * tool params を再帰走査し、denyPaths にマッチする path 候補を探す。
@@ -165,13 +158,6 @@ export function findDenyPathMatch(
                 reason: "deny_path_match_inode",
               };
             }
-            if (denyInodes.truncated) {
-              return {
-                matched: denyInodes.truncatedDenyRoot ?? denyPaths[0] ?? "(unknown)",
-                field: fieldPath,
-                reason: "deny_path_match_inode",
-              };
-            }
           }
         }
       }
@@ -206,30 +192,15 @@ export function findDenyPathMatch(
  * denyPaths が directory の場合は、配下も再帰的に収集する。
  * 実 FS に存在しない deny path はスキップ（test 環境で /data/workspace 等が無いケース対応）。
  */
-function collectDenyInodes(denyPaths: string[]): DenyInodeCacheEntry {
-  const cacheKey = denyPaths.map((p) => normalizePathForMatch(p)).join("\0");
-  const now = Date.now();
-  const cached = denyInodeCache.get(cacheKey);
-  if (cached && now - cached.createdAt <= DENY_INODE_CACHE_TTL_MS) {
-    return cached;
-  }
-
+function collectDenyInodes(denyPaths: string[]): DenyInodeScanResult {
   const map = new Map<string, string>();
   const visitedDirs = new Set<string>();
-  const state = { scannedEntries: 0, truncated: false, truncatedDenyRoot: null as string | null };
+  const state = { scannedEntries: 0, truncated: false };
   for (const p of denyPaths) {
     collectDenyPathInodes(p, p, map, visitedDirs, state);
     if (state.truncated) break;
   }
-  const entry = {
-    createdAt: now,
-    map,
-    scannedEntries: state.scannedEntries,
-    truncated: state.truncated,
-    truncatedDenyRoot: state.truncatedDenyRoot,
-  };
-  denyInodeCache.set(cacheKey, entry);
-  return entry;
+  return { map };
 }
 
 function collectDenyPathInodes(
@@ -237,12 +208,11 @@ function collectDenyPathInodes(
   currentPath: string,
   map: Map<string, string>,
   visitedDirs: Set<string>,
-  state: { scannedEntries: number; truncated: boolean; truncatedDenyRoot: string | null },
+  state: { scannedEntries: number; truncated: boolean },
 ): void {
   if (state.truncated) return;
   if (state.scannedEntries >= DENY_INODE_SCAN_LIMIT) {
     state.truncated = true;
-    state.truncatedDenyRoot = denyRoot;
     return;
   }
   state.scannedEntries++;
@@ -265,7 +235,6 @@ function collectDenyPathInodes(
     }
     if (state.scannedEntries >= DENY_INODE_SCAN_LIMIT) {
       state.truncated = true;
-      state.truncatedDenyRoot = denyRoot;
       return;
     }
     state.scannedEntries++;
@@ -274,23 +243,6 @@ function collectDenyPathInodes(
       map.set(`${entryStat.dev}:${entryStat.ino}`, denyRoot);
     }
   }
-}
-
-export function clearDenyInodeCacheForTest(): void {
-  denyInodeCache.clear();
-}
-
-export function getDenyInodeCacheStatsForTest(): {
-  size: number;
-  entries: { scannedEntries: number; truncated: boolean }[];
-} {
-  return {
-    size: denyInodeCache.size,
-    entries: [...denyInodeCache.values()].map((entry) => ({
-      scannedEntries: entry.scannedEntries,
-      truncated: entry.truncated,
-    })),
-  };
 }
 
 function tryReadDir(p: string): Dirent[] | null {

--- a/packages/cost-guard/src/path-checker.ts
+++ b/packages/cost-guard/src/path-checker.ts
@@ -1,0 +1,385 @@
+/**
+ * Path canonical 化と denyPaths マッチ判定
+ *
+ * Phase 0 の cost-guard-hello に対し以下を追加：
+ * - realpath（symlink 解決）：fs.realpathSync で実 FS の symlink を解消
+ * - inode 一致検査：denyHardlinkTraversal=true 時、stat の (dev, ino) が denyPaths 配下のいずれかと一致するか確認
+ * - 30+ 迂回パターン耐性：相対 path、`../`、cwd 起点、command 内 redirection、option value 隣接、bare filename、
+ *   symlink、hardlink、/proc/self/fd 経由、URL-encoded、二重 slash、末尾 slash 有無
+ *
+ * 30+ 迂回パターンの内訳：
+ *  1. 絶対 path 直書き
+ *  2. `../` 経由
+ *  3. `./` 経由
+ *  4. 二重 slash `//`
+ *  5. 末尾 slash 有無
+ *  6. URL-encoded（`%2F`, `%2E`）
+ *  7. cwd 起点の相対 path
+ *  8. workdir 起点の相対 path
+ *  9. dir 起点の相対 path
+ * 10. bare filename + cwd
+ * 11. command 内 redirection `<`
+ * 12. command 内 `>`
+ * 13. command 内 option value `--file=`
+ * 14. command 内 pipe `|`
+ * 15. command 内空白区切り
+ * 16. args 配列の各要素
+ * 17. ネスト object
+ * 18. ネスト array
+ * 19. base64 で偽装した path → 元 string で検出（補助）
+ * 20. symlink 経由（realpath で解決）
+ * 21. hardlink 経由（inode 一致で検出）
+ * 22. /proc/self/fd 経由（path token で捕捉）
+ * 23. /proc/<pid>/root/... 経由
+ * 24. 大文字小文字混在（macOS では区別、Linux では区別 → 文字列比較）
+ * 25. UTF-8 異常文字混入（NFC 正規化）
+ * 26. 改行混入（CR / LF / CRLF）
+ * 27. tab 混入
+ * 28. zero-width space 混入
+ * 29. 末尾空白
+ * 30. 先頭空白
+ * 31. 連続 `../` (`/../../../`)
+ * 32. 自己参照 `./.`
+ *
+ * 実 FS 不在時（CI / unit test）は realpath / stat エラーを無視し、文字列ベースの canonical 化のみで判定。
+ */
+
+import { realpathSync, type Stats, statSync } from "node:fs";
+import path from "node:path";
+
+export interface PathCheckOptions {
+  denyPaths: string[];
+  denyHardlinkTraversal: boolean;
+  resolveSymlinks: boolean;
+}
+
+export interface PathMatchResult {
+  matched: string;
+  field: string;
+  reason: "deny_path_match" | "deny_path_match_symlink" | "deny_path_match_inode";
+}
+
+const BASE_DIR_FIELD_NAMES = new Set([
+  "cwd",
+  "workdir",
+  "workingdir",
+  "workingdirectory",
+  "working_directory",
+  "dir",
+]);
+
+/**
+ * tool params を再帰走査し、denyPaths にマッチする path 候補を探す。
+ *
+ * @returns マッチがあれば PathMatchResult、なければ null
+ */
+export function findDenyPathMatch(
+  params: unknown,
+  options: PathCheckOptions,
+): PathMatchResult | null {
+  const denyPaths = options.denyPaths.filter((s) => typeof s === "string" && s.length > 0);
+  if (denyPaths.length === 0) return null;
+  const visited = new WeakSet<object>();
+  const normalizedDenyPaths = denyPaths.map((p) => ({
+    original: p,
+    normalized: normalizePathForMatch(p),
+  }));
+  // symlink 解決後の deny 一致を検出するため、deny dir 自体も realpath 化したものを別途保持
+  // 例：macOS では /tmp が /private/tmp への symlink のため、deny dir を渡しても
+  //     candidate を realpath したら /private/tmp/... になり一致しなくなる
+  const symlinkResolvedDenyPaths = options.resolveSymlinks
+    ? denyPaths
+        .map((p) => {
+          const realDeny = tryRealpath(p);
+          if (!realDeny) return null;
+          const normalizedReal = normalizePathForMatch(realDeny);
+          return { original: p, normalized: normalizedReal };
+        })
+        .filter((x): x is { original: string; normalized: string } => x !== null)
+    : [];
+  const denyInodeMap = options.denyHardlinkTraversal ? collectDenyInodes(denyPaths) : null;
+
+  function walk(value: unknown, fieldPath: string, baseDirs: string[]): PathMatchResult | null {
+    if (typeof value === "string") {
+      const candidates = expandPathCandidates(value, baseDirs, isCommandLikeField(fieldPath));
+      for (const candidate of candidates) {
+        // 1. 文字列ベース canonical 一致
+        for (const deny of normalizedDenyPaths) {
+          if (isWithinDenyPath(candidate, deny.normalized)) {
+            return { matched: deny.original, field: fieldPath, reason: "deny_path_match" };
+          }
+        }
+        // 2. symlink 解決後の一致（実 FS 触る、エラー無視）
+        //    candidate を realpath した結果が、deny dir そのものまたは deny dir を realpath したもの
+        //    どちらかの配下にあれば「symlink 経由で deny に到達」と判定
+        if (options.resolveSymlinks && path.isAbsolute(candidate)) {
+          const resolved = tryRealpath(candidate);
+          if (resolved && resolved !== candidate) {
+            const normalizedResolved = normalizePathForMatch(resolved);
+            // (a) 元 deny dir（文字列のまま）と比較
+            for (const deny of normalizedDenyPaths) {
+              if (isWithinDenyPath(normalizedResolved, deny.normalized)) {
+                return {
+                  matched: deny.original,
+                  field: fieldPath,
+                  reason: "deny_path_match_symlink",
+                };
+              }
+            }
+            // (b) deny dir を realpath したものと比較
+            //     macOS の /tmp → /private/tmp や symlinked deploy dir に対応
+            for (const deny of symlinkResolvedDenyPaths) {
+              if (isWithinDenyPath(normalizedResolved, deny.normalized)) {
+                return {
+                  matched: deny.original,
+                  field: fieldPath,
+                  reason: "deny_path_match_symlink",
+                };
+              }
+            }
+          }
+        }
+        // 3. inode 一致（hardlink 経由）
+        if (denyInodeMap && path.isAbsolute(candidate)) {
+          const stat = tryStat(candidate);
+          if (stat) {
+            const key = `${stat.dev}:${stat.ino}`;
+            const denyOriginal = denyInodeMap.get(key);
+            if (denyOriginal) {
+              return {
+                matched: denyOriginal,
+                field: fieldPath,
+                reason: "deny_path_match_inode",
+              };
+            }
+          }
+        }
+      }
+      return null;
+    }
+    if (typeof value !== "object" || value === null) return null;
+    if (visited.has(value as object)) return null;
+    visited.add(value as object);
+
+    if (Array.isArray(value)) {
+      for (let i = 0; i < value.length; i++) {
+        const r = walk(value[i], `${fieldPath}[${i}]`, baseDirs);
+        if (r) return r;
+      }
+      return null;
+    }
+    const entries = Object.entries(value as Record<string, unknown>);
+    const scopedBaseDirs = collectScopedBaseDirs(entries, baseDirs);
+    for (const [k, v] of entries) {
+      const childField = fieldPath === "" ? k : `${fieldPath}.${k}`;
+      const r = walk(v, childField, scopedBaseDirs);
+      if (r) return r;
+    }
+    return null;
+  }
+
+  return walk(params, "", []);
+}
+
+/**
+ * denyPaths 各 entry の inode を収集する。
+ * 実 FS に存在しない deny path はスキップ（test 環境で /data/workspace 等が無いケース対応）。
+ */
+function collectDenyInodes(denyPaths: string[]): Map<string, string> {
+  const map = new Map<string, string>();
+  for (const p of denyPaths) {
+    const stat = tryStat(p);
+    if (stat) {
+      map.set(`${stat.dev}:${stat.ino}`, p);
+    }
+  }
+  return map;
+}
+
+function tryRealpath(p: string): string | null {
+  try {
+    return realpathSync(p);
+  } catch {
+    return null;
+  }
+}
+
+function tryStat(p: string): Stats | null {
+  try {
+    return statSync(p);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * 文字列を path-like 解釈して canonical 化候補集合を返す。
+ *
+ * 候補（cost-guard-hello から拡張）：
+ * - 元の文字列（生）
+ * - URL-decode（`%2F`/`%2E` 等の de-obfuscate）
+ * - 不可視文字（zero-width space, BOM, NBSP, タブ）を除去した変種
+ * - 空白除去
+ * - path.resolve("/", s) … 絶対起点
+ * - path.resolve(s) … cwd 起点
+ * - path.resolve(baseDir, s) … baseDir 起点（cwd / workdir / dir）
+ * - command-like field では bare filename token も baseDir 起点で resolve
+ * - command 内の path token / 埋め込み絶対 path も再帰展開
+ */
+export function expandPathCandidates(
+  s: string,
+  baseDirs: string[],
+  includeBareTokens: boolean,
+): string[] {
+  const candidates = new Set<string>();
+  if (s === "") {
+    candidates.add(s);
+    return [...candidates];
+  }
+  for (const variant of stringVariants(s)) {
+    candidates.add(variant);
+    addResolvedPathCandidates(candidates, variant, baseDirs);
+    for (const token of extractPathLikeTokens(variant, includeBareTokens && baseDirs.length > 0)) {
+      addResolvedPathCandidates(candidates, token, baseDirs);
+      for (const absolutePath of extractEmbeddedAbsolutePaths(token)) {
+        addResolvedPathCandidates(candidates, absolutePath, baseDirs);
+      }
+    }
+  }
+  return [...candidates];
+}
+
+/**
+ * 1 つの string から「文字列ベースの canonical 変種」を返す。
+ * URL decode・不可視文字除去・空白 trim を組み合わせて迂回パターンを正規化する。
+ */
+function stringVariants(s: string): string[] {
+  const variants = new Set<string>();
+  variants.add(s);
+  const trimmed = s.trim();
+  if (trimmed !== s) variants.add(trimmed);
+
+  // 不可視文字（zero-width space U+200B, BOM U+FEFF, NBSP U+00A0, 各種改行 / tab）を除去
+  const stripped = s.replace(/[​﻿ \r\n\t]+/g, "");
+  if (stripped !== s) variants.add(stripped);
+  const strippedTrimmed = stripped.trim();
+  if (strippedTrimmed !== stripped) variants.add(strippedTrimmed);
+
+  // URL-decode（部分的に encode されたケースのため try/catch）
+  for (const variant of [...variants]) {
+    try {
+      const decoded = decodeURIComponent(variant);
+      if (decoded !== variant) variants.add(decoded);
+    } catch {
+      // ignore malformed encoding
+    }
+  }
+  // NFKC 正規化（mojibake / 全角混在）
+  for (const variant of [...variants]) {
+    try {
+      const nfkc = variant.normalize("NFKC");
+      if (nfkc !== variant) variants.add(nfkc);
+    } catch {
+      // ignore
+    }
+  }
+  return [...variants];
+}
+
+function addResolvedPathCandidates(
+  candidates: Set<string>,
+  value: string,
+  baseDirs: string[],
+): void {
+  if (value === "") return;
+  try {
+    candidates.add(path.resolve("/", value));
+  } catch {
+    // ignore
+  }
+  try {
+    candidates.add(path.resolve(value));
+  } catch {
+    // ignore
+  }
+  for (const baseDir of baseDirs) {
+    try {
+      candidates.add(path.resolve(baseDir, value));
+    } catch {
+      // ignore
+    }
+  }
+}
+
+function extractPathLikeTokens(s: string, includeBareTokens: boolean): string[] {
+  return s
+    .split(/\s+/)
+    .map((token) => token.replace(/^[`"'([{<]+|[`"',;:)\]}<>]+$/g, ""))
+    .filter((token) => token !== "")
+    .filter((token) => includeBareTokens || token.includes("/") || token.startsWith("."));
+}
+
+function extractEmbeddedAbsolutePaths(token: string): string[] {
+  return [...token.matchAll(/\/[^\s`"'|&;(){}[\]<>]*/g)]
+    .map((match) => match[0].replace(/[`"',;:)\]}<>]+$/g, ""))
+    .filter((pathFragment) => pathFragment !== "" && pathFragment !== path.sep);
+}
+
+function isCommandLikeField(fieldPath: string): boolean {
+  const leaf =
+    fieldPath
+      .split(".")
+      .at(-1)
+      ?.replace(/\[\d+\]$/g, "")
+      .toLowerCase() ?? "";
+  return leaf === "command" || leaf === "cmd" || leaf === "script" || leaf === "shell";
+}
+
+/**
+ * 候補 path が denyPath 配下にあるか判定する。
+ * - 候補を normalize した結果が deny と同一、または deny + path.sep プレフィックスを持てば true
+ * - deny が `/` の場合は任意の絶対 path を deny 扱い
+ */
+export function isWithinDenyPath(candidate: string, normalizedDeny: string): boolean {
+  const normalizedCandidate = normalizePathForMatch(candidate);
+  if (normalizedCandidate === normalizedDeny) return true;
+  if (normalizedDeny === path.sep) return normalizedCandidate.startsWith(path.sep);
+  return normalizedCandidate.startsWith(`${normalizedDeny}${path.sep}`);
+}
+
+export function normalizePathForMatch(value: string): string {
+  const trimmed = value.trim();
+  if (trimmed === "") return value;
+  let resolved: string;
+  try {
+    resolved = path.resolve("/", trimmed);
+  } catch {
+    resolved = trimmed;
+  }
+  if (resolved === path.sep) return resolved;
+  return resolved.replace(/\/+$/g, "");
+}
+
+function collectScopedBaseDirs(
+  entries: [string, unknown][],
+  inheritedBaseDirs: string[],
+): string[] {
+  const baseDirs = new Set(inheritedBaseDirs);
+  for (const [key, value] of entries) {
+    if (typeof value !== "string") continue;
+    if (!BASE_DIR_FIELD_NAMES.has(key.toLowerCase())) continue;
+    const trimmed = value.trim();
+    if (trimmed === "") continue;
+    try {
+      baseDirs.add(path.resolve("/", trimmed));
+    } catch {
+      // ignore
+    }
+    try {
+      baseDirs.add(path.resolve(trimmed));
+    } catch {
+      // ignore
+    }
+  }
+  return [...baseDirs];
+}

--- a/packages/cost-guard/src/path-checker.ts
+++ b/packages/cost-guard/src/path-checker.ts
@@ -68,6 +68,18 @@ const BASE_DIR_FIELD_NAMES = new Set([
   "dir",
 ]);
 
+const DENY_INODE_CACHE_TTL_MS = 60_000;
+const DENY_INODE_SCAN_LIMIT = 10_000;
+
+interface DenyInodeCacheEntry {
+  createdAt: number;
+  map: Map<string, string>;
+  scannedEntries: number;
+  truncated: boolean;
+}
+
+const denyInodeCache = new Map<string, DenyInodeCacheEntry>();
+
 /**
  * tool params を再帰走査し、denyPaths にマッチする path 候補を探す。
  *
@@ -187,11 +199,26 @@ export function findDenyPathMatch(
  * 実 FS に存在しない deny path はスキップ（test 環境で /data/workspace 等が無いケース対応）。
  */
 function collectDenyInodes(denyPaths: string[]): Map<string, string> {
+  const cacheKey = denyPaths.map((p) => normalizePathForMatch(p)).join("\0");
+  const now = Date.now();
+  const cached = denyInodeCache.get(cacheKey);
+  if (cached && now - cached.createdAt <= DENY_INODE_CACHE_TTL_MS) {
+    return cached.map;
+  }
+
   const map = new Map<string, string>();
   const visitedDirs = new Set<string>();
+  const state = { scannedEntries: 0, truncated: false };
   for (const p of denyPaths) {
-    collectDenyPathInodes(p, p, map, visitedDirs);
+    collectDenyPathInodes(p, p, map, visitedDirs, state);
+    if (state.truncated) break;
   }
+  denyInodeCache.set(cacheKey, {
+    createdAt: now,
+    map,
+    scannedEntries: state.scannedEntries,
+    truncated: state.truncated,
+  });
   return map;
 }
 
@@ -200,7 +227,14 @@ function collectDenyPathInodes(
   currentPath: string,
   map: Map<string, string>,
   visitedDirs: Set<string>,
+  state: { scannedEntries: number; truncated: boolean },
 ): void {
+  if (state.truncated) return;
+  if (state.scannedEntries >= DENY_INODE_SCAN_LIMIT) {
+    state.truncated = true;
+    return;
+  }
+  state.scannedEntries++;
   const stat = tryStat(currentPath);
   if (!stat) return;
   const inodeKey = `${stat.dev}:${stat.ino}`;
@@ -212,16 +246,39 @@ function collectDenyPathInodes(
   const entries = tryReadDir(currentPath);
   if (!entries) return;
   for (const entry of entries) {
+    if (state.truncated) return;
     const entryPath = path.join(currentPath, entry.name);
     if (entry.isDirectory()) {
-      collectDenyPathInodes(denyRoot, entryPath, map, visitedDirs);
+      collectDenyPathInodes(denyRoot, entryPath, map, visitedDirs, state);
       continue;
     }
+    if (state.scannedEntries >= DENY_INODE_SCAN_LIMIT) {
+      state.truncated = true;
+      return;
+    }
+    state.scannedEntries++;
     const entryStat = tryStat(entryPath);
     if (entryStat) {
       map.set(`${entryStat.dev}:${entryStat.ino}`, denyRoot);
     }
   }
+}
+
+export function clearDenyInodeCacheForTest(): void {
+  denyInodeCache.clear();
+}
+
+export function getDenyInodeCacheStatsForTest(): {
+  size: number;
+  entries: { scannedEntries: number; truncated: boolean }[];
+} {
+  return {
+    size: denyInodeCache.size,
+    entries: [...denyInodeCache.values()].map((entry) => ({
+      scannedEntries: entry.scannedEntries,
+      truncated: entry.truncated,
+    })),
+  };
 }
 
 function tryReadDir(p: string): Dirent[] | null {

--- a/packages/cost-guard/src/path-checker.ts
+++ b/packages/cost-guard/src/path-checker.ts
@@ -76,6 +76,7 @@ interface DenyInodeCacheEntry {
   map: Map<string, string>;
   scannedEntries: number;
   truncated: boolean;
+  truncatedDenyRoot: string | null;
 }
 
 const denyInodeCache = new Map<string, DenyInodeCacheEntry>();
@@ -109,7 +110,7 @@ export function findDenyPathMatch(
         })
         .filter((x): x is { original: string; normalized: string } => x !== null)
     : [];
-  const denyInodeMap = options.denyHardlinkTraversal ? collectDenyInodes(denyPaths) : null;
+  const denyInodes = options.denyHardlinkTraversal ? collectDenyInodes(denyPaths) : null;
 
   function walk(value: unknown, fieldPath: string, baseDirs: string[]): PathMatchResult | null {
     if (typeof value === "string") {
@@ -152,14 +153,21 @@ export function findDenyPathMatch(
           }
         }
         // 3. inode 一致（hardlink 経由）
-        if (denyInodeMap && path.isAbsolute(candidate)) {
+        if (denyInodes && path.isAbsolute(candidate)) {
           const stat = tryStat(candidate);
           if (stat) {
             const key = `${stat.dev}:${stat.ino}`;
-            const denyOriginal = denyInodeMap.get(key);
+            const denyOriginal = denyInodes.map.get(key);
             if (denyOriginal) {
               return {
                 matched: denyOriginal,
+                field: fieldPath,
+                reason: "deny_path_match_inode",
+              };
+            }
+            if (denyInodes.truncated) {
+              return {
+                matched: denyInodes.truncatedDenyRoot ?? denyPaths[0] ?? "(unknown)",
                 field: fieldPath,
                 reason: "deny_path_match_inode",
               };
@@ -198,28 +206,30 @@ export function findDenyPathMatch(
  * denyPaths が directory の場合は、配下も再帰的に収集する。
  * 実 FS に存在しない deny path はスキップ（test 環境で /data/workspace 等が無いケース対応）。
  */
-function collectDenyInodes(denyPaths: string[]): Map<string, string> {
+function collectDenyInodes(denyPaths: string[]): DenyInodeCacheEntry {
   const cacheKey = denyPaths.map((p) => normalizePathForMatch(p)).join("\0");
   const now = Date.now();
   const cached = denyInodeCache.get(cacheKey);
   if (cached && now - cached.createdAt <= DENY_INODE_CACHE_TTL_MS) {
-    return cached.map;
+    return cached;
   }
 
   const map = new Map<string, string>();
   const visitedDirs = new Set<string>();
-  const state = { scannedEntries: 0, truncated: false };
+  const state = { scannedEntries: 0, truncated: false, truncatedDenyRoot: null as string | null };
   for (const p of denyPaths) {
     collectDenyPathInodes(p, p, map, visitedDirs, state);
     if (state.truncated) break;
   }
-  denyInodeCache.set(cacheKey, {
+  const entry = {
     createdAt: now,
     map,
     scannedEntries: state.scannedEntries,
     truncated: state.truncated,
-  });
-  return map;
+    truncatedDenyRoot: state.truncatedDenyRoot,
+  };
+  denyInodeCache.set(cacheKey, entry);
+  return entry;
 }
 
 function collectDenyPathInodes(
@@ -227,11 +237,12 @@ function collectDenyPathInodes(
   currentPath: string,
   map: Map<string, string>,
   visitedDirs: Set<string>,
-  state: { scannedEntries: number; truncated: boolean },
+  state: { scannedEntries: number; truncated: boolean; truncatedDenyRoot: string | null },
 ): void {
   if (state.truncated) return;
   if (state.scannedEntries >= DENY_INODE_SCAN_LIMIT) {
     state.truncated = true;
+    state.truncatedDenyRoot = denyRoot;
     return;
   }
   state.scannedEntries++;
@@ -254,6 +265,7 @@ function collectDenyPathInodes(
     }
     if (state.scannedEntries >= DENY_INODE_SCAN_LIMIT) {
       state.truncated = true;
+      state.truncatedDenyRoot = denyRoot;
       return;
     }
     state.scannedEntries++;

--- a/packages/cost-guard/src/path-checker.ts
+++ b/packages/cost-guard/src/path-checker.ts
@@ -72,9 +72,6 @@ interface DenyInodeScanResult {
   map: Map<string, string>;
 }
 
-const DENY_INODE_CACHE_TTL_MS = 1000;
-const denyInodeCache = new Map<string, { expiresAt: number; result: DenyInodeScanResult }>();
-
 /**
  * tool params を再帰走査し、denyPaths にマッチする path 候補を探す。
  *
@@ -150,7 +147,7 @@ export function findDenyPathMatch(
         if (options.denyHardlinkTraversal && path.isAbsolute(candidate)) {
           const stat = tryStat(candidate);
           if (stat && shouldCheckDenyInodes(stat)) {
-            denyInodes ??= collectDenyInodesCached(denyPaths);
+            denyInodes ??= collectDenyInodes(denyPaths);
             const key = `${stat.dev}:${stat.ino}`;
             const denyOriginal = denyInodes.map.get(key);
             if (denyOriginal) {
@@ -192,19 +189,9 @@ export function findDenyPathMatch(
 /**
  * denyPaths 各 entry の inode を収集する。
  * denyPaths が directory の場合は、配下も再帰的に収集する。
- * 呼び出し側は候補 path が hardlink の可能性を持つ場合だけ実行し、結果は短時間 cache する。
+ * 呼び出し側は候補 path が hardlink の可能性を持つ場合だけ実行する。
  * 実 FS に存在しない deny path はスキップ（test 環境で /data/workspace 等が無いケース対応）。
  */
-function collectDenyInodesCached(denyPaths: string[]): DenyInodeScanResult {
-  const cacheKey = denyPaths.join("\0");
-  const now = Date.now();
-  const cached = denyInodeCache.get(cacheKey);
-  if (cached && cached.expiresAt > now) return cached.result;
-  const result = collectDenyInodes(denyPaths);
-  denyInodeCache.set(cacheKey, { expiresAt: now + DENY_INODE_CACHE_TTL_MS, result });
-  return result;
-}
-
 function collectDenyInodes(denyPaths: string[]): DenyInodeScanResult {
   const map = new Map<string, string>();
   const visitedDirs = new Set<string>();

--- a/packages/cost-guard/src/sentinel.test.ts
+++ b/packages/cost-guard/src/sentinel.test.ts
@@ -1,0 +1,113 @@
+/**
+ * sentinel module の単体テスト
+ *
+ * 検証点：
+ * - SENTINEL_PREFIX が contracts.md §2.2 の固定文字列と一致
+ * - buildSentinelMessage が prefix + bytes + guidance を含む
+ * - computeContentBytes が型別に UTF-8 byte 数を返す
+ * - isSentinelMessage が prefix で始まる文字列のみ true を返す
+ * - boundary value（49,999 / 50,000 / 50,001 byte）で sentinel 置換の有無が正しく切り替わる
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  buildSentinelMessage,
+  computeContentBytes,
+  isSentinelMessage,
+  SENTINEL_PREFIX,
+} from "./sentinel.js";
+
+describe("SENTINEL_PREFIX", () => {
+  it("contracts.md §2.2 の固定文字列と一致", () => {
+    expect(SENTINEL_PREFIX).toBe("[cost-guard] tool result truncated");
+  });
+});
+
+describe("buildSentinelMessage", () => {
+  it("prefix + bytes + analyze_transcript guidance を含む", () => {
+    const msg = buildSentinelMessage(105234);
+    expect(msg.startsWith(SENTINEL_PREFIX)).toBe(true);
+    expect(msg).toContain("105234 bytes");
+    expect(msg).toContain("analyze_transcript");
+  });
+
+  it("0 byte でも sentinel として返す", () => {
+    const msg = buildSentinelMessage(0);
+    expect(msg).toContain("(0 bytes)");
+  });
+
+  it("極端に大きい byte 数も正しく表示", () => {
+    const msg = buildSentinelMessage(99_999_999_999);
+    expect(msg).toContain("99999999999");
+  });
+});
+
+describe("computeContentBytes", () => {
+  it("string の UTF-8 byte 数を返す", () => {
+    expect(computeContentBytes("hello")).toBe(5);
+    expect(computeContentBytes("日本語")).toBe(9); // 3 chars * 3 bytes
+  });
+
+  it("undefined / null は 0 を返す", () => {
+    expect(computeContentBytes(undefined)).toBe(0);
+    expect(computeContentBytes(null)).toBe(0);
+  });
+
+  it("number / boolean は String 化した byte 数を返す", () => {
+    expect(computeContentBytes(12345)).toBe(5);
+    expect(computeContentBytes(true)).toBe(4);
+    expect(computeContentBytes(false)).toBe(5);
+  });
+
+  it("object は JSON 化した byte 数を返す", () => {
+    expect(computeContentBytes({ a: 1 })).toBe(7); // '{"a":1}'
+    expect(computeContentBytes([1, 2, 3])).toBe(7); // '[1,2,3]'
+  });
+
+  it("循環参照 object は 0 を返す（JSON.stringify 失敗時）", () => {
+    const o: Record<string, unknown> = {};
+    o.self = o;
+    expect(computeContentBytes(o)).toBe(0);
+  });
+
+  describe("rewriteThresholdBytes 境界値検証", () => {
+    const threshold = 50_000;
+
+    it("49,999 byte は threshold 未満（sentinel 置換なし）", () => {
+      const content = "x".repeat(49_999);
+      expect(computeContentBytes(content)).toBe(49_999);
+      expect(computeContentBytes(content) > threshold).toBe(false);
+    });
+
+    it("50,000 byte は threshold ちょうど（sentinel 置換なし）", () => {
+      const content = "x".repeat(50_000);
+      expect(computeContentBytes(content)).toBe(50_000);
+      expect(computeContentBytes(content) > threshold).toBe(false);
+    });
+
+    it("50,001 byte は threshold 超過（sentinel 置換あり）", () => {
+      const content = "x".repeat(50_001);
+      expect(computeContentBytes(content)).toBe(50_001);
+      expect(computeContentBytes(content) > threshold).toBe(true);
+    });
+  });
+});
+
+describe("isSentinelMessage", () => {
+  it("SENTINEL_PREFIX で始まる文字列は true", () => {
+    expect(isSentinelMessage(buildSentinelMessage(100))).toBe(true);
+    expect(isSentinelMessage(`${SENTINEL_PREFIX} (1 bytes).`)).toBe(true);
+  });
+
+  it("prefix を含まない文字列は false", () => {
+    expect(isSentinelMessage("hello world")).toBe(false);
+    expect(isSentinelMessage("")).toBe(false);
+  });
+
+  it("string 以外は false", () => {
+    expect(isSentinelMessage(undefined)).toBe(false);
+    expect(isSentinelMessage(null)).toBe(false);
+    expect(isSentinelMessage(123)).toBe(false);
+    expect(isSentinelMessage({})).toBe(false);
+  });
+});

--- a/packages/cost-guard/src/sentinel.ts
+++ b/packages/cost-guard/src/sentinel.ts
@@ -1,0 +1,53 @@
+/**
+ * sentinel 文字列生成と判定
+ *
+ * tool_result_persist で result が rewriteThresholdBytes を超えた場合に
+ * 置換用の sentinel メッセージを生成する。フォーマットは contracts.md §2.2 準拠。
+ *
+ * 例：
+ *   "[cost-guard] tool result truncated (105234 bytes). Use analyze_transcript or specific tool to access content."
+ */
+
+export const SENTINEL_PREFIX = "[cost-guard] tool result truncated";
+
+/**
+ * sentinel メッセージを生成する。
+ *
+ * @param originalBytes - 置換前の content の byte 数
+ * @returns sentinel 文字列
+ */
+export function buildSentinelMessage(originalBytes: number): string {
+  return (
+    `${SENTINEL_PREFIX} (${originalBytes} bytes). ` +
+    "Use analyze_transcript or specific tool to access content."
+  );
+}
+
+/**
+ * 与えられた値の byte 数を計算する。
+ *
+ * - string: UTF-8 byte 数
+ * - object / array: JSON.stringify した文字列の UTF-8 byte 数
+ * - undefined / null: 0
+ * - その他 (number / boolean): String 化した byte 数
+ */
+export function computeContentBytes(value: unknown): number {
+  if (value === undefined || value === null) return 0;
+  if (typeof value === "string") return Buffer.byteLength(value, "utf8");
+  if (typeof value === "number" || typeof value === "boolean") {
+    return Buffer.byteLength(String(value), "utf8");
+  }
+  try {
+    return Buffer.byteLength(JSON.stringify(value) ?? "", "utf8");
+  } catch {
+    return 0;
+  }
+}
+
+/**
+ * 文字列が sentinel メッセージかを判定する。
+ * before_agent_run の cleanup 時に「既に置換済みの message」を再置換しないために使用する。
+ */
+export function isSentinelMessage(content: unknown): boolean {
+  return typeof content === "string" && content.startsWith(SENTINEL_PREFIX);
+}

--- a/packages/cost-guard/src/token-estimator.test.ts
+++ b/packages/cost-guard/src/token-estimator.test.ts
@@ -1,0 +1,156 @@
+/**
+ * token-estimator の単体テスト
+ *
+ * 検証点：
+ * - utf8ByteLength が UTF-8 byte 数を返す
+ * - estimateTokenCount が byte 数 / 4 の ceil を返す
+ * - estimateMessagesTokenCount が messages 配列の合算を返す
+ * - estimatePromptInputTokens が prompt + messages の合算を返す
+ * - perTurnPromptInputThreshold 境界値（49,999 / 50,000 / 50,001 token）で gate の判定が正しい
+ * - sessionTokenBudget 境界値（499,999 / 500,000 / 500,001 token）で breaker の判定が正しい
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  estimateMessagesTokenCount,
+  estimatePromptInputTokens,
+  estimateTokenCount,
+  utf8ByteLength,
+} from "./token-estimator.js";
+
+describe("utf8ByteLength", () => {
+  it("ASCII の byte 数を返す", () => {
+    expect(utf8ByteLength("hello")).toBe(5);
+    expect(utf8ByteLength("")).toBe(0);
+  });
+
+  it("日本語 (3 byte/char) の byte 数を返す", () => {
+    expect(utf8ByteLength("日本語")).toBe(9);
+  });
+});
+
+describe("estimateTokenCount", () => {
+  it("空文字列は 0 token", () => {
+    expect(estimateTokenCount("")).toBe(0);
+  });
+
+  it("4 byte は 1 token", () => {
+    expect(estimateTokenCount("abcd")).toBe(1);
+  });
+
+  it("5 byte は 2 token（ceil）", () => {
+    expect(estimateTokenCount("abcde")).toBe(2);
+  });
+
+  it("3 byte は 1 token（ceil）", () => {
+    expect(estimateTokenCount("abc")).toBe(1);
+  });
+});
+
+describe("estimateMessagesTokenCount", () => {
+  it("undefined / null は 0", () => {
+    expect(estimateMessagesTokenCount(undefined)).toBe(0);
+    expect(estimateMessagesTokenCount(null)).toBe(0);
+  });
+
+  it("空配列は 0", () => {
+    expect(estimateMessagesTokenCount([])).toBe(0);
+  });
+
+  it("単一 message を含めて合算", () => {
+    const r = estimateMessagesTokenCount([{ role: "user", content: "hello world" }]);
+    // role(4 byte = 1 token) + content(11 byte = 3 token) + tool_call_id(0) + overhead(4) = 8
+    expect(r).toBe(8);
+  });
+
+  it("複数 message を合算", () => {
+    const r = estimateMessagesTokenCount([
+      { role: "user", content: "abcd" },
+      { role: "assistant", content: "efgh" },
+    ]);
+    // user: 1 + 1 + 0 + 4 = 6
+    // assistant: 3 + 1 + 0 + 4 = 8
+    expect(r).toBe(14);
+  });
+
+  it("tool_call_id も加算", () => {
+    const r = estimateMessagesTokenCount([
+      { role: "tool", content: "abcd", tool_call_id: "tcid_abcd" },
+    ]);
+    // tool: 1 + 1 + 3 + 4 = 9
+    expect(r).toBe(9);
+  });
+
+  it("不正な entry はスキップ", () => {
+    const r = estimateMessagesTokenCount([
+      null as any,
+      undefined as any,
+      { role: "user", content: "abcd" },
+    ]);
+    expect(r).toBe(6); // valid one only
+  });
+});
+
+describe("estimatePromptInputTokens", () => {
+  it("prompt + messages を合算", () => {
+    const r = estimatePromptInputTokens("abcd", [{ role: "user", content: "efgh" }]);
+    // prompt(4 byte = 1 token) + messages(1 + 1 + 0 + 4 = 6) = 7
+    expect(r).toBe(7);
+  });
+
+  it("prompt 未定義時は messages のみ", () => {
+    const r = estimatePromptInputTokens(undefined, [{ role: "user", content: "abcd" }]);
+    expect(r).toBe(6);
+  });
+
+  describe("perTurnPromptInputThreshold 境界値検証", () => {
+    const threshold = 50_000;
+
+    it("threshold 未満 (49,999 token) は block しない", () => {
+      // 4 byte * 49_999 - overhead 4 = 199_996 - 16 = ... 単純化のため prompt 直接
+      const prompt = "x".repeat(199_996); // 49_999 tokens
+      const tokens = estimatePromptInputTokens(prompt, undefined);
+      expect(tokens).toBe(49_999);
+      expect(tokens > threshold).toBe(false);
+    });
+
+    it("threshold ちょうど (50,000 token) は block しない", () => {
+      const prompt = "x".repeat(200_000); // 50_000 tokens
+      const tokens = estimatePromptInputTokens(prompt, undefined);
+      expect(tokens).toBe(50_000);
+      expect(tokens > threshold).toBe(false);
+    });
+
+    it("threshold 超過 (50,001 token) は block する", () => {
+      const prompt = "x".repeat(200_004); // 50_001 tokens
+      const tokens = estimatePromptInputTokens(prompt, undefined);
+      expect(tokens).toBe(50_001);
+      expect(tokens > threshold).toBe(true);
+    });
+  });
+
+  describe("sessionTokenBudget 境界値検証", () => {
+    const budget = 500_000;
+
+    it("budget 未満 (499,999 token) は block しない", () => {
+      const prompt = "x".repeat(1_999_996); // 499_999 tokens
+      const tokens = estimatePromptInputTokens(prompt, undefined);
+      expect(tokens).toBe(499_999);
+      expect(tokens > budget).toBe(false);
+    });
+
+    it("budget ちょうど (500,000 token) は block しない", () => {
+      const prompt = "x".repeat(2_000_000); // 500_000 tokens
+      const tokens = estimatePromptInputTokens(prompt, undefined);
+      expect(tokens).toBe(500_000);
+      expect(tokens > budget).toBe(false);
+    });
+
+    it("budget 超過 (500,001 token) は block する", () => {
+      const prompt = "x".repeat(2_000_004); // 500_001 tokens
+      const tokens = estimatePromptInputTokens(prompt, undefined);
+      expect(tokens).toBe(500_001);
+      expect(tokens > budget).toBe(true);
+    });
+  });
+});

--- a/packages/cost-guard/src/token-estimator.test.ts
+++ b/packages/cost-guard/src/token-estimator.test.ts
@@ -81,6 +81,20 @@ describe("estimateMessagesTokenCount", () => {
     expect(r).toBe(9);
   });
 
+  it("配列 content の text payload も token 見積もり対象にする", () => {
+    const r = estimateMessagesTokenCount([
+      { role: "user", content: [{ type: "text", text: "x".repeat(200_004) }] },
+    ]);
+    expect(r).toBeGreaterThan(50_000);
+  });
+
+  it("content 以外の message payload も token 見積もり対象にする", () => {
+    const r = estimateMessagesTokenCount([
+      { role: "user", content: "", metadata: { text: "x".repeat(200_004) } } as any,
+    ]);
+    expect(r).toBeGreaterThan(50_000);
+  });
+
   it("不正な entry はスキップ", () => {
     const r = estimateMessagesTokenCount([
       null as any,

--- a/packages/cost-guard/src/token-estimator.ts
+++ b/packages/cost-guard/src/token-estimator.ts
@@ -1,0 +1,75 @@
+/**
+ * Token 数の見積もり（軽量近似）
+ *
+ * 新規依存追加を避けるため、tiktoken / @anthropic-ai/tokenizer を使わず、
+ * UTF-8 byte 数ベースの近似式で token 数を見積もる。
+ *
+ * 近似式：tokens ≈ ceil(utf8_bytes / 4)
+ *
+ * 根拠：
+ * - Claude / GPT 系の BPE tokenizer では英文 1 token ≈ 4 byte が経験則
+ * - 日本語混在では 1 token ≈ 2 byte 程度になり過大評価になるが、Phase 1 では
+ *   「閾値 50,000 token を超えたら block」という保守的判定のため過大評価は安全側
+ * - 厳密な値が必要になれば fallback で tokenizer を import すれば良い（Phase 2 検討）
+ *
+ * 比較対象：
+ * - prompt 全体（string）
+ * - messages 配列（role / content / tool_call_id を JSON 化して合算）
+ */
+
+export interface SessionMessage {
+  role: "user" | "assistant" | "tool" | "system";
+  content: string;
+  tool_call_id?: string;
+}
+
+/**
+ * 文字列の UTF-8 byte 数を返す。
+ */
+export function utf8ByteLength(s: string): number {
+  return Buffer.byteLength(s, "utf8");
+}
+
+/**
+ * 文字列の token 数を近似する。
+ *
+ * @param s - 対象文字列
+ * @returns 推定 token 数（ceil(utf8_bytes / 4)）
+ */
+export function estimateTokenCount(s: string): number {
+  if (!s) return 0;
+  const bytes = utf8ByteLength(s);
+  return Math.ceil(bytes / 4);
+}
+
+/**
+ * messages 配列全体の token 数を近似する。
+ * 各 message の role / content / tool_call_id（あれば）を結合した文字列で見積もる。
+ */
+export function estimateMessagesTokenCount(messages: SessionMessage[] | undefined | null): number {
+  if (!Array.isArray(messages) || messages.length === 0) return 0;
+  let total = 0;
+  for (const msg of messages) {
+    if (!msg || typeof msg !== "object") continue;
+    const role = typeof msg.role === "string" ? msg.role : "";
+    const content = typeof msg.content === "string" ? msg.content : "";
+    const toolCallId = typeof msg.tool_call_id === "string" ? msg.tool_call_id : "";
+    // 1 message あたり 4 token のオーバーヘッド（role marker 等）を加味
+    total +=
+      estimateTokenCount(role) + estimateTokenCount(content) + estimateTokenCount(toolCallId) + 4;
+  }
+  return total;
+}
+
+/**
+ * prompt + messages の合計 token 数を近似する。
+ * before_agent_run の段 1（per-turn prompt input gate）で次ターン入力の見積もりに使う。
+ */
+export function estimatePromptInputTokens(
+  prompt: string | undefined,
+  messages: SessionMessage[] | undefined,
+): number {
+  const promptTokens = estimateTokenCount(prompt ?? "");
+  const messagesTokens = estimateMessagesTokenCount(messages);
+  return promptTokens + messagesTokens;
+}

--- a/packages/cost-guard/src/token-estimator.ts
+++ b/packages/cost-guard/src/token-estimator.ts
@@ -19,8 +19,9 @@
 
 export interface SessionMessage {
   role: "user" | "assistant" | "tool" | "system";
-  content: string;
+  content: unknown;
   tool_call_id?: string;
+  [key: string]: unknown;
 }
 
 /**
@@ -52,13 +53,48 @@ export function estimateMessagesTokenCount(messages: SessionMessage[] | undefine
   for (const msg of messages) {
     if (!msg || typeof msg !== "object") continue;
     const role = typeof msg.role === "string" ? msg.role : "";
-    const content = typeof msg.content === "string" ? msg.content : "";
+    const content = messageFieldToString(msg.content);
     const toolCallId = typeof msg.tool_call_id === "string" ? msg.tool_call_id : "";
+    const extraPayload = messageExtraPayloadToString(msg);
     // 1 message あたり 4 token のオーバーヘッド（role marker 等）を加味
     total +=
-      estimateTokenCount(role) + estimateTokenCount(content) + estimateTokenCount(toolCallId) + 4;
+      estimateTokenCount(role) +
+      estimateTokenCount(content) +
+      estimateTokenCount(toolCallId) +
+      estimateTokenCount(extraPayload) +
+      4;
   }
   return total;
+}
+
+function messageFieldToString(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (value === undefined || value === null) return "";
+  return safeJsonStringify(value);
+}
+
+function messageExtraPayloadToString(msg: SessionMessage): string {
+  const extraEntries = Object.entries(msg).filter(
+    ([key]) => key !== "role" && key !== "content" && key !== "tool_call_id",
+  );
+  if (extraEntries.length === 0) return "";
+  return safeJsonStringify(Object.fromEntries(extraEntries));
+}
+
+function safeJsonStringify(value: unknown): string {
+  const seen = new WeakSet<object>();
+  try {
+    return (
+      JSON.stringify(value, (_key, v: unknown) => {
+        if (typeof v !== "object" || v === null) return v;
+        if (seen.has(v)) return "[Circular]";
+        seen.add(v);
+        return v;
+      }) ?? ""
+    );
+  } catch {
+    return String(value);
+  }
 }
 
 /**

--- a/packages/cost-guard/tsconfig.json
+++ b/packages/cost-guard/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./cost-guard",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
+}


### PR DESCRIPTION
## 概要

hongmong-ochi-agent の transcript コスト爆発（Claude API $1990/月）への構造対策として、Phase 1 設計 v6（estack-inc/easy-flow#398）の L1 cost-guard plugin（本格版）を実装する。default deny + tool allowlist + 2 段 breaker で `denyPaths` 配下への汎用 file access を遮断し、`transcript-analyzer.*` の 3 tool のみを通す。

## 変更の種類

- [x] 新機能 (new feature)
- [ ] バグ修正
- [ ] 機能改善
- [ ] リファクタリング
- [ ] テスト追加・修正
- [ ] ドキュメント
- [ ] CI/CD・設定

## 関連 Issue

- 案件: estack-inc/easy-flow リポジトリの `docs/operations/multi-agent-cases/transcript-cost-prevention-phase1-impl/`
- task: task-1
- 関連 Issue: estack-inc/easy-flow#360 / estack-inc/easy-flow#376

## 要件（AI レビューで充足確認されます）

- [x] `before_tool_call`: `denyPaths` 配下への汎用 tool 呼び出しを block、`allowlistedToolsForDenyPaths` のみ通過。`realpath` で symlink 解決 + `denyHardlinkTraversal=true` 時に inode 一致で hardlink 経由も検出
- [x] `tool_result_persist`: `rewriteThresholdBytes` (50KB) 超の result を sentinel 置換、`tool_call_id` を保持
- [x] `before_agent_run`: 段 1 per-turn input gate (50K token) → 段 2 session cumulative budget breaker (500K token) → 通過後 `cleanupOnSessionStart=true` 時に過去 messages の `denyPaths` 参照を sentinel 置換
- [x] rollback Mode A（`suspendAgent: true`）対応
- [x] contracts.md §2.1 / §2.2 / §2.3 / §7.1 / §7.2 の return type に厳密準拠
- [x] 5 metric (`cost_guard.*`) を発行、`api.metrics` 未提供の OpenClaw 旧版でも動作
- [x] 30+ 迂回パターン耐性（unit test で全パス）
- [x] unit test カバレッジ 95.51%（DoD ≥ 90%）

## 変更内容

- `packages/cost-guard/` 配下に 14 ファイル新規追加
  - `openclaw.plugin.json`: plugin metadata + configSchema (contracts.md §9.1 の 12 property)
  - `package.json` / `tsconfig.json`: npm workspace package + ESM + TypeScript
  - `README.md`: 使い方 / 設定 / 30+ 迂回パターン解説 / 運用注意事項
  - `src/index.ts`: register entry point + 3 hook 実装
  - `src/path-checker.ts`: 文字列 canonical 化 + `realpath` + inode 一致検査
  - `src/command-checker.ts`: `commandDenylist` の AST 検査
  - `src/token-estimator.ts`: 軽量 token 近似（utf8_bytes / 4、新規依存を避ける）
  - `src/sentinel.ts`: sentinel 文字列生成 + byte 計算
  - 各モジュールに対応する `*.test.ts`（合計 177 unit test）
- `.gitignore`: build 出力ディレクトリ `packages/cost-guard/cost-guard/` を ignore（既存 `cost-guard-hello` の前例に倣う）
- `package-lock.json`: `@vitest/coverage-v8` を新規 devDependency 追加した結果のロックファイル更新

## 影響パッケージ

- [x] なし（新規 plugin package 追加のみ。既存 package は変更なし）

cost-guard-hello への影響：なし（Phase 0 実証用 plugin として共存。回帰 test 43 件 pass）。

## Breaking Changes

なし。新規 plugin package の追加であり、既存 plugin の API は変更していない。

## テスト

- [x] cost-guard package 全テスト pass: `npm test -w cost-guard` → 177 test、coverage 95.51%
- [x] cost-guard-hello 無回帰確認: `npm test -w cost-guard-hello` → 43 test pass
- [x] typecheck: `npm run typecheck -w cost-guard` clean
- [x] lint: `npm run lint -w cost-guard` clean（Biome）
- [x] build: `npm run build -w cost-guard` 成功

### 重点 test 観点

- **30+ 迂回パターン**: 絶対 path / `../` / URL-encoded / 不可視文字 / cwd 起点 / command 内 redirection / option value / bare filename + cwd / symlink / hardlink (inode 一致) / NFKC など、`packages/cost-guard/src/path-checker.test.ts` で各パターンを test
- **sentinel boundary value**: 49,999 byte（置換なし）/ 50,000 byte（境界、置換なし）/ 50,001 byte（置換あり）
- **2 段 breaker boundary value**: per-turn 49,999 / 50,000 / 50,001 token、session 499,999 / 500,000 / 500,001 token
- **latency**: 50 件の path 検査が 500ms 未満で完了（path-checker.test.ts のベンチマーク）

## クロスリポジトリへの影響

- [x] なし（本 PR は estack-inc/easy-flow-agent 内に閉じる）
- [ ] openclaw-templates への影響: 別案件で `cost-guard` を `base/entrypoint.sh` の extension sync list に追加予定（本 PR では対象外）
- [ ] easy-flow-infra への影響: なし
- [ ] openclaw-clients への影響: なし

## チェックリスト

- [x] コードの自己レビュー完了（Self-review Gate + Skill `review` iterate 1 round で 2 件の指摘を反映）
- [x] テスト通過（177 unit test, coverage 95.51%）
- [x] 型エラーなし
- [x] CLAUDE.md / specs/ の更新: 不要（新規 package 追加のみ、既存ルールに準拠）

## briefing target_files 範囲外の変更について

briefing.md の `target_files` には `pnpm-workspace.yaml` が記載されていたが、本 repo は npm workspaces を使用しており、該当ファイルは存在しない。npm workspaces は `package.json` の `workspaces: ["packages/*"]` glob で新規 package を自動登録するため、ワークスペース登録用の追加ファイル変更は不要。

ただし以下 2 ファイルは target_files に明示されていないが、briefing の意図（完全に動作する package を追加する）を満たすために必要なため変更している：

- `.gitignore`: 既存 `cost-guard-hello` 同様、build 出力（`packages/cost-guard/cost-guard/`）を ignore に追加（1 行追記のみ）
- `package-lock.json`: `@vitest/coverage-v8` を新規 devDependency 追加した自動的な結果。coverage ≥ 90% の DoD を満たすために本 dep は必須

## Owner 目視確認推奨（leaf_node: false）

本 plugin は `denyPaths` + `allowlistedToolsForDenyPaths` で全 tool 呼び出しを判定する critical path であり、認証・セキュリティ関連の core 機能（leaf_node: false）に該当する。merge 前に以下を Owner 目視確認推奨：

- `src/index.ts` の 3 hook 戻り値が contracts.md §2.1 / §2.2 / §2.3 と一致しているか
- `src/path-checker.ts` の `realpath` / inode 一致処理が想定通り動くか（macOS の `/tmp` → `/private/tmp` symlink 解決を test で検証済）
- `commandDenylist` の AST 検査が shell injection を確実に捕捉するか
- 5 metric (`cost_guard.tool_call_blocked` / `tool_result_rewritten` / `per_turn_input_blocked` / `session_budget_exceeded` / `transcript_pollution_detected`) + 追加 1 metric (`cost_guard.agent_suspended_block`、suspendAgent 専用) が想定通り発行されるか

---

## Fleet 実装ジョブ

- [x] Skill `review` iterate clean（iterate 1 で 2 件の指摘を反映 → iterate 2 で指摘 0）
- [x] target_files 内のファイルのみを変更（`.gitignore` / `package-lock.json` は target_files の意図を満たすための必要最小限の差分で、上記「briefing target_files 範囲外の変更について」で明示）
- [x] `--no-verify` / `--dangerously-skip-permissions` / hook bypass を使用していない
- [x] gh CLI 経由以外で GitHub API を呼び出していない

## AIレビュースキップ理由

- 該当なし（AI レビュー対象）

<!-- slack_channel: C0ALHTE50Q5 -->
<!-- slack_thread_ts: -->
<!-- slack_agent_mention: -->
