### PR TITLE
fix(codex-review): 巨大 diff を infra 障害と誤報告しないよう gate の配線を修復する

### DIFF
--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -675,9 +675,9 @@ jobs:
       - name: Render webhook infra failure review
         id: review_infra_failure
         if: >-
-          always()&&
-          steps.applicable.outputs.applicable == 'true'&&
-          steps.oversize_gate.outputs.oversize != 'true'&&
+          always() &&
+          steps.applicable.outputs.applicable == 'true' &&
+          steps.oversize_gate.outputs.oversize != 'true' &&
           (steps.codex_review.outputs.curl_rc != '0' || steps.codex_review.outputs.http_status != '200')
         env:
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
@@ -716,8 +716,8 @@ jobs:
       - name: Re-check applicability before posting
         id: recheck
         if: >-
-          always()&&
-          steps.applicable.outputs.applicable == 'true'&&
+          always() &&
+          steps.applicable.outputs.applicable == 'true' &&
           (steps.review_json.outputs.verdict != '' || steps.review_infra_failure.outputs.verdict != '' || steps.oversize_gate.outputs.verdict != '')
         env:
           GH_TOKEN: ${{ secrets.REPO_ACCESS_TOKEN || github.token }}

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -129,7 +129,11 @@ jobs:
         id: oversize_gate
         if: steps.applicable.outputs.applicable == 'true'
         env:
-          GH_TOKEN: ${{ secrets.REPO_ACCESS_TOKEN }}
+          # diff のサイズを測るだけなので REPO_ACCESS_TOKEN 固有の権限は要らない。
+          # フォールバックを置くことで、secret 未設定のリポ (オンボード直後など)
+          # でも gate が働く。両方で取れなかった場合だけ下の fail-closed 分岐へ
+          # 進むので、fail-closed の保証は落ちない。
+          GH_TOKEN: ${{ secrets.REPO_ACCESS_TOKEN || github.token }}
           REPO: ${{ github.repository }}
           PR_NUM: ${{ github.event.pull_request.number }}
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -675,10 +675,10 @@ jobs:
       - name: Render webhook infra failure review
         id: review_infra_failure
         if: >-
-          always() &&
-          steps.applicable.outputs.applicable == 'true' &&
-          (steps.codex_review.outputs.curl_rc != '0' ||
-           steps.codex_review.outputs.http_status != '200')
+          always()&&
+          steps.applicable.outputs.applicable == 'true'&&
+          steps.oversize_gate.outputs.oversize != 'true'&&
+          (steps.codex_review.outputs.curl_rc != '0' || steps.codex_review.outputs.http_status != '200')
         env:
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           CODEX_REVIEW_COMMENT_MARKER: '<!-- codex-reviewer-bot:v1 sha=${{ github.event.pull_request.head.sha }} -->'
@@ -716,10 +716,9 @@ jobs:
       - name: Re-check applicability before posting
         id: recheck
         if: >-
-          always() &&
-          steps.applicable.outputs.applicable == 'true' &&
-          (steps.review_json.outputs.verdict != '' ||
-           steps.review_infra_failure.outputs.verdict != '')
+          always()&&
+          steps.applicable.outputs.applicable == 'true'&&
+          (steps.review_json.outputs.verdict != '' || steps.review_infra_failure.outputs.verdict != '' || steps.oversize_gate.outputs.verdict != '')
         env:
           GH_TOKEN: ${{ secrets.REPO_ACCESS_TOKEN || github.token }}
           REPO: ${{ github.repository }}


### PR DESCRIPTION
## 概要

oversize gate の配線欠落を修復します。gate は入っていますが、**現状では機能していません**。

関連: estack-inc/easy-flow#484

## 何が起きているか

巨大 diff を検出したとき、投稿されるのは「webhook インフラ障害」というレビューです。実際の原因（diff が上限超過）は伝わりません。

原因は 2 つの `if` に gate の条件が入っていないことです。

**1. infra failure step が誤発火する**

gate が webhook をスキップすると `codex_review.outputs.curl_rc` が空になります。infra failure step の条件は `curl_rc != '0'` なので、**空文字はこれを満たしてしまい** infra 障害として verdict を生成します。VERDICT 式は `review_json || review_infra_failure || oversize_gate` の順なので、gate の verdict は選ばれません。

**2. recheck が発火しない**

`Submit review verdict` は `recheck.still_applicable == 'true'` を要求しますが、`recheck` の条件に gate の verdict が入っていません。infra failure が誤発火しなければ recheck も走らず、**エスカレーション自体が投稿されません**。

## 変更内容

canonical と同じ条件に揃えます。

```diff
   - name: Render webhook infra failure review
     if: >-
       always() &&
       steps.applicable.outputs.applicable == 'true' &&
+      steps.oversize_gate.outputs.oversize != 'true' &&
       (steps.codex_review.outputs.curl_rc != '0' || ...)
```

```diff
   - name: Re-check applicability before posting
     if: >-
       always() &&
       steps.applicable.outputs.applicable == 'true' &&
       (steps.review_json.outputs.verdict != '' ||
-       steps.review_infra_failure.outputs.verdict != '')
+       steps.review_infra_failure.outputs.verdict != '' ||
+       steps.oversize_gate.outputs.verdict != '')
```

step 名や `if` の形はリポごとに揺れているため、名前ではなく **step id で特定**して条件を追加しています。

## 検証

GitHub Actions の式評価器を実装し、4 シナリオで「どの verdict が投稿されるか」をシミュレートして確認しています。

| シナリオ | 期待する verdict | 修正前 | 修正後 |
| --- | --- | --- | --- |
| 巨大 diff | oversize_gate | ❌ infra 障害と誤報告 | ✅ |
| diff サイズ不明 | oversize_gate | ❌ infra 障害と誤報告 | ✅ |
| webhook 障害 | review_infra_failure | ✅ | ✅ |
| 正常レビュー | review_json | ✅ | ✅ |

canonical が 4 シナリオすべて期待どおりであることを基準にしています。

step の有無や名前ではなく **step を順に評価して Submit review verdict への到達可能性と verdict の選択元を判定**するため、リポごとの構造差に影響されません。
