### PR TITLE
chore(codex-review): infra 障害を分類して job を赤くする managed region を追加する

### DIFF
--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -1039,3 +1039,76 @@ jobs:
           curl -sS -X POST "$SLACK_WEBHOOK_URL" -H 'Content-Type: application/json' \
             --data "$(jq -n --arg t "$TEXT" '{text:$t}')" \
             || echo "::warning::Slack 通知失敗"
+
+      # BEGIN:managed:codex_review_infra_failure_gate
+      - name: Classify and surface webhook infra failure
+        # webhook 呼び出し step は continue-on-error で握られている。これは infra 障害時
+        # でも後続の fail-closed（infra failure review の投稿・stale bot approval の
+        # dismiss）を完走させるための意図的な設計だが、副作用として job が success で
+        # 終わり、502 や通信断が run 一覧からも Slack 未設定リポからも見えなくなる。
+        #
+        # 本 step は fail-closed の投稿がすべて終わった最後に置き、失敗を分類して
+        # step summary に残したうえで job を赤くする。ゲート強制力は従来どおり bot の
+        # CHANGES_REQUESTED review が担い（冒頭「ブランチ保護運用の前提」を参照）、
+        # 本 job は required status check ではないため赤化しても merge は block しない。
+        # 目的は「壊れていることが見えること」であり、merge の可否は変えない。
+        #
+        # schema_ok は空文字を「判定不能」として扱い発火条件から外す。本 region は
+        # 全配布先で同一のため、schema_ok を GITHUB_OUTPUT に書かない世代の workflow
+        # （配布対象 48 リポ中 10 リポ）にも同じ式が入る。空文字を弾かないと
+        # `!= '1'` が常に真になり、レビューが正常に通った PR でも job が赤くなる。
+        # それらのリポでは schema 不正の可視化だけが効かない状態になるが、
+        # 通信・HTTP 由来の失敗は curl_rc / http_status 側で従来どおり検出できる。
+        if: >-
+          always() &&
+          steps.applicable.outputs.applicable == 'true' &&
+          steps.oversize_gate.outputs.oversize != 'true' &&
+          (steps.codex_review.outputs.curl_rc != '0' ||
+           steps.codex_review.outputs.http_status != '200' ||
+           (steps.codex_review.outputs.schema_ok != '' &&
+            steps.codex_review.outputs.schema_ok != '1'))
+        env:
+          CURL_RC: ${{ steps.codex_review.outputs.curl_rc }}
+          HTTP_STATUS: ${{ steps.codex_review.outputs.http_status }}
+          SCHEMA_OK: ${{ steps.codex_review.outputs.schema_ok }}
+        run: |
+          # curl exit code と HTTP status を突き合わせて障害を分類する。分類なしに
+          # 「webhook に失敗」とだけ記録すると、呼び出し側の予算切れ・到達不能・
+          # サーバー側 codex 失敗・認証/payload 不正が区別できず、時間予算を変えて
+          # 直ったのか別の失敗へ移っただけなのか判定できない。
+          case "${CURL_RC:-unknown}" in
+            0)
+              case "${HTTP_STATUS:-000}" in
+                # HTTP は成功しているのに schema 検証が SCHEMA_RETRY_MAX 回とも通らなかった経路。
+                # レビュー本体は成立しておらず F-JSON-CONTRACT に倒れているため、infra 障害と
+                # 同じく run 一覧から見えるようにする（分類は分けて原因を取り違えないようにする）。
+                200) CLASS="invalid_response_schema"; HINT="webhook は 200 を返したが応答が JSON 契約を満たさず schema retry を使い切った。reviewer の出力ブレが継続していないか、cjs と prompt の世代が揃っているかを確認する" ;;
+                502) CLASS="server_codex_failure"; HINT="サーバー側で codex 実行が失敗（多くは pass timeout 到達）。webhook の journal で error_code を確認する" ;;
+                401) CLASS="unauthorized"; HINT="Bearer token 不一致、または webhook の ALLOWED_REPOSITORIES 未登録" ;;
+                400) CLASS="invalid_payload"; HINT="payload が webhook の検証に不合格。pr_url / repository / pr_number の整合を確認する" ;;
+                413) CLASS="payload_too_large"; HINT="payload が上限超過。oversize gate の閾値と webhook 側上限の整合を確認する" ;;
+                403) CLASS="forbidden"; HINT="エンドポイントが無効化されているか、リポジトリが許可されていない" ;;
+                *)   CLASS="unexpected_http_status"; HINT="想定外の HTTP status。webhook 側のログを確認する" ;;
+              esac
+              ;;
+            28) CLASS="caller_timeout"; HINT="curl --max-time に到達。呼び出し側の時間予算がレビュー所要時間に対して不足している" ;;
+            # 56 は転送中の受信失敗。2026-08-04 に Tailscale Funnel の DERP 接続が落ちた際、
+            # 到達不能でありながら 6/7/35 ではなく 56 が観測されたため到達不能系に含める。
+            6|7|35|56) CLASS="unreachable"; HINT="DNS / 接続 / TLS / 転送中の切断。Tailscale Funnel（tailscale status の Self.Online と netcheck の DERP latency）と webhook サービスの稼働を確認する" ;;
+            *) CLASS="transport_error"; HINT="curl がエラー終了。exit code を curl のマニュアルで確認する" ;;
+          esac
+          {
+            echo "## Codex Review infra failure"
+            echo
+            echo "| 項目 | 値 |"
+            echo "| --- | --- |"
+            echo "| 分類 | \`$CLASS\` |"
+            echo "| curl_rc | \`${CURL_RC:-unknown}\` |"
+            echo "| http_status | \`${HTTP_STATUS:-unknown}\` |"
+            echo "| schema_ok | \`${SCHEMA_OK:-unknown}\` |"
+            echo
+            echo "$HINT"
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "::error::Codex Review infra failure ($CLASS, curl_rc=${CURL_RC:-unknown}, http_status=${HTTP_STATUS:-unknown}) — $HINT"
+          exit 1
+      # END:managed:codex_review_infra_failure_gate


### PR DESCRIPTION
## 背景

codex-review の webhook 呼び出しが失敗しても、**GitHub の run 一覧は success 表示になる**。webhook 呼び出し step に `continue-on-error: true` が付いており、その後の fail-closed step（infra failure review の投稿・stale bot approval の dismiss）を完走させる設計のためである。

estack-inc/easy-flow で実測したところ、過去 7 日 349 run 中 22 件が 502 で失敗していたが、run 一覧からは 1 件も判別できなかった。代替の検知経路である Slack 通知 step は実装済みだが、`SLACK_WEBHOOK_URL` を持つリポジトリは 72 リポ中 2 件のみで機能していない。

## 変更内容

fail-closed の投稿がすべて終わった最後に判定 step を追加し、失敗を分類して step summary に残したうえで job を赤くする。

| 条件 | 分類 |
| --- | --- |
| curl_rc=0, http=200, schema_ok≠1 | `invalid_response_schema` |
| curl_rc=0, http=502 | `server_codex_failure` |
| curl_rc=0, http=401 / 400 / 413 / 403 | `unauthorized` / `invalid_payload` / `payload_too_large` / `forbidden` |
| curl_rc=0, その他 | `unexpected_http_status` |
| curl_rc=28 | `caller_timeout` |
| curl_rc=6/7/35/56 | `unreachable` |
| その他 | `transport_error` |

分類なしに「webhook 失敗」とだけ記録すると、呼び出し側の予算切れ・到達不能・サーバー側 codex 失敗・認証/payload 不正・reviewer の出力ブレが区別できず、設定を変えて直ったのか別の失敗へ移っただけなのか判定できない。

`curl 56` を到達不能系に含めているのは実測に基づく。2026-08-04 に Tailscale Funnel の DERP 接続が落ちた際、観測された exit code は 6/7/35 ではなく 56 だった。

## merge の可否は変えない

本 job は required status check ではない（workflow 冒頭「ブランチ保護運用の前提」に明記）。**配布対象 72 リポの branch protection / ruleset を監査し、codex-review が required 登録されているリポが 0 件であることを確認済み**。赤化しても merge は block されない。ゲート強制力は従来どおり bot の CHANGES_REQUESTED review が担う。

目的は「壊れていることが見えること」であり、正常にレビューが通っている PR の挙動は変わらない。

## 検証

配布元 estack-inc/easy-flow で回帰テストを整備したうえで、**本リポジトリの挿入結果に対しても個別に実測した**。

- 正常時に発火しないこと（`curl_rc=0` / `http_status=200` / `schema_ok=1` および `schema_ok` 未出力の両方）
- 異常時に発火すること（502 / curl 28 / curl 56）
- 分類器を bash で実行し、13 通りの入力すべてが期待どおりの分類になること
- YAML パースと 3 つの managed region の BEGIN/END 対応

`schema_ok` を `GITHUB_OUTPUT` に書かない世代の workflow では、空文字を「判定不能」として発火条件から外している（estack-inc/easy-flow#473）。そのため schema 不正の可視化だけが効かないが、通信・HTTP 由来の失敗は従来どおり検出される。

## 配布契約

本 step は `BEGIN:managed:codex_review_infra_failure_gate` / `END:managed:codex_review_infra_failure_gate` で囲まれた managed region である。patch mode は marker 間の置換であって marker 自体を作らないため、初回のみ marker ごと書き込む必要があり、本 PR がそれにあたる。以降は `distribute_rules.py apply` で estack-inc/easy-flow から自動同期される。

marker の外（`repository_context` / `checklists` / `summary` など per-repo 部分）には一切触れていない。差分は末尾への 73 行追加のみ。

## 関連

estack-inc/easy-flow#472（region の追加）、estack-inc/easy-flow#473（`schema_ok` 未出力世代への対応）
