### PR TITLE
fix(codex-review): workflow 定義を PR から改変できないよう pull_request_target へ移行する

### DIFF
--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -34,7 +34,7 @@
 name: Codex Code Review
 
 on:
-  pull_request:
+  pull_request_target:
     # 以下のイベント遷移でも cleanup step が走るように types を拡張する。
     #   - converted_to_draft: ready → draft（bot APPROVED が残ると stale になるため dismiss する）
     #   - labeled / unlabeled: ラベル付与・解除で適用可否が反転するため再評価する


### PR DESCRIPTION
## 概要

codex-review のトリガーを `pull_request` から `pull_request_target` へ移行します。

関連: estack-inc/easy-flow#492

## 何が問題だったか

`on: pull_request` では、**workflow ファイル自身も PR head 版が実行されます**。

この job は secret と write 権限を持ちます。

- `CODEX_REVIEW_WEBHOOK_TOKEN` / `CODEX_REVIEW_WEBHOOK_URL`
- `REPO_ACCESS_TOKEN`（PR レビューの投稿・dismiss 権限）

そのため PR で `.github/workflows/codex-review.yml` を書き換えると、**その改変版が上記の権限を持って実行されます**。base のスクリプトだけを実行する防御を入れても、その防御ごと削除できるため意味がありません。

`pull_request_target` なら workflow 定義は base 版で固定され、PR から改変できません。

## 変更内容

```diff
 on:
-  pull_request:
+  pull_request_target:
     types: [...]
     branches: [...]
```

**`types` / `branches` / コメントはすべて現状のまま**です。差し替えたのはトリガー名のみです。

## レビュー挙動は変わりません

移行前に、PR head の checkout に依存する処理が無いことを確認しています。

| 検査項目 | 結果 |
| --- | --- |
| checkout が PR head を明示指定 | なし |
| ローカルパスでのスクリプト実行 | なし |
| `npm ci` / `npm install` | なし |
| workspace ファイルの読み込み | なし |
| PR 由来文字列（title / body / branch 名）の shell への式展開 | なし |

レビュー対象の diff は `gh pr diff`（GitHub API）から取得し、補助スクリプトは base から取り直した trusted copy を実行しています。**checkout の中身を実質使っていない**ため、base に変わっても動作は同じです。

## 検証

- 変換後の YAML をパースし、`types` / `branches` / 他トリガー / `jobs` が変更前と**構造として一致**することを確認
- `pull_request` が残存していないこと、`pull_request_target` が存在することを確認
- `pull_request_target` 化で危険になる要素（PR head の実行・式展開）が無いことを確認

## 留意点

fork PR でも secret が渡るようになります。private リポのため fork できる範囲は限定的ですが、挙動としては変わります。`pull_request_target` の hardening 条件（PR head のコードを実行しない、PR 由来文字列を式展開しない）は上記の検査で満たしていることを確認済みです。
