### PR TITLE
chore(codex-review): cjs と対になる契約テストを配布元へ同期する

### DIFF
--- a/scripts/codex-review-json.test.cjs
+++ b/scripts/codex-review-json.test.cjs
@@ -909,8 +909,9 @@ test('render escapes triple backticks in finding.root_cause', (t) => {
 });
 
 test('render escapes heading markers in finding.title', (t) => {
+  // 改行を挟んだ見出し偽装が最も危険（行頭 `## ` になりうる）ため、それを入力にする。
   const finding = blockingFinding({
-    title: '## 偽装見出し で構造を破壊',
+    title: '通常タイトル\n## 偽装見出し で構造を破壊',
   });
   const checklist = baseChecklist();
   checklist[2] = { ...checklist[2], status: 'finding', finding_ids: [finding.id] };
@@ -924,13 +925,33 @@ test('render escapes heading markers in finding.title', (t) => {
   const result = runScript('render', filePath);
 
   assert.equal(result.status, 0);
-  // 行頭 `## ` で始まる偽装見出しは出力されない
-  // (#### ...severity... 偽装見出し ... のレンダ行はあるが、その中の `##` は行頭ではないので問題なし)
-  // → 「行頭」`## ` の偽装パターンが残らないことを確認
-  const titleLine = result.stdout.split('\n').find((l) => l.includes('偽装見出し'));
+
+  // sanitizeMarkdownHeading の契約は 2 つ。どちらか片方でも欠けると偽装見出しが通る。
+  //   1. 行頭の `#` を `\#` へエスケープする
+  //   2. 見出しは 1 行に収める（改行を空白へ畳む）
+  // 旧テストは「偽装見出し を含む行が /^## / でない」ことしか見ておらず、
+  // レンダラーが行頭に `#### F-001 ...` を付ける以上、無害化が無くても必ず通る
+  // 空振り assertion だった。ここでは無害化そのものを検証する。
+  const lines = result.stdout.split('\n');
+
+  // 1. 出力のどの行も `## 偽装見出し` で始まらない（見出し偽装が成立していない）
+  assert.ok(
+    lines.every((l) => !/^#{1,6}\s+偽装見出し/.test(l)),
+    `偽装見出しが行頭の見出しとして出力された: ${JSON.stringify(lines.filter((l) => /偽装見出し/.test(l)))}`,
+  );
+
+  // 2. title 由来の `##` はエスケープされて残る
+  const titleLine = lines.find((l) => l.includes('偽装見出し'));
   assert.ok(titleLine, 'title 行が見当たらない');
-  // 「## 偽装」が title 行頭になっていないこと (sanitize で `\## ` になっているか sanitize 元の `## ` が消えているか)
-  assert.doesNotMatch(titleLine, /^## /);
+  assert.match(titleLine, /\\## 偽装見出し/);
+
+  // 3. title 内の改行は畳まれ、title は 1 行に収まる
+  //    (改行が残ると 2 行目が行頭 `## ` になり 1 が破られる)
+  assert.match(titleLine, /^#### /);
+  assert.ok(
+    titleLine.includes('通常タイトル') && titleLine.includes('偽装見出し'),
+    `title が複数行に分割された: ${titleLine}`,
+  );
 });
 
 test('render escapes list markers in finding.required_fix', (t) => {


### PR DESCRIPTION
## 背景

`scripts/codex-review-json.cjs` と対になる契約テスト `scripts/codex-review-json.test.cjs` が、本リポジトリでは配布元と同期されていない。

中央配布の manifest では両者を **matched pair** として扱っている（`manifests/profiles/codex-review.yaml`）。cjs だけを更新して test を置き去りにすると、後で test を CI 実行するようにしたときに古い期待値で落ちる。

この乖離は長期間検知できていなかった。配布元の drift-check が cross-repo read 用の token を持たず、対象リポの 94% が `fetch-error` として記録されていたためである（2026-08-04 に token を設定して解消。48 リポすべてが読めるようになり、本件を含む乖離が可視化された）。

## 変更内容

`scripts/codex-review-json.test.cjs` を配布元と同一内容へ更新する（新規配置または上書き）。

- sha256: `dd76e06c4bbbd927…`（配布元 estack-inc/easy-flow と一致）
- 60 テスト / fail 0
- overwrite モードの配布対象で per-repo customize はしない。配布元と同一であることが正しい状態

## 安全性

本リポジトリの `scripts/codex-review-json.cjs` が**配布元とバイト一致していることを確認済み**。したがって同じ test が同じ結果になる。

cjs 自体が配布元と異なるリポジトリ（9 件）は本 PR の対象外とした。cjs と test を同時に更新する必要があり、cjs 側の差分を精査してから別途対応する。

## 検証

- 配布元で 60 テスト pass / fail 0
- 本リポジトリの cjs が配布元と sha256 一致
- 差分は当該 1 ファイルのみ

## 関連

estack-inc/easy-flow#475（台帳の org 横断化と drift-check の token 分離）
