### PR TITLE
fix: transcript-analyzer の tool 名を Claude 互換に修正（本番ブロッカー）

### DIFF
--- a/packages/cost-guard/README.md
+++ b/packages/cost-guard/README.md
@@ -47,9 +47,9 @@ openclaw plugins inspect cost-guard --runtime --json
           "blockMode": "block",
           "denyPaths": ["/data/workspace/zoom_transcribe/"],
           "allowlistedToolsForDenyPaths": [
-            "transcript-analyzer.list_transcripts",
-            "transcript-analyzer.search_transcripts",
-            "transcript-analyzer.analyze_transcript"
+            "transcript_analyzer_list_transcripts",
+            "transcript_analyzer_search_transcripts",
+            "transcript_analyzer_analyze_transcript"
           ],
           "rewriteThresholdBytes": 50000,
           "sessionTokenBudget": 500000,

--- a/packages/cost-guard/cost-guard/index.js
+++ b/packages/cost-guard/cost-guard/index.js
@@ -150,10 +150,12 @@ export default function register(api) {
     // tool_result_persist: rewriteThresholdBytes 超で sentinel 置換
     // --------------------------------------------------------------------------
     api.on("tool_result_persist", (event, _ctx) => {
+        // OpenClaw の tool_result_persist event は tool result を `message`(AgentMessage) に格納する。
+        // `result` フィールドは存在しない（hook-types.d.ts: PluginHookToolResultPersistEvent）。
         const e = event;
-        const toolId = e.toolId ?? e.toolName ?? "(unknown)";
-        const toolCallId = e.toolCallId ?? e.tool_call_id ?? "";
-        const contentBytes = extractResultContentBytes(e.result);
+        const toolId = e.toolName ?? "(unknown)";
+        const toolCallId = e.message?.tool_call_id ?? e.toolCallId ?? "";
+        const contentBytes = extractResultContentBytes(e.message);
         if (cfg.logging) {
             log.info(`${TAG} tool_result_persist: tool=${toolId} call_id=${toolCallId || "(none)"} bytes=${contentBytes}`);
         }
@@ -167,6 +169,7 @@ export default function register(api) {
                 return {};
             return {
                 message: {
+                    ...e.message,
                     role: "tool",
                     tool_call_id: toolCallId,
                     content: sentinel,
@@ -178,9 +181,12 @@ export default function register(api) {
     // --------------------------------------------------------------------------
     // before_agent_run: 段 1 per-turn gate → 段 2 session budget → cleanup
     // --------------------------------------------------------------------------
-    api.on("before_agent_run", (event, _ctx) => {
+    api.on("before_agent_run", (event, ctx) => {
         const e = event;
-        const sessionId = e.sessionId ?? e.channelId ?? e.accountId ?? "default";
+        // session 識別子は ctx(PluginHookAgentContext) が正本（OpenClaw 実 event には sessionId が無い）。
+        // e.sessionId は後方互換 fallback（ctx より低優先。host 差異や旧 event 形式への保険）。
+        const c = ctx;
+        const sessionId = c.sessionId ?? c.sessionKey ?? e.sessionId ?? e.channelId ?? e.accountId ?? "default";
         // 0. rollback Mode A: suspendAgent
         //    本 case は contracts.md §10.1 の 5 metric とは独立した運用イベントのため、
         //    `cost_guard.session_budget_exceeded` には混ぜず、専用 metric を別途発行する。

--- a/packages/cost-guard/cost-guard/index.js
+++ b/packages/cost-guard/cost-guard/index.js
@@ -39,9 +39,9 @@ const DEFAULTS = {
     blockMode: "block",
     denyPaths: ["/data/workspace/zoom_transcribe/"],
     allowlistedToolsForDenyPaths: [
-        "transcript-analyzer.list_transcripts",
-        "transcript-analyzer.search_transcripts",
-        "transcript-analyzer.analyze_transcript",
+        "transcript_analyzer_list_transcripts",
+        "transcript_analyzer_search_transcripts",
+        "transcript_analyzer_analyze_transcript",
     ],
     rewriteThresholdBytes: 50000,
     sessionTokenBudget: 500000,

--- a/packages/cost-guard/cost-guard/openclaw.plugin.json
+++ b/packages/cost-guard/cost-guard/openclaw.plugin.json
@@ -33,9 +33,9 @@
         "type": "array",
         "items": { "type": "string" },
         "default": [
-          "transcript-analyzer.list_transcripts",
-          "transcript-analyzer.search_transcripts",
-          "transcript-analyzer.analyze_transcript"
+          "transcript_analyzer_list_transcripts",
+          "transcript_analyzer_search_transcripts",
+          "transcript_analyzer_analyze_transcript"
         ],
         "description": "denyPaths 配下にアクセス可能な tool id allowlist"
       },

--- a/packages/cost-guard/openclaw.plugin.json
+++ b/packages/cost-guard/openclaw.plugin.json
@@ -33,9 +33,9 @@
         "type": "array",
         "items": { "type": "string" },
         "default": [
-          "transcript-analyzer.list_transcripts",
-          "transcript-analyzer.search_transcripts",
-          "transcript-analyzer.analyze_transcript"
+          "transcript_analyzer_list_transcripts",
+          "transcript_analyzer_search_transcripts",
+          "transcript_analyzer_analyze_transcript"
         ],
         "description": "denyPaths 配下にアクセス可能な tool id allowlist"
       },

--- a/packages/cost-guard/src/index.test.ts
+++ b/packages/cost-guard/src/index.test.ts
@@ -134,13 +134,13 @@ describe("before_tool_call - denyPaths block", () => {
     expect((result as any).block).toBe(true);
   });
 
-  it("allowlist 内 tool（transcript-analyzer.list_transcripts）は通過", () => {
+  it("allowlist 内 tool（transcript_analyzer_list_transcripts）は通過", () => {
     const api = makeApi();
     register(api as any);
     const handler = api.hooks.get("before_tool_call")!;
     const result = handler(
       {
-        toolId: "transcript-analyzer.list_transcripts",
+        toolId: "transcript_analyzer_list_transcripts",
         params: { path: `${DENY}transcript.txt` },
       },
       {},
@@ -148,13 +148,13 @@ describe("before_tool_call - denyPaths block", () => {
     expect(result).toEqual({});
   });
 
-  it("allowlist 内 tool（transcript-analyzer.search_transcripts）は通過", () => {
+  it("allowlist 内 tool（transcript_analyzer_search_transcripts）は通過", () => {
     const api = makeApi();
     register(api as any);
     const handler = api.hooks.get("before_tool_call")!;
     const result = handler(
       {
-        toolId: "transcript-analyzer.search_transcripts",
+        toolId: "transcript_analyzer_search_transcripts",
         params: { query: "hello", dir: DENY },
       },
       {},
@@ -162,13 +162,13 @@ describe("before_tool_call - denyPaths block", () => {
     expect(result).toEqual({});
   });
 
-  it("allowlist 内 tool（transcript-analyzer.analyze_transcript）は通過", () => {
+  it("allowlist 内 tool（transcript_analyzer_analyze_transcript）は通過", () => {
     const api = makeApi();
     register(api as any);
     const handler = api.hooks.get("before_tool_call")!;
     const result = handler(
       {
-        toolId: "transcript-analyzer.analyze_transcript",
+        toolId: "transcript_analyzer_analyze_transcript",
         params: { transcript_id: "xx", query: "hello" },
       },
       {},

--- a/packages/cost-guard/src/index.test.ts
+++ b/packages/cost-guard/src/index.test.ts
@@ -348,7 +348,10 @@ describe("tool_result_persist - sentinel boundary", () => {
     register(api as any);
     const handler = api.hooks.get("tool_result_persist")!;
     const result = handler(
-      { toolName: "read", message: { role: "tool", tool_call_id: "tcid_str", content: "x".repeat(60_000) } },
+      {
+        toolName: "read",
+        message: { role: "tool", tool_call_id: "tcid_str", content: "x".repeat(60_000) },
+      },
       {},
     ) as ToolResultPersistResult;
     expect((result as any).message).toBeDefined();
@@ -359,7 +362,10 @@ describe("tool_result_persist - sentinel boundary", () => {
     register(api as any);
     const handler = api.hooks.get("tool_result_persist")!;
     const result = handler(
-      { toolName: "read", message: { role: "tool", tool_call_id: "tcid_x", content: "x".repeat(1001) } },
+      {
+        toolName: "read",
+        message: { role: "tool", tool_call_id: "tcid_x", content: "x".repeat(1001) },
+      },
       {},
     ) as ToolResultPersistResult;
     expect((result as any).message).toBeDefined();
@@ -369,7 +375,13 @@ describe("tool_result_persist - sentinel boundary", () => {
     const api = makeApi();
     register(api as any);
     const handler = api.hooks.get("tool_result_persist")!;
-    handler({ toolName: "read", message: { role: "tool", tool_call_id: "tcid_m", content: "x".repeat(60_000) } }, {});
+    handler(
+      {
+        toolName: "read",
+        message: { role: "tool", tool_call_id: "tcid_m", content: "x".repeat(60_000) },
+      },
+      {},
+    );
     expect(api.metrics.incrementCounter).toHaveBeenCalledWith(
       "cost_guard.tool_result_rewritten",
       expect.objectContaining({ toolId: "read" }),
@@ -381,7 +393,10 @@ describe("tool_result_persist - sentinel boundary", () => {
     register(api as any);
     const handler = api.hooks.get("tool_result_persist")!;
     const result = handler(
-      { toolName: "read", message: { role: "tool", tool_call_id: "tcid_obs", content: "x".repeat(60_000) } },
+      {
+        toolName: "read",
+        message: { role: "tool", tool_call_id: "tcid_obs", content: "x".repeat(60_000) },
+      },
       {},
     );
     expect(result).toEqual({});
@@ -397,7 +412,10 @@ describe("tool_result_persist - sentinel boundary", () => {
     const handler = api.hooks.get("tool_result_persist")!;
     api.logger.info.mockClear();
     handler(
-      { toolName: "read", message: { role: "tool", tool_call_id: "tcid_obs_log", content: "x".repeat(60_000) } },
+      {
+        toolName: "read",
+        message: { role: "tool", tool_call_id: "tcid_obs_log", content: "x".repeat(60_000) },
+      },
       {},
     );
     const infoCalls = api.logger.info.mock.calls.map((c: unknown[]) => c[0] as string);
@@ -411,7 +429,10 @@ describe("tool_result_persist - sentinel boundary", () => {
     const handler = api.hooks.get("tool_result_persist")!;
     api.logger.info.mockClear();
     handler(
-      { toolName: "read", message: { role: "tool", tool_call_id: "tcid_block_log", content: "x".repeat(60_000) } },
+      {
+        toolName: "read",
+        message: { role: "tool", tool_call_id: "tcid_block_log", content: "x".repeat(60_000) },
+      },
       {},
     );
     const infoCalls = api.logger.info.mock.calls.map((c: unknown[]) => c[0] as string);
@@ -463,7 +484,11 @@ describe("tool_result_persist - sentinel boundary", () => {
     const result = handler(
       {
         toolName: "read",
-        message: { role: "tool", tool_call_id: "tcid_arr2", content: [{ blob: "x".repeat(100_000) }] },
+        message: {
+          role: "tool",
+          tool_call_id: "tcid_arr2",
+          content: [{ blob: "x".repeat(100_000) }],
+        },
       },
       {},
     ) as ToolResultPersistResult;
@@ -477,7 +502,11 @@ describe("tool_result_persist - sentinel boundary", () => {
     const result = handler(
       {
         toolName: "read",
-        message: { role: "tool", tool_call_id: "tcid_arr3", content: ["text".repeat(50), 12345, true] },
+        message: {
+          role: "tool",
+          tool_call_id: "tcid_arr3",
+          content: ["text".repeat(50), 12345, true],
+        },
       },
       {},
     ) as ToolResultPersistResult;
@@ -663,7 +692,10 @@ describe("session state 累積（cumulative budget tracking）", () => {
     const api = makeApi();
     register(api as any);
     const handler = api.hooks.get("before_agent_run")!;
-    handler({ sessionId: "ev_s", prompt: "x".repeat(300_000), messages: [] }, { sessionId: "ctx_s" });
+    handler(
+      { sessionId: "ev_s", prompt: "x".repeat(300_000), messages: [] },
+      { sessionId: "ctx_s" },
+    );
     expect(api.metrics.incrementCounter).toHaveBeenCalledWith(
       "cost_guard.per_turn_input_blocked",
       expect.objectContaining({ sessionId: "ctx_s" }),
@@ -1145,7 +1177,13 @@ describe("metric 発行（contracts.md §10.1 の 5 metric）", () => {
     const api = makeApi();
     register(api as any);
     const handler = api.hooks.get("tool_result_persist")!;
-    handler({ toolName: "read", message: { role: "tool", tool_call_id: "tcid_a", content: "x".repeat(60_000) } }, {});
+    handler(
+      {
+        toolName: "read",
+        message: { role: "tool", tool_call_id: "tcid_a", content: "x".repeat(60_000) },
+      },
+      {},
+    );
     expect(api.metrics.incrementCounter).toHaveBeenCalledWith(
       "cost_guard.tool_result_rewritten",
       expect.anything(),

--- a/packages/cost-guard/src/index.test.ts
+++ b/packages/cost-guard/src/index.test.ts
@@ -274,9 +274,8 @@ describe("tool_result_persist - sentinel boundary", () => {
     const handler = api.hooks.get("tool_result_persist")!;
     const result = handler(
       {
-        toolId: "read",
-        toolCallId: "tcid_001",
-        result: { content: "x".repeat(49_999) },
+        toolName: "read",
+        message: { role: "tool", tool_call_id: "tcid_001", content: "x".repeat(49_999) },
       },
       {},
     ) as ToolResultPersistResult;
@@ -289,9 +288,8 @@ describe("tool_result_persist - sentinel boundary", () => {
     const handler = api.hooks.get("tool_result_persist")!;
     const result = handler(
       {
-        toolId: "read",
-        toolCallId: "tcid_002",
-        result: { content: "x".repeat(50_000) },
+        toolName: "read",
+        message: { role: "tool", tool_call_id: "tcid_002", content: "x".repeat(50_000) },
       },
       {},
     ) as ToolResultPersistResult;
@@ -304,9 +302,8 @@ describe("tool_result_persist - sentinel boundary", () => {
     const handler = api.hooks.get("tool_result_persist")!;
     const result = handler(
       {
-        toolId: "read",
-        toolCallId: "tcid_003",
-        result: { content: "x".repeat(50_001) },
+        toolName: "read",
+        message: { role: "tool", tool_call_id: "tcid_003", content: "x".repeat(50_001) },
       },
       {},
     ) as ToolResultPersistResult;
@@ -323,36 +320,35 @@ describe("tool_result_persist - sentinel boundary", () => {
     const handler = api.hooks.get("tool_result_persist")!;
     const result = handler(
       {
-        toolId: "read",
-        toolCallId: "tcid_preserve_me",
-        result: { content: "x".repeat(60_000) },
+        toolName: "read",
+        message: { role: "tool", tool_call_id: "tcid_preserve_me", content: "x".repeat(60_000) },
       },
       {},
     ) as ToolResultPersistResult;
     expect((result as any).message.tool_call_id).toBe("tcid_preserve_me");
   });
 
-  it("event.tool_call_id の snake_case 入力も sentinel message に保持", () => {
+  it("message に tool_call_id が無い場合は event.toolCallId(top-level) を fallback で保持", () => {
     const api = makeApi();
     register(api as any);
     const handler = api.hooks.get("tool_result_persist")!;
     const result = handler(
       {
-        toolId: "read",
-        tool_call_id: "tcid_x",
-        result: { content: "x".repeat(60_000) },
+        toolName: "read",
+        toolCallId: "tcid_x",
+        message: { role: "tool", content: "x".repeat(60_000) },
       },
       {},
     ) as ToolResultPersistResult;
     expect((result as any).message.tool_call_id).toBe("tcid_x");
   });
 
-  it("string 直結 result でも byte 数計算", () => {
+  it("message.content が string 直結でも byte 数計算", () => {
     const api = makeApi();
     register(api as any);
     const handler = api.hooks.get("tool_result_persist")!;
     const result = handler(
-      { toolId: "read", toolCallId: "tcid_str", result: "x".repeat(60_000) },
+      { toolName: "read", message: { role: "tool", tool_call_id: "tcid_str", content: "x".repeat(60_000) } },
       {},
     ) as ToolResultPersistResult;
     expect((result as any).message).toBeDefined();
@@ -363,7 +359,7 @@ describe("tool_result_persist - sentinel boundary", () => {
     register(api as any);
     const handler = api.hooks.get("tool_result_persist")!;
     const result = handler(
-      { toolId: "read", toolCallId: "tcid_x", result: { content: "x".repeat(1001) } },
+      { toolName: "read", message: { role: "tool", tool_call_id: "tcid_x", content: "x".repeat(1001) } },
       {},
     ) as ToolResultPersistResult;
     expect((result as any).message).toBeDefined();
@@ -373,7 +369,7 @@ describe("tool_result_persist - sentinel boundary", () => {
     const api = makeApi();
     register(api as any);
     const handler = api.hooks.get("tool_result_persist")!;
-    handler({ toolId: "read", toolCallId: "tcid_m", result: { content: "x".repeat(60_000) } }, {});
+    handler({ toolName: "read", message: { role: "tool", tool_call_id: "tcid_m", content: "x".repeat(60_000) } }, {});
     expect(api.metrics.incrementCounter).toHaveBeenCalledWith(
       "cost_guard.tool_result_rewritten",
       expect.objectContaining({ toolId: "read" }),
@@ -385,7 +381,7 @@ describe("tool_result_persist - sentinel boundary", () => {
     register(api as any);
     const handler = api.hooks.get("tool_result_persist")!;
     const result = handler(
-      { toolId: "read", toolCallId: "tcid_obs", result: { content: "x".repeat(60_000) } },
+      { toolName: "read", message: { role: "tool", tool_call_id: "tcid_obs", content: "x".repeat(60_000) } },
       {},
     );
     expect(result).toEqual({});
@@ -401,7 +397,7 @@ describe("tool_result_persist - sentinel boundary", () => {
     const handler = api.hooks.get("tool_result_persist")!;
     api.logger.info.mockClear();
     handler(
-      { toolId: "read", toolCallId: "tcid_obs_log", result: { content: "x".repeat(60_000) } },
+      { toolName: "read", message: { role: "tool", tool_call_id: "tcid_obs_log", content: "x".repeat(60_000) } },
       {},
     );
     const infoCalls = api.logger.info.mock.calls.map((c: unknown[]) => c[0] as string);
@@ -415,22 +411,23 @@ describe("tool_result_persist - sentinel boundary", () => {
     const handler = api.hooks.get("tool_result_persist")!;
     api.logger.info.mockClear();
     handler(
-      { toolId: "read", toolCallId: "tcid_block_log", result: { content: "x".repeat(60_000) } },
+      { toolName: "read", message: { role: "tool", tool_call_id: "tcid_block_log", content: "x".repeat(60_000) } },
       {},
     );
     const infoCalls = api.logger.info.mock.calls.map((c: unknown[]) => c[0] as string);
     expect(infoCalls.some((m) => m.includes("tool_result_rewritten:"))).toBe(true);
   });
 
-  it("result.content が配列（[{text: '...'}, ...]）形式でも byte 数を合算", () => {
+  it("message.content が配列（[{text: '...'}, ...]）形式でも byte 数を合算", () => {
     const api = makeApi();
     register(api as any);
     const handler = api.hooks.get("tool_result_persist")!;
     const result = handler(
       {
-        toolId: "read",
-        toolCallId: "tcid_arr",
-        result: {
+        toolName: "read",
+        message: {
+          role: "tool",
+          tool_call_id: "tcid_arr",
           content: [{ text: "x".repeat(30_000) }, { text: "y".repeat(30_000) }],
         },
       },
@@ -440,15 +437,16 @@ describe("tool_result_persist - sentinel boundary", () => {
     expect((result as any).message.content).toContain(SENTINEL_PREFIX);
   });
 
-  it("result.content 配列内の object は text 以外の巨大 field も byte 数に含める", () => {
+  it("message.content 配列内の object は text 以外の巨大 field も byte 数に含める", () => {
     const api = makeApi();
     register(api as any);
     const handler = api.hooks.get("tool_result_persist")!;
     const result = handler(
       {
-        toolId: "read",
-        toolCallId: "tcid_arr_raw",
-        result: {
+        toolName: "read",
+        message: {
+          role: "tool",
+          tool_call_id: "tcid_arr_raw",
           content: [{ text: "ok", raw: "x".repeat(60_000) }],
         },
       },
@@ -458,55 +456,52 @@ describe("tool_result_persist - sentinel boundary", () => {
     expect((result as any).message.content).toContain(SENTINEL_PREFIX);
   });
 
-  it("result.content 配列内の object に text が無い場合は JSON 化 byte 数で計算", () => {
+  it("message.content 配列内の object に text が無い場合は JSON 化 byte 数で計算", () => {
     const api = makeApi();
     register(api as any);
     const handler = api.hooks.get("tool_result_persist")!;
     const result = handler(
       {
-        toolId: "read",
-        toolCallId: "tcid_arr2",
-        result: { content: [{ blob: "x".repeat(100_000) }] },
+        toolName: "read",
+        message: { role: "tool", tool_call_id: "tcid_arr2", content: [{ blob: "x".repeat(100_000) }] },
       },
       {},
     ) as ToolResultPersistResult;
     expect((result as any).message).toBeDefined();
   });
 
-  it("result.content 配列内の非 object 要素も byte 数で計算", () => {
+  it("message.content 配列内の非 object 要素も byte 数で計算", () => {
     const api = makeApi({ rewriteThresholdBytes: 100 });
     register(api as any);
     const handler = api.hooks.get("tool_result_persist")!;
     const result = handler(
       {
-        toolId: "read",
-        toolCallId: "tcid_arr3",
-        result: { content: ["text".repeat(50), 12345, true] },
+        toolName: "read",
+        message: { role: "tool", tool_call_id: "tcid_arr3", content: ["text".repeat(50), 12345, true] },
       },
       {},
     ) as ToolResultPersistResult;
     expect((result as any).message).toBeDefined();
   });
 
-  it("result が undefined / null の場合は 0 byte 扱いで置換しない", () => {
+  it("message が undefined / null の場合は 0 byte 扱いで置換しない", () => {
     const api = makeApi();
     register(api as any);
     const handler = api.hooks.get("tool_result_persist")!;
-    const result1 = handler({ toolId: "read", toolCallId: "n1", result: null }, {});
-    const result2 = handler({ toolId: "read", toolCallId: "n2", result: undefined }, {});
+    const result1 = handler({ toolName: "read", message: null }, {});
+    const result2 = handler({ toolName: "read", message: undefined }, {});
     expect(result1).toEqual({});
     expect(result2).toEqual({});
   });
 
-  it("result が plain object（content なし）の場合は JSON 化 byte 数で計算", () => {
+  it("message が plain object（content なし）の場合は JSON 化 byte 数で計算", () => {
     const api = makeApi({ rewriteThresholdBytes: 50 });
     register(api as any);
     const handler = api.hooks.get("tool_result_persist")!;
     const result = handler(
       {
-        toolId: "read",
-        toolCallId: "tcid_plain",
-        result: { other: "x".repeat(200) },
+        toolName: "read",
+        message: { role: "tool", tool_call_id: "tcid_plain", other: "x".repeat(200) },
       },
       {},
     ) as ToolResultPersistResult;
@@ -650,6 +645,40 @@ describe("session state 累積（cumulative budget tracking）", () => {
     expect((result1 as BeforeAgentRunResult).outcome).toBe("pass");
     expect((result2 as BeforeAgentRunResult).outcome).toBe("pass");
     expect((result3 as BeforeAgentRunResult).outcome).toBe("pass");
+  });
+
+  // 実 OpenClaw 経路の検証（session 識別子は ctx が正本。event には sessionId が無い）。回帰防止。
+  it("session 識別子は ctx.sessionId を正本として metric に反映する", () => {
+    const api = makeApi();
+    register(api as any);
+    const handler = api.hooks.get("before_agent_run")!;
+    handler({ prompt: "x".repeat(300_000), messages: [] }, { sessionId: "ctx_s1" });
+    expect(api.metrics.incrementCounter).toHaveBeenCalledWith(
+      "cost_guard.per_turn_input_blocked",
+      expect.objectContaining({ sessionId: "ctx_s1" }),
+    );
+  });
+
+  it("ctx.sessionId は event.sessionId より優先される（ctx が正本）", () => {
+    const api = makeApi();
+    register(api as any);
+    const handler = api.hooks.get("before_agent_run")!;
+    handler({ sessionId: "ev_s", prompt: "x".repeat(300_000), messages: [] }, { sessionId: "ctx_s" });
+    expect(api.metrics.incrementCounter).toHaveBeenCalledWith(
+      "cost_guard.per_turn_input_blocked",
+      expect.objectContaining({ sessionId: "ctx_s" }),
+    );
+  });
+
+  it("ctx.sessionId 不在時は ctx.sessionKey を session 識別子に使う", () => {
+    const api = makeApi();
+    register(api as any);
+    const handler = api.hooks.get("before_agent_run")!;
+    handler({ prompt: "x".repeat(300_000), messages: [] }, { sessionKey: "agent:main:k1" });
+    expect(api.metrics.incrementCounter).toHaveBeenCalledWith(
+      "cost_guard.per_turn_input_blocked",
+      expect.objectContaining({ sessionId: "agent:main:k1" }),
+    );
   });
 });
 
@@ -1116,7 +1145,7 @@ describe("metric 発行（contracts.md §10.1 の 5 metric）", () => {
     const api = makeApi();
     register(api as any);
     const handler = api.hooks.get("tool_result_persist")!;
-    handler({ toolId: "read", toolCallId: "tcid_a", result: { content: "x".repeat(60_000) } }, {});
+    handler({ toolName: "read", message: { role: "tool", tool_call_id: "tcid_a", content: "x".repeat(60_000) } }, {});
     expect(api.metrics.incrementCounter).toHaveBeenCalledWith(
       "cost_guard.tool_result_rewritten",
       expect.anything(),

--- a/packages/cost-guard/src/index.ts
+++ b/packages/cost-guard/src/index.ts
@@ -273,16 +273,17 @@ export default function register(api: OpenClawPluginApi): void {
   // tool_result_persist: rewriteThresholdBytes 超で sentinel 置換
   // --------------------------------------------------------------------------
   api.on("tool_result_persist", (event: unknown, _ctx: unknown): ToolResultPersistResult => {
+    // OpenClaw の tool_result_persist event は tool result を `message`(AgentMessage) に格納する。
+    // `result` フィールドは存在しない（hook-types.d.ts: PluginHookToolResultPersistEvent）。
     const e = event as {
       toolName?: string;
-      toolId?: string;
       toolCallId?: string;
-      tool_call_id?: string;
-      result?: unknown;
+      message?: { role?: string; content?: unknown; tool_call_id?: string; [k: string]: unknown };
+      isSynthetic?: boolean;
     };
-    const toolId = e.toolId ?? e.toolName ?? "(unknown)";
-    const toolCallId = e.toolCallId ?? e.tool_call_id ?? "";
-    const contentBytes = extractResultContentBytes(e.result);
+    const toolId = e.toolName ?? "(unknown)";
+    const toolCallId = e.message?.tool_call_id ?? e.toolCallId ?? "";
+    const contentBytes = extractResultContentBytes(e.message);
 
     if (cfg.logging) {
       log.info(
@@ -302,7 +303,8 @@ export default function register(api: OpenClawPluginApi): void {
       if (cfg.blockMode === "observe") return {};
       return {
         message: {
-          role: "tool",
+          ...e.message,
+          role: "tool" as const,
           tool_call_id: toolCallId,
           content: sentinel,
         },
@@ -314,7 +316,7 @@ export default function register(api: OpenClawPluginApi): void {
   // --------------------------------------------------------------------------
   // before_agent_run: 段 1 per-turn gate → 段 2 session budget → cleanup
   // --------------------------------------------------------------------------
-  api.on("before_agent_run", (event: unknown, _ctx: unknown): BeforeAgentRunResult => {
+  api.on("before_agent_run", (event: unknown, ctx: unknown): BeforeAgentRunResult => {
     const e = event as {
       prompt?: string;
       messages?: SessionMessage[];
@@ -322,7 +324,11 @@ export default function register(api: OpenClawPluginApi): void {
       accountId?: string;
       channelId?: string;
     };
-    const sessionId = e.sessionId ?? e.channelId ?? e.accountId ?? "default";
+    // session 識別子は ctx(PluginHookAgentContext) が正本（OpenClaw 実 event には sessionId が無い）。
+    // e.sessionId は後方互換 fallback（ctx より低優先。host 差異や旧 event 形式への保険）。
+    const c = ctx as { sessionId?: string; sessionKey?: string };
+    const sessionId =
+      c.sessionId ?? c.sessionKey ?? e.sessionId ?? e.channelId ?? e.accountId ?? "default";
 
     // 0. rollback Mode A: suspendAgent
     //    本 case は contracts.md §10.1 の 5 metric とは独立した運用イベントのため、

--- a/packages/cost-guard/src/index.ts
+++ b/packages/cost-guard/src/index.ts
@@ -123,9 +123,9 @@ const DEFAULTS = {
   blockMode: "block" as const,
   denyPaths: ["/data/workspace/zoom_transcribe/"],
   allowlistedToolsForDenyPaths: [
-    "transcript-analyzer.list_transcripts",
-    "transcript-analyzer.search_transcripts",
-    "transcript-analyzer.analyze_transcript",
+    "transcript_analyzer_list_transcripts",
+    "transcript_analyzer_search_transcripts",
+    "transcript_analyzer_analyze_transcript",
   ],
   rewriteThresholdBytes: 50000,
   sessionTokenBudget: 500000,

--- a/packages/transcript-analyzer/README.md
+++ b/packages/transcript-analyzer/README.md
@@ -8,9 +8,9 @@ OpenClaw 2026.5.12 以降向け **Phase 1 transcript-analyzer plugin**。`hongmo
 
 | tool | 役割 |
 |---|---|
-| `transcript-analyzer.list_transcripts` | transcriptDir 配下のファイル一覧。機密 metadata は redact 済み summary_excerpt のみ |
-| `transcript-analyzer.search_transcripts` | query に関連する transcript chunk を top-k 返す（Phase 1：BM25 風 keyword 検索、Phase 2 で pgvector embedding 検索に置換予定） |
-| `transcript-analyzer.analyze_transcript` | transcript 全文を Gemini 2.5 Flash で解析し structured JSON（answer + citations + confidence）を返す |
+| `transcript_analyzer_list_transcripts` | transcriptDir 配下のファイル一覧。機密 metadata は redact 済み summary_excerpt のみ |
+| `transcript_analyzer_search_transcripts` | query に関連する transcript chunk を top-k 返す（Phase 1：BM25 風 keyword 検索、Phase 2 で pgvector embedding 検索に置換予定） |
+| `transcript_analyzer_analyze_transcript` | transcript 全文を Gemini 2.5 Flash で解析し structured JSON（answer + citations + confidence）を返す |
 
 詳細設計：[Phase 1 設計 v6（estack-inc/easy-flow#398）](https://github.com/estack-inc/easy-flow/pull/398)
 契約：本案件の `contracts.md`（同 case 配下）

--- a/packages/transcript-analyzer/openclaw.plugin.json
+++ b/packages/transcript-analyzer/openclaw.plugin.json
@@ -5,9 +5,9 @@
   "description": "Phase 1 transcript-analyzer plugin。transcript を業務利用する唯一の合法経路として 3 tool（list_transcripts / search_transcripts / analyze_transcript）を提供。Gemini 2.5 Flash で transcript を analyze し structured JSON（answer + citations + confidence）を返す。cost-guard の allowlist 通過対象。多段 fallback（cache → Gemini → chunk 分割 → fallbackModel → 明示的失敗）。Sonnet 全文 fallback は禁止。",
   "contracts": {
     "tools": [
-      "transcript-analyzer.list_transcripts",
-      "transcript-analyzer.search_transcripts",
-      "transcript-analyzer.analyze_transcript"
+      "transcript_analyzer_list_transcripts",
+      "transcript_analyzer_search_transcripts",
+      "transcript_analyzer_analyze_transcript"
     ]
   },
   "configSchema": {

--- a/packages/transcript-analyzer/src/analyze-transcript.ts
+++ b/packages/transcript-analyzer/src/analyze-transcript.ts
@@ -1,5 +1,5 @@
 /**
- * T3: transcript-analyzer.analyze_transcript
+ * T3: transcript_analyzer_analyze_transcript
  *
  * transcript 全文を Gemini 2.5 Flash で読み込み、query に対する answer + citations を抽出する。
  *

--- a/packages/transcript-analyzer/src/index.test.ts
+++ b/packages/transcript-analyzer/src/index.test.ts
@@ -132,9 +132,9 @@ describe("register", () => {
     expect(api.registerTool).toHaveBeenCalledOnce();
     const [, options] = api.registerTool.mock.calls[0];
     expect(options.names).toEqual([
-      "transcript-analyzer.list_transcripts",
-      "transcript-analyzer.search_transcripts",
-      "transcript-analyzer.analyze_transcript",
+      "transcript_analyzer_list_transcripts",
+      "transcript_analyzer_search_transcripts",
+      "transcript_analyzer_analyze_transcript",
     ]);
     // 3 tool は標準 tool として登録する（optional 指定なし）。optional: true だと OpenClaw の
     // pluginToolNamesMatchAllowlist が agent の道具公開 allowlist 明示を要求し、既定では公開されない。
@@ -178,9 +178,9 @@ describe("register", () => {
     expect(Array.isArray(tools)).toBe(true);
     expect(tools).toHaveLength(3);
     expect(tools.map((t: { name: string }) => t.name)).toEqual([
-      "transcript-analyzer.list_transcripts",
-      "transcript-analyzer.search_transcripts",
-      "transcript-analyzer.analyze_transcript",
+      "transcript_analyzer_list_transcripts",
+      "transcript_analyzer_search_transcripts",
+      "transcript_analyzer_analyze_transcript",
     ]);
   });
 
@@ -201,7 +201,7 @@ describe("register", () => {
     const factory = api.registerTool.mock.calls[0][0];
     const tools = factory({});
     const listTool = tools.find(
-      (t: { name: string }) => t.name === "transcript-analyzer.list_transcripts",
+      (t: { name: string }) => t.name === "transcript_analyzer_list_transcripts",
     );
     const result = await listTool.execute("call-1", {});
     expect(result.content[0].type).toBe("text");
@@ -215,7 +215,7 @@ describe("register", () => {
     const factory = api.registerTool.mock.calls[0][0];
     const tools = factory({});
     const searchTool = tools.find(
-      (t: { name: string }) => t.name === "transcript-analyzer.search_transcripts",
+      (t: { name: string }) => t.name === "transcript_analyzer_search_transcripts",
     );
     const result = await searchTool.execute("call-1", { query: "" });
     const parsed = JSON.parse(result.content[0].text);
@@ -229,7 +229,7 @@ describe("register", () => {
     const factory = api.registerTool.mock.calls[0][0];
     const tools = factory({ sessionId: "test-1" });
     const analyzeTool = tools.find(
-      (t: { name: string }) => t.name === "transcript-analyzer.analyze_transcript",
+      (t: { name: string }) => t.name === "transcript_analyzer_analyze_transcript",
     );
     const result = await analyzeTool.execute("call-1", {
       transcript_id: "",
@@ -302,9 +302,9 @@ describe("npm package metadata", () => {
     expect(api.registerTool).toHaveBeenCalledOnce();
     const [, options] = api.registerTool.mock.calls[0];
     expect(options.names).toEqual([
-      "transcript-analyzer.list_transcripts",
-      "transcript-analyzer.search_transcripts",
-      "transcript-analyzer.analyze_transcript",
+      "transcript_analyzer_list_transcripts",
+      "transcript_analyzer_search_transcripts",
+      "transcript_analyzer_analyze_transcript",
     ]);
   });
 });

--- a/packages/transcript-analyzer/src/index.ts
+++ b/packages/transcript-analyzer/src/index.ts
@@ -179,7 +179,7 @@ export function createQuotaStore(): QuotaStore {
 
 function createListTranscriptsTool(deps: ToolDependencies): AgentToolLike {
   return {
-    name: "transcript-analyzer.list_transcripts",
+    name: "transcript_analyzer_list_transcripts",
     description:
       "List transcripts available under transcriptDir. Returns redacted metadata only " +
       "(no participant names, meeting names, etc. shown in clear text). " +
@@ -205,7 +205,7 @@ function createListTranscriptsTool(deps: ToolDependencies): AgentToolLike {
 
 function createSearchTranscriptsTool(deps: ToolDependencies): AgentToolLike {
   return {
-    name: "transcript-analyzer.search_transcripts",
+    name: "transcript_analyzer_search_transcripts",
     description:
       "Search transcript chunks matching the query (BM25-like keyword scoring in Phase 1). " +
       "Returns top-k chunks with transcript_id, chunk_id, byte_range, score (0.0-1.0). " +
@@ -250,7 +250,7 @@ function createAnalyzeTranscriptTool(
   ctx: PluginContextLike,
 ): AgentToolLike {
   return {
-    name: "transcript-analyzer.analyze_transcript",
+    name: "transcript_analyzer_analyze_transcript",
     description:
       "Analyze a transcript with Gemini 2.5 Flash and return a structured answer with citations. " +
       "Returns AnalyzeTranscriptResponse with answer, citations[], confidence (0.0-1.0), " +
@@ -376,9 +376,9 @@ const transcriptAnalyzerPlugin = {
       },
       {
         names: [
-          "transcript-analyzer.list_transcripts",
-          "transcript-analyzer.search_transcripts",
-          "transcript-analyzer.analyze_transcript",
+          "transcript_analyzer_list_transcripts",
+          "transcript_analyzer_search_transcripts",
+          "transcript_analyzer_analyze_transcript",
         ],
         // 3 tool は denyPaths（zoom_transcribe）への唯一の正規アクセス経路（cost-guard allowlist 対象）であり、
         // agent が常用すべき標準 tool。optional: true にすると OpenClaw の pluginToolNamesMatchAllowlist が

--- a/packages/transcript-analyzer/src/list-transcripts.ts
+++ b/packages/transcript-analyzer/src/list-transcripts.ts
@@ -1,5 +1,5 @@
 /**
- * T1: transcript-analyzer.list_transcripts
+ * T1: transcript_analyzer_list_transcripts
  *
  * transcriptDir 配下のファイル一覧を返す。
  * 機密 metadata（participant / meeting_name 等）は redact 済み summary_excerpt のみ含める。

--- a/packages/transcript-analyzer/src/search-transcripts.ts
+++ b/packages/transcript-analyzer/src/search-transcripts.ts
@@ -1,5 +1,5 @@
 /**
- * T2: transcript-analyzer.search_transcripts
+ * T2: transcript_analyzer_search_transcripts
  *
  * query に関連する transcript chunk を BM25 風スコアで top-k 返す。
  * Phase 1 は keyword 一致ベース（structured search の代用）の実装。

--- a/packages/transcript-analyzer/transcript-analyzer/analyze-transcript.d.ts
+++ b/packages/transcript-analyzer/transcript-analyzer/analyze-transcript.d.ts
@@ -1,5 +1,5 @@
 /**
- * T3: transcript-analyzer.analyze_transcript
+ * T3: transcript_analyzer_analyze_transcript
  *
  * transcript 全文を Gemini 2.5 Flash で読み込み、query に対する answer + citations を抽出する。
  *

--- a/packages/transcript-analyzer/transcript-analyzer/index.js
+++ b/packages/transcript-analyzer/transcript-analyzer/index.js
@@ -2372,7 +2372,7 @@ function createQuotaStore() {
 }
 function createListTranscriptsTool(deps) {
   return {
-    name: "transcript-analyzer.list_transcripts",
+    name: "transcript_analyzer_list_transcripts",
     description: "List transcripts available under transcriptDir. Returns redacted metadata only (no participant names, meeting names, etc. shown in clear text). Use this before search_transcripts or analyze_transcript to discover transcript_id.",
     parameters: {
       type: "object",
@@ -2394,7 +2394,7 @@ function createListTranscriptsTool(deps) {
 }
 function createSearchTranscriptsTool(deps) {
   return {
-    name: "transcript-analyzer.search_transcripts",
+    name: "transcript_analyzer_search_transcripts",
     description: "Search transcript chunks matching the query (BM25-like keyword scoring in Phase 1). Returns top-k chunks with transcript_id, chunk_id, byte_range, score (0.0-1.0). Use the returned transcript_id with analyze_transcript for deep analysis.",
     parameters: {
       type: "object",
@@ -2432,7 +2432,7 @@ function createSearchTranscriptsTool(deps) {
 }
 function createAnalyzeTranscriptTool(deps, ctx) {
   return {
-    name: "transcript-analyzer.analyze_transcript",
+    name: "transcript_analyzer_analyze_transcript",
     description: "Analyze a transcript with Gemini 2.5 Flash and return a structured answer with citations. Returns AnalyzeTranscriptResponse with answer, citations[], confidence (0.0-1.0), answer_scope ('explicit'/'inferred'/'not_found'), cache_status, and redactions. transcript_id must be obtained from list_transcripts or search_transcripts.",
     parameters: {
       type: "object",
@@ -2533,9 +2533,9 @@ var transcriptAnalyzerPlugin = {
       },
       {
         names: [
-          "transcript-analyzer.list_transcripts",
-          "transcript-analyzer.search_transcripts",
-          "transcript-analyzer.analyze_transcript"
+          "transcript_analyzer_list_transcripts",
+          "transcript_analyzer_search_transcripts",
+          "transcript_analyzer_analyze_transcript"
         ]
         // 3 tool は denyPaths（zoom_transcribe）への唯一の正規アクセス経路（cost-guard allowlist 対象）であり、
         // agent が常用すべき標準 tool。optional: true にすると OpenClaw の pluginToolNamesMatchAllowlist が

--- a/packages/transcript-analyzer/transcript-analyzer/list-transcripts.d.ts
+++ b/packages/transcript-analyzer/transcript-analyzer/list-transcripts.d.ts
@@ -1,5 +1,5 @@
 /**
- * T1: transcript-analyzer.list_transcripts
+ * T1: transcript_analyzer_list_transcripts
  *
  * transcriptDir 配下のファイル一覧を返す。
  * 機密 metadata（participant / meeting_name 等）は redact 済み summary_excerpt のみ含める。

--- a/packages/transcript-analyzer/transcript-analyzer/openclaw.plugin.json
+++ b/packages/transcript-analyzer/transcript-analyzer/openclaw.plugin.json
@@ -5,9 +5,9 @@
   "description": "Phase 1 transcript-analyzer plugin。transcript を業務利用する唯一の合法経路として 3 tool（list_transcripts / search_transcripts / analyze_transcript）を提供。Gemini 2.5 Flash で transcript を analyze し structured JSON（answer + citations + confidence）を返す。cost-guard の allowlist 通過対象。多段 fallback（cache → Gemini → chunk 分割 → fallbackModel → 明示的失敗）。Sonnet 全文 fallback は禁止。",
   "contracts": {
     "tools": [
-      "transcript-analyzer.list_transcripts",
-      "transcript-analyzer.search_transcripts",
-      "transcript-analyzer.analyze_transcript"
+      "transcript_analyzer_list_transcripts",
+      "transcript_analyzer_search_transcripts",
+      "transcript_analyzer_analyze_transcript"
     ]
   },
   "configSchema": {

--- a/packages/transcript-analyzer/transcript-analyzer/search-transcripts.d.ts
+++ b/packages/transcript-analyzer/transcript-analyzer/search-transcripts.d.ts
@@ -1,5 +1,5 @@
 /**
- * T2: transcript-analyzer.search_transcripts
+ * T2: transcript_analyzer_search_transcripts
  *
  * query に関連する transcript chunk を BM25 風スコアで top-k 返す。
  * Phase 1 は keyword 一致ベース（structured search の代用）の実装。


### PR DESCRIPTION
## 概要
transcript-analyzer の custom tool 名に含まれるドットが Claude の tool name パターン `^[a-zA-Z0-9_-]{1,128}$` に違反し、gateway runner（Claude provider）で agent run が `FailoverError` 停止する本番ブロッカーを修正。

## 発見の経緯
cost-guard 動作検証のため dev を本番同等の Claude primary に切替えた際、agent run が `tools.27.custom.name` エラーで失敗。grok provider では tool name 検証が緩く露見していなかった。

## 修正
- tool 名のドット → アンダースコア（`transcript-analyzer.list_transcripts` → `transcript_analyzer_list_transcripts` ほか 3 tool）
- cost-guard の allowlist（3 tool 名）も連動更新
- 両 plugin 再ビルド

## 検証
- transcript-analyzer test: 167 passed
- cost-guard test: 209 passed