### PR TITLE
fix(transcript-analyzer): 道具一覧の申告（contracts.tools）を追加し 3 tool を登録可能にする

### DIFF
--- a/packages/transcript-analyzer/openclaw.plugin.json
+++ b/packages/transcript-analyzer/openclaw.plugin.json
@@ -3,6 +3,13 @@
   "kind": "plugin",
   "name": "Transcript Analyzer",
   "description": "Phase 1 transcript-analyzer plugin。transcript を業務利用する唯一の合法経路として 3 tool（list_transcripts / search_transcripts / analyze_transcript）を提供。Gemini 2.5 Flash で transcript を analyze し structured JSON（answer + citations + confidence）を返す。cost-guard の allowlist 通過対象。多段 fallback（cache → Gemini → chunk 分割 → fallbackModel → 明示的失敗）。Sonnet 全文 fallback は禁止。",
+  "contracts": {
+    "tools": [
+      "transcript-analyzer.list_transcripts",
+      "transcript-analyzer.search_transcripts",
+      "transcript-analyzer.analyze_transcript"
+    ]
+  },
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/packages/transcript-analyzer/transcript-analyzer/openclaw.plugin.json
+++ b/packages/transcript-analyzer/transcript-analyzer/openclaw.plugin.json
@@ -3,6 +3,13 @@
   "kind": "plugin",
   "name": "Transcript Analyzer",
   "description": "Phase 1 transcript-analyzer plugin。transcript を業務利用する唯一の合法経路として 3 tool（list_transcripts / search_transcripts / analyze_transcript）を提供。Gemini 2.5 Flash で transcript を analyze し structured JSON（answer + citations + confidence）を返す。cost-guard の allowlist 通過対象。多段 fallback（cache → Gemini → chunk 分割 → fallbackModel → 明示的失敗）。Sonnet 全文 fallback は禁止。",
+  "contracts": {
+    "tools": [
+      "transcript-analyzer.list_transcripts",
+      "transcript-analyzer.search_transcripts",
+      "transcript-analyzer.analyze_transcript"
+    ]
+  },
   "configSchema": {
     "type": "object",
     "additionalProperties": false,


### PR DESCRIPTION
## 背景

検証環境（dev-and-test-agent）への配布後の点検で、transcript-analyzer の 3 つの道具（一覧・検索・要約）が AI 本体から呼び出せない問題が判明しました。起動・読み込みは成功し、依存内包バンドル（#173）も正しく動作していますが、肝心の道具が未登録でした。

## 原因

OpenClaw 2026.5.12 は、plugin が道具を登録する前に `openclaw.plugin.json` の `contracts.tools`（提供する道具一覧）の宣言を必須化しています。基盤ソース（`loader-DkTFEskE.js` の `registerTool`）で「宣言が空なら error 診断を出して登録を中止（return）」する処理を確認しました。transcript-analyzer は `contracts` 未宣言のため、起動はするが 3 道具が未登録でした（dev `plugins doctor` で確認）。

## 修正

`openclaw.plugin.json` に `contracts.tools` を追加します。道具解決時（`tools-DsGaQCaM.js`）に、factory が返す各道具の `name` を `contracts.tools` と完全一致照合し未申告道具を除外するため、登録名と同じ接頭辞付き完全名（`transcript-analyzer.*`）で宣言します。

## 検証

- dev の OpenClaw 2026.5.12 基盤ソースで登録経路（registerTool → 道具解決時の照合）を確認
- 第三者レビュー（codex）で方針検証（接頭辞付き完全名での宣言が正しいことを確認）
- ローカルテスト 167 件全通過・カバレッジ閾値クリア（行 90.46% / 分岐 81.73%）
- ビルド出力の `openclaw.plugin.json` にも cp 経由で反映確認
- 変更は申告ファイルのみ（道具の実体 index.js は #173 のまま）

## マージ後

openclaw-templates の Phase 1 取得元 SHA を本マージコミットに更新し、dev-and-test-agent へ再配布して 3 道具の登録を確認します（Issue estack-inc/easy-flow#360 / #376）。