### PR TITLE
fix: cost-guard が OpenClaw event 構造を正しく読むよう修正（印置換・session budget の root cause）

### DIFF
--- a/packages/cost-guard/cost-guard/index.js
+++ b/packages/cost-guard/cost-guard/index.js
@@ -150,10 +150,12 @@ export default function register(api) {
     // tool_result_persist: rewriteThresholdBytes 超で sentinel 置換
     // --------------------------------------------------------------------------
     api.on("tool_result_persist", (event, _ctx) => {
+        // OpenClaw の tool_result_persist event は tool result を `message`(AgentMessage) に格納する。
+        // `result` フィールドは存在しない（hook-types.d.ts: PluginHookToolResultPersistEvent）。
         const e = event;
-        const toolId = e.toolId ?? e.toolName ?? "(unknown)";
-        const toolCallId = e.toolCallId ?? e.tool_call_id ?? "";
-        const contentBytes = extractResultContentBytes(e.result);
+        const toolId = e.toolName ?? "(unknown)";
+        const toolCallId = e.message?.tool_call_id ?? e.toolCallId ?? "";
+        const contentBytes = extractResultContentBytes(e.message);
         if (cfg.logging) {
             log.info(`${TAG} tool_result_persist: tool=${toolId} call_id=${toolCallId || "(none)"} bytes=${contentBytes}`);
         }
@@ -167,6 +169,7 @@ export default function register(api) {
                 return {};
             return {
                 message: {
+                    ...e.message,
                     role: "tool",
                     tool_call_id: toolCallId,
                     content: sentinel,
@@ -178,9 +181,12 @@ export default function register(api) {
     // --------------------------------------------------------------------------
     // before_agent_run: 段 1 per-turn gate → 段 2 session budget → cleanup
     // --------------------------------------------------------------------------
-    api.on("before_agent_run", (event, _ctx) => {
+    api.on("before_agent_run", (event, ctx) => {
         const e = event;
-        const sessionId = e.sessionId ?? e.channelId ?? e.accountId ?? "default";
+        // session 識別子は ctx(PluginHookAgentContext) が正本（OpenClaw 実 event には sessionId が無い）。
+        // e.sessionId は後方互換 fallback（ctx より低優先。host 差異や旧 event 形式への保険）。
+        const c = ctx;
+        const sessionId = c.sessionId ?? c.sessionKey ?? e.sessionId ?? e.channelId ?? e.accountId ?? "default";
         // 0. rollback Mode A: suspendAgent
         //    本 case は contracts.md §10.1 の 5 metric とは独立した運用イベントのため、
         //    `cost_guard.session_budget_exceeded` には混ぜず、専用 metric を別途発行する。

--- a/packages/cost-guard/src/index.test.ts
+++ b/packages/cost-guard/src/index.test.ts
@@ -348,7 +348,10 @@ describe("tool_result_persist - sentinel boundary", () => {
     register(api as any);
     const handler = api.hooks.get("tool_result_persist")!;
     const result = handler(
-      { toolName: "read", message: { role: "tool", tool_call_id: "tcid_str", content: "x".repeat(60_000) } },
+      {
+        toolName: "read",
+        message: { role: "tool", tool_call_id: "tcid_str", content: "x".repeat(60_000) },
+      },
       {},
     ) as ToolResultPersistResult;
     expect((result as any).message).toBeDefined();
@@ -359,7 +362,10 @@ describe("tool_result_persist - sentinel boundary", () => {
     register(api as any);
     const handler = api.hooks.get("tool_result_persist")!;
     const result = handler(
-      { toolName: "read", message: { role: "tool", tool_call_id: "tcid_x", content: "x".repeat(1001) } },
+      {
+        toolName: "read",
+        message: { role: "tool", tool_call_id: "tcid_x", content: "x".repeat(1001) },
+      },
       {},
     ) as ToolResultPersistResult;
     expect((result as any).message).toBeDefined();
@@ -369,7 +375,13 @@ describe("tool_result_persist - sentinel boundary", () => {
     const api = makeApi();
     register(api as any);
     const handler = api.hooks.get("tool_result_persist")!;
-    handler({ toolName: "read", message: { role: "tool", tool_call_id: "tcid_m", content: "x".repeat(60_000) } }, {});
+    handler(
+      {
+        toolName: "read",
+        message: { role: "tool", tool_call_id: "tcid_m", content: "x".repeat(60_000) },
+      },
+      {},
+    );
     expect(api.metrics.incrementCounter).toHaveBeenCalledWith(
       "cost_guard.tool_result_rewritten",
       expect.objectContaining({ toolId: "read" }),
@@ -381,7 +393,10 @@ describe("tool_result_persist - sentinel boundary", () => {
     register(api as any);
     const handler = api.hooks.get("tool_result_persist")!;
     const result = handler(
-      { toolName: "read", message: { role: "tool", tool_call_id: "tcid_obs", content: "x".repeat(60_000) } },
+      {
+        toolName: "read",
+        message: { role: "tool", tool_call_id: "tcid_obs", content: "x".repeat(60_000) },
+      },
       {},
     );
     expect(result).toEqual({});
@@ -397,7 +412,10 @@ describe("tool_result_persist - sentinel boundary", () => {
     const handler = api.hooks.get("tool_result_persist")!;
     api.logger.info.mockClear();
     handler(
-      { toolName: "read", message: { role: "tool", tool_call_id: "tcid_obs_log", content: "x".repeat(60_000) } },
+      {
+        toolName: "read",
+        message: { role: "tool", tool_call_id: "tcid_obs_log", content: "x".repeat(60_000) },
+      },
       {},
     );
     const infoCalls = api.logger.info.mock.calls.map((c: unknown[]) => c[0] as string);
@@ -411,7 +429,10 @@ describe("tool_result_persist - sentinel boundary", () => {
     const handler = api.hooks.get("tool_result_persist")!;
     api.logger.info.mockClear();
     handler(
-      { toolName: "read", message: { role: "tool", tool_call_id: "tcid_block_log", content: "x".repeat(60_000) } },
+      {
+        toolName: "read",
+        message: { role: "tool", tool_call_id: "tcid_block_log", content: "x".repeat(60_000) },
+      },
       {},
     );
     const infoCalls = api.logger.info.mock.calls.map((c: unknown[]) => c[0] as string);
@@ -463,7 +484,11 @@ describe("tool_result_persist - sentinel boundary", () => {
     const result = handler(
       {
         toolName: "read",
-        message: { role: "tool", tool_call_id: "tcid_arr2", content: [{ blob: "x".repeat(100_000) }] },
+        message: {
+          role: "tool",
+          tool_call_id: "tcid_arr2",
+          content: [{ blob: "x".repeat(100_000) }],
+        },
       },
       {},
     ) as ToolResultPersistResult;
@@ -477,7 +502,11 @@ describe("tool_result_persist - sentinel boundary", () => {
     const result = handler(
       {
         toolName: "read",
-        message: { role: "tool", tool_call_id: "tcid_arr3", content: ["text".repeat(50), 12345, true] },
+        message: {
+          role: "tool",
+          tool_call_id: "tcid_arr3",
+          content: ["text".repeat(50), 12345, true],
+        },
       },
       {},
     ) as ToolResultPersistResult;
@@ -663,7 +692,10 @@ describe("session state 累積（cumulative budget tracking）", () => {
     const api = makeApi();
     register(api as any);
     const handler = api.hooks.get("before_agent_run")!;
-    handler({ sessionId: "ev_s", prompt: "x".repeat(300_000), messages: [] }, { sessionId: "ctx_s" });
+    handler(
+      { sessionId: "ev_s", prompt: "x".repeat(300_000), messages: [] },
+      { sessionId: "ctx_s" },
+    );
     expect(api.metrics.incrementCounter).toHaveBeenCalledWith(
       "cost_guard.per_turn_input_blocked",
       expect.objectContaining({ sessionId: "ctx_s" }),
@@ -1145,7 +1177,13 @@ describe("metric 発行（contracts.md §10.1 の 5 metric）", () => {
     const api = makeApi();
     register(api as any);
     const handler = api.hooks.get("tool_result_persist")!;
-    handler({ toolName: "read", message: { role: "tool", tool_call_id: "tcid_a", content: "x".repeat(60_000) } }, {});
+    handler(
+      {
+        toolName: "read",
+        message: { role: "tool", tool_call_id: "tcid_a", content: "x".repeat(60_000) },
+      },
+      {},
+    );
     expect(api.metrics.incrementCounter).toHaveBeenCalledWith(
       "cost_guard.tool_result_rewritten",
       expect.anything(),

--- a/packages/cost-guard/src/index.test.ts
+++ b/packages/cost-guard/src/index.test.ts
@@ -274,9 +274,8 @@ describe("tool_result_persist - sentinel boundary", () => {
     const handler = api.hooks.get("tool_result_persist")!;
     const result = handler(
       {
-        toolId: "read",
-        toolCallId: "tcid_001",
-        result: { content: "x".repeat(49_999) },
+        toolName: "read",
+        message: { role: "tool", tool_call_id: "tcid_001", content: "x".repeat(49_999) },
       },
       {},
     ) as ToolResultPersistResult;
@@ -289,9 +288,8 @@ describe("tool_result_persist - sentinel boundary", () => {
     const handler = api.hooks.get("tool_result_persist")!;
     const result = handler(
       {
-        toolId: "read",
-        toolCallId: "tcid_002",
-        result: { content: "x".repeat(50_000) },
+        toolName: "read",
+        message: { role: "tool", tool_call_id: "tcid_002", content: "x".repeat(50_000) },
       },
       {},
     ) as ToolResultPersistResult;
@@ -304,9 +302,8 @@ describe("tool_result_persist - sentinel boundary", () => {
     const handler = api.hooks.get("tool_result_persist")!;
     const result = handler(
       {
-        toolId: "read",
-        toolCallId: "tcid_003",
-        result: { content: "x".repeat(50_001) },
+        toolName: "read",
+        message: { role: "tool", tool_call_id: "tcid_003", content: "x".repeat(50_001) },
       },
       {},
     ) as ToolResultPersistResult;
@@ -323,36 +320,35 @@ describe("tool_result_persist - sentinel boundary", () => {
     const handler = api.hooks.get("tool_result_persist")!;
     const result = handler(
       {
-        toolId: "read",
-        toolCallId: "tcid_preserve_me",
-        result: { content: "x".repeat(60_000) },
+        toolName: "read",
+        message: { role: "tool", tool_call_id: "tcid_preserve_me", content: "x".repeat(60_000) },
       },
       {},
     ) as ToolResultPersistResult;
     expect((result as any).message.tool_call_id).toBe("tcid_preserve_me");
   });
 
-  it("event.tool_call_id の snake_case 入力も sentinel message に保持", () => {
+  it("message に tool_call_id が無い場合は event.toolCallId(top-level) を fallback で保持", () => {
     const api = makeApi();
     register(api as any);
     const handler = api.hooks.get("tool_result_persist")!;
     const result = handler(
       {
-        toolId: "read",
-        tool_call_id: "tcid_x",
-        result: { content: "x".repeat(60_000) },
+        toolName: "read",
+        toolCallId: "tcid_x",
+        message: { role: "tool", content: "x".repeat(60_000) },
       },
       {},
     ) as ToolResultPersistResult;
     expect((result as any).message.tool_call_id).toBe("tcid_x");
   });
 
-  it("string 直結 result でも byte 数計算", () => {
+  it("message.content が string 直結でも byte 数計算", () => {
     const api = makeApi();
     register(api as any);
     const handler = api.hooks.get("tool_result_persist")!;
     const result = handler(
-      { toolId: "read", toolCallId: "tcid_str", result: "x".repeat(60_000) },
+      { toolName: "read", message: { role: "tool", tool_call_id: "tcid_str", content: "x".repeat(60_000) } },
       {},
     ) as ToolResultPersistResult;
     expect((result as any).message).toBeDefined();
@@ -363,7 +359,7 @@ describe("tool_result_persist - sentinel boundary", () => {
     register(api as any);
     const handler = api.hooks.get("tool_result_persist")!;
     const result = handler(
-      { toolId: "read", toolCallId: "tcid_x", result: { content: "x".repeat(1001) } },
+      { toolName: "read", message: { role: "tool", tool_call_id: "tcid_x", content: "x".repeat(1001) } },
       {},
     ) as ToolResultPersistResult;
     expect((result as any).message).toBeDefined();
@@ -373,7 +369,7 @@ describe("tool_result_persist - sentinel boundary", () => {
     const api = makeApi();
     register(api as any);
     const handler = api.hooks.get("tool_result_persist")!;
-    handler({ toolId: "read", toolCallId: "tcid_m", result: { content: "x".repeat(60_000) } }, {});
+    handler({ toolName: "read", message: { role: "tool", tool_call_id: "tcid_m", content: "x".repeat(60_000) } }, {});
     expect(api.metrics.incrementCounter).toHaveBeenCalledWith(
       "cost_guard.tool_result_rewritten",
       expect.objectContaining({ toolId: "read" }),
@@ -385,7 +381,7 @@ describe("tool_result_persist - sentinel boundary", () => {
     register(api as any);
     const handler = api.hooks.get("tool_result_persist")!;
     const result = handler(
-      { toolId: "read", toolCallId: "tcid_obs", result: { content: "x".repeat(60_000) } },
+      { toolName: "read", message: { role: "tool", tool_call_id: "tcid_obs", content: "x".repeat(60_000) } },
       {},
     );
     expect(result).toEqual({});
@@ -401,7 +397,7 @@ describe("tool_result_persist - sentinel boundary", () => {
     const handler = api.hooks.get("tool_result_persist")!;
     api.logger.info.mockClear();
     handler(
-      { toolId: "read", toolCallId: "tcid_obs_log", result: { content: "x".repeat(60_000) } },
+      { toolName: "read", message: { role: "tool", tool_call_id: "tcid_obs_log", content: "x".repeat(60_000) } },
       {},
     );
     const infoCalls = api.logger.info.mock.calls.map((c: unknown[]) => c[0] as string);
@@ -415,22 +411,23 @@ describe("tool_result_persist - sentinel boundary", () => {
     const handler = api.hooks.get("tool_result_persist")!;
     api.logger.info.mockClear();
     handler(
-      { toolId: "read", toolCallId: "tcid_block_log", result: { content: "x".repeat(60_000) } },
+      { toolName: "read", message: { role: "tool", tool_call_id: "tcid_block_log", content: "x".repeat(60_000) } },
       {},
     );
     const infoCalls = api.logger.info.mock.calls.map((c: unknown[]) => c[0] as string);
     expect(infoCalls.some((m) => m.includes("tool_result_rewritten:"))).toBe(true);
   });
 
-  it("result.content が配列（[{text: '...'}, ...]）形式でも byte 数を合算", () => {
+  it("message.content が配列（[{text: '...'}, ...]）形式でも byte 数を合算", () => {
     const api = makeApi();
     register(api as any);
     const handler = api.hooks.get("tool_result_persist")!;
     const result = handler(
       {
-        toolId: "read",
-        toolCallId: "tcid_arr",
-        result: {
+        toolName: "read",
+        message: {
+          role: "tool",
+          tool_call_id: "tcid_arr",
           content: [{ text: "x".repeat(30_000) }, { text: "y".repeat(30_000) }],
         },
       },
@@ -440,15 +437,16 @@ describe("tool_result_persist - sentinel boundary", () => {
     expect((result as any).message.content).toContain(SENTINEL_PREFIX);
   });
 
-  it("result.content 配列内の object は text 以外の巨大 field も byte 数に含める", () => {
+  it("message.content 配列内の object は text 以外の巨大 field も byte 数に含める", () => {
     const api = makeApi();
     register(api as any);
     const handler = api.hooks.get("tool_result_persist")!;
     const result = handler(
       {
-        toolId: "read",
-        toolCallId: "tcid_arr_raw",
-        result: {
+        toolName: "read",
+        message: {
+          role: "tool",
+          tool_call_id: "tcid_arr_raw",
           content: [{ text: "ok", raw: "x".repeat(60_000) }],
         },
       },
@@ -458,55 +456,52 @@ describe("tool_result_persist - sentinel boundary", () => {
     expect((result as any).message.content).toContain(SENTINEL_PREFIX);
   });
 
-  it("result.content 配列内の object に text が無い場合は JSON 化 byte 数で計算", () => {
+  it("message.content 配列内の object に text が無い場合は JSON 化 byte 数で計算", () => {
     const api = makeApi();
     register(api as any);
     const handler = api.hooks.get("tool_result_persist")!;
     const result = handler(
       {
-        toolId: "read",
-        toolCallId: "tcid_arr2",
-        result: { content: [{ blob: "x".repeat(100_000) }] },
+        toolName: "read",
+        message: { role: "tool", tool_call_id: "tcid_arr2", content: [{ blob: "x".repeat(100_000) }] },
       },
       {},
     ) as ToolResultPersistResult;
     expect((result as any).message).toBeDefined();
   });
 
-  it("result.content 配列内の非 object 要素も byte 数で計算", () => {
+  it("message.content 配列内の非 object 要素も byte 数で計算", () => {
     const api = makeApi({ rewriteThresholdBytes: 100 });
     register(api as any);
     const handler = api.hooks.get("tool_result_persist")!;
     const result = handler(
       {
-        toolId: "read",
-        toolCallId: "tcid_arr3",
-        result: { content: ["text".repeat(50), 12345, true] },
+        toolName: "read",
+        message: { role: "tool", tool_call_id: "tcid_arr3", content: ["text".repeat(50), 12345, true] },
       },
       {},
     ) as ToolResultPersistResult;
     expect((result as any).message).toBeDefined();
   });
 
-  it("result が undefined / null の場合は 0 byte 扱いで置換しない", () => {
+  it("message が undefined / null の場合は 0 byte 扱いで置換しない", () => {
     const api = makeApi();
     register(api as any);
     const handler = api.hooks.get("tool_result_persist")!;
-    const result1 = handler({ toolId: "read", toolCallId: "n1", result: null }, {});
-    const result2 = handler({ toolId: "read", toolCallId: "n2", result: undefined }, {});
+    const result1 = handler({ toolName: "read", message: null }, {});
+    const result2 = handler({ toolName: "read", message: undefined }, {});
     expect(result1).toEqual({});
     expect(result2).toEqual({});
   });
 
-  it("result が plain object（content なし）の場合は JSON 化 byte 数で計算", () => {
+  it("message が plain object（content なし）の場合は JSON 化 byte 数で計算", () => {
     const api = makeApi({ rewriteThresholdBytes: 50 });
     register(api as any);
     const handler = api.hooks.get("tool_result_persist")!;
     const result = handler(
       {
-        toolId: "read",
-        toolCallId: "tcid_plain",
-        result: { other: "x".repeat(200) },
+        toolName: "read",
+        message: { role: "tool", tool_call_id: "tcid_plain", other: "x".repeat(200) },
       },
       {},
     ) as ToolResultPersistResult;
@@ -650,6 +645,40 @@ describe("session state 累積（cumulative budget tracking）", () => {
     expect((result1 as BeforeAgentRunResult).outcome).toBe("pass");
     expect((result2 as BeforeAgentRunResult).outcome).toBe("pass");
     expect((result3 as BeforeAgentRunResult).outcome).toBe("pass");
+  });
+
+  // 実 OpenClaw 経路の検証（session 識別子は ctx が正本。event には sessionId が無い）。回帰防止。
+  it("session 識別子は ctx.sessionId を正本として metric に反映する", () => {
+    const api = makeApi();
+    register(api as any);
+    const handler = api.hooks.get("before_agent_run")!;
+    handler({ prompt: "x".repeat(300_000), messages: [] }, { sessionId: "ctx_s1" });
+    expect(api.metrics.incrementCounter).toHaveBeenCalledWith(
+      "cost_guard.per_turn_input_blocked",
+      expect.objectContaining({ sessionId: "ctx_s1" }),
+    );
+  });
+
+  it("ctx.sessionId は event.sessionId より優先される（ctx が正本）", () => {
+    const api = makeApi();
+    register(api as any);
+    const handler = api.hooks.get("before_agent_run")!;
+    handler({ sessionId: "ev_s", prompt: "x".repeat(300_000), messages: [] }, { sessionId: "ctx_s" });
+    expect(api.metrics.incrementCounter).toHaveBeenCalledWith(
+      "cost_guard.per_turn_input_blocked",
+      expect.objectContaining({ sessionId: "ctx_s" }),
+    );
+  });
+
+  it("ctx.sessionId 不在時は ctx.sessionKey を session 識別子に使う", () => {
+    const api = makeApi();
+    register(api as any);
+    const handler = api.hooks.get("before_agent_run")!;
+    handler({ prompt: "x".repeat(300_000), messages: [] }, { sessionKey: "agent:main:k1" });
+    expect(api.metrics.incrementCounter).toHaveBeenCalledWith(
+      "cost_guard.per_turn_input_blocked",
+      expect.objectContaining({ sessionId: "agent:main:k1" }),
+    );
   });
 });
 
@@ -1116,7 +1145,7 @@ describe("metric 発行（contracts.md §10.1 の 5 metric）", () => {
     const api = makeApi();
     register(api as any);
     const handler = api.hooks.get("tool_result_persist")!;
-    handler({ toolId: "read", toolCallId: "tcid_a", result: { content: "x".repeat(60_000) } }, {});
+    handler({ toolName: "read", message: { role: "tool", tool_call_id: "tcid_a", content: "x".repeat(60_000) } }, {});
     expect(api.metrics.incrementCounter).toHaveBeenCalledWith(
       "cost_guard.tool_result_rewritten",
       expect.anything(),

--- a/packages/cost-guard/src/index.ts
+++ b/packages/cost-guard/src/index.ts
@@ -273,16 +273,17 @@ export default function register(api: OpenClawPluginApi): void {
   // tool_result_persist: rewriteThresholdBytes 超で sentinel 置換
   // --------------------------------------------------------------------------
   api.on("tool_result_persist", (event: unknown, _ctx: unknown): ToolResultPersistResult => {
+    // OpenClaw の tool_result_persist event は tool result を `message`(AgentMessage) に格納する。
+    // `result` フィールドは存在しない（hook-types.d.ts: PluginHookToolResultPersistEvent）。
     const e = event as {
       toolName?: string;
-      toolId?: string;
       toolCallId?: string;
-      tool_call_id?: string;
-      result?: unknown;
+      message?: { role?: string; content?: unknown; tool_call_id?: string; [k: string]: unknown };
+      isSynthetic?: boolean;
     };
-    const toolId = e.toolId ?? e.toolName ?? "(unknown)";
-    const toolCallId = e.toolCallId ?? e.tool_call_id ?? "";
-    const contentBytes = extractResultContentBytes(e.result);
+    const toolId = e.toolName ?? "(unknown)";
+    const toolCallId = e.message?.tool_call_id ?? e.toolCallId ?? "";
+    const contentBytes = extractResultContentBytes(e.message);
 
     if (cfg.logging) {
       log.info(
@@ -302,7 +303,8 @@ export default function register(api: OpenClawPluginApi): void {
       if (cfg.blockMode === "observe") return {};
       return {
         message: {
-          role: "tool",
+          ...e.message,
+          role: "tool" as const,
           tool_call_id: toolCallId,
           content: sentinel,
         },
@@ -314,7 +316,7 @@ export default function register(api: OpenClawPluginApi): void {
   // --------------------------------------------------------------------------
   // before_agent_run: 段 1 per-turn gate → 段 2 session budget → cleanup
   // --------------------------------------------------------------------------
-  api.on("before_agent_run", (event: unknown, _ctx: unknown): BeforeAgentRunResult => {
+  api.on("before_agent_run", (event: unknown, ctx: unknown): BeforeAgentRunResult => {
     const e = event as {
       prompt?: string;
       messages?: SessionMessage[];
@@ -322,7 +324,11 @@ export default function register(api: OpenClawPluginApi): void {
       accountId?: string;
       channelId?: string;
     };
-    const sessionId = e.sessionId ?? e.channelId ?? e.accountId ?? "default";
+    // session 識別子は ctx(PluginHookAgentContext) が正本（OpenClaw 実 event には sessionId が無い）。
+    // e.sessionId は後方互換 fallback（ctx より低優先。host 差異や旧 event 形式への保険）。
+    const c = ctx as { sessionId?: string; sessionKey?: string };
+    const sessionId =
+      c.sessionId ?? c.sessionKey ?? e.sessionId ?? e.channelId ?? e.accountId ?? "default";
 
     // 0. rollback Mode A: suspendAgent
     //    本 case は contracts.md §10.1 の 5 metric とは独立した運用イベントのため、


### PR DESCRIPTION
## 概要
cost-guard plugin が OpenClaw の event 構造と不一致で、**印置換（コスト削減の核心）と session budget が dev で機能していなかった** root cause を修正。dev-and-test-agent の canary 検証中に発見。

## root cause（dev 実機 OpenClaw 2026.5.12 の hook-types.d.ts で確認）
- **tool_result_persist**: `event.result`（存在しない）を読んでいた。OpenClaw は tool result を `message`(AgentMessage) に格納（`PluginHookToolResultPersistEvent = { toolName?, toolCallId?, message, isSynthetic? }`）。→ 結果サイズが常に 0 判定 → 50KB 超の sentinel 置換が一度も発火しなかった。
- **before_agent_run**: `event.sessionId`（存在しない）を読んでいた。session 識別子は `ctx`(PluginHookAgentContext) 側。→ session budget の粒度が default に集約。

## 修正
- tool_result_persist: `extractResultContentBytes(e.message)` + 戻り値を元 message 保持（role: "tool"）
- before_agent_run: session 識別子を `ctx.sessionId/sessionKey` から取得（event 後方互換 fallback 付き）
- テスト: 18 個の mock を実 event 構造（message）に修正 + ctx 経路の新規テスト 3 つ（実装とテストが同じ誤った前提を共有する再発を防止）

## 検証（dev-and-test-agent）
- **印置換 root cause 修正**: ✅ cost-guard が結果サイズを測れる（bytes 0→112/16494）
- **遮断**: ✅ PASS（zoom_transcribe への read を BLOCKED、回帰なし）
- **hongmong 経路**: 確認完了（hongmong も 2026.5.12、read 縮小 + 遮断で防げる。印置換は二次防御）
- **token gate / gateway runner の cost-guard ロード**: dev は gateway 接続失敗で embedded fallback のため確認困難。実運用経路（channel → gateway runner）では動く見込み。**本番デプロイ後に実トラフィックで最終確認**。

## レビュー
codex（high reasoning）で root cause・修正案とも妥当と確認済み。全 209 テスト green。