### PR TITLE
fix(codex-review): チェックリストの接頭ラベルを外す

### DIFF
--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -226,10 +226,10 @@ jobs:
           JSON
           cat > /tmp/codex-review-checklists.json <<'JSON'
           [
-            "[A] 要件充足・影響範囲: PR description の要件が全て実装されている / シグネチャ変更時に全呼び出し元が更新されている / インターフェース変更時に全実装が更新されている / 新機能にテストがある",
-            "[B] コード品質 (CLAUDE.md 参照): TypeScript strict モード準拠 / ESM import パスに `.js` 拡張子 / JSON 永続化互換 (Set 不使用) / Vitest テストあり / パッケージ間依存が妥当",
-            "[C] セキュリティ: console.log / debugger が残っていない / 機密情報がハードコードされていない / 入力値のバリデーションが適切",
-            "[D] GitHub Actions 品質 (yml 変更時): 構文が正しい / secrets 参照が適切 / パーミッション設定が最小権限"
+            "要件充足・影響範囲: PR description の要件が全て実装されている / シグネチャ変更時に全呼び出し元が更新されている / インターフェース変更時に全実装が更新されている / 新機能にテストがある",
+            "コード品質 (CLAUDE.md 参照): TypeScript strict モード準拠 / ESM import パスに `.js` 拡張子 / JSON 永続化互換 (Set 不使用) / Vitest テストあり / パッケージ間依存が妥当",
+            "セキュリティ: console.log / debugger が残っていない / 機密情報がハードコードされていない / 入力値のバリデーションが適切",
+            "GitHub Actions 品質 (yml 変更時): 構文が正しい / secrets 参照が適切 / パーミッション設定が最小権限"
           ]
           JSON
           jq -c '[.[] | split(":")[0] | gsub("^\\s+|\\s+$"; "")]' /tmp/codex-review-checklists.json > /tmp/codex-review-required-checklist-names.json


### PR DESCRIPTION
## 背景

2026-08-02 の調査で、このリポジトリの codex-review の**判定表が捏造されていた**ことが判明しました。全項目が `➖ 対象外 / reviewer 出力に欠落していたため自動補完` になった状態で APPROVED になったレビューが多数あります。

webhook ホストに残る reviewer の生応答を照合したところ、原因が確定しました。

**reviewer は全項目を判定して返しているが、項目名の `[A] ` `[B] ` といった接頭ラベルを確率的に落として返す。**

| 実行 | reviewer が返した名前 | 結果 |
| --- | --- | --- |
| `1785640136125-2923bf1e` | `要件充足・影響範囲`（ラベルなし） | 全 4 件が不一致 → 捨てられて補完 |
| `1785638302772-bf3525a4` | `[A] 要件充足・影響範囲`（ラベルあり） | 一致 → 正常 |

`required_checklist_names` は `split(":")[0]` で `[A] 要件充足・影響範囲` になるため、ラベルが落ちた名前は 1 件も一致せず、判定が揃っていても丸ごと破棄されていました。

## 変更内容

`checklists` の各項目から接頭ラベル（`[A] ` 〜 `[D] `）を外します。他の箇所は変更していません（差分は checklist 行のみ）。

なお、根本対処として `scripts/codex-review-json.cjs` 側にも接頭ラベルの正規化を追加しています（estack-inc/easy-flow#470）。本 PR は曖昧さの原因そのものを消すもので、両方を入れることで再発を防ぎます。

## 検証

- 差分が checklist 行のみであることを機械確認済み
- `pull_request_target` のため **この PR 自体はレビューされません**。効果はマージ後の次の PR で確認します

## 関連

- estack-inc/easy-flow#470（`normalizeChecklistName` の接頭ラベル対応・診断ログ）
- estack-inc/easy-flow#469（codex-review 再設計。本件は Phase 0.1）