### PR TITLE
fix(codex-review): oversize gate が PR の最終差分を測るようにする

### DIFF
--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -149,7 +149,12 @@ jobs:
           # clipContext は text.length で判定するため同じ単位に揃える (wc -c のバイト数では
           # 日本語 diff が約 1/3 の文字数で弾かれて閾値の意味がずれる)。
           set +e
-          gh pr diff "$PR_NUM" --repo "$REPO" --patch > /tmp/oversize-diff.patch
+          #
+          # --patch を付けない。--patch はコミットごとの diff を連結するため、
+          # コミット数に比例して膨らむ (実測: 27 コミットの PR で 144KB → 300KB)。
+          # webhook がレビューするのは PR の最終差分なので、--patch なしの出力
+          # (GitHub API の application/vnd.github.v3.diff と一致) で測る。
+          gh pr diff "$PR_NUM" --repo "$REPO" > /tmp/oversize-diff.patch
           GH_DIFF_RC=$?
           set -e
           if [ "$GH_DIFF_RC" -ne 0 ]; then


### PR DESCRIPTION
## 概要

oversize gate が **PR の差分を 2 倍以上に過大計測**していました。`gh pr diff --patch` を使っていたためです。

関連: estack-inc/easy-flow#502

## 何が問題か

`--patch` はコミットごとの diff を連結して出力します。**コミット数に比例して膨らみます。**

| 計測方法 | サイズ（実測） |
| --- | --- |
| `gh pr diff --patch`（gate が使用） | **299,910** |
| `gh pr diff` | 144,448 |
| GitHub API `v3.diff` | 144,448 |

27 コミットの PR で 2 倍以上に膨れ、上限 240,000 を超えて弾かれました。**コミット数が多いだけの PR が、実際は上限内なのに人間レビューへ回されます。**

## どう見つかったか

canonical 側の PR（[estack-inc/easy-flow#496](https://github.com/estack-inc/easy-flow/pull/496)）で発生しました。gate を作っている PR を、その gate が「巨大 diff」として弾きました。実際の差分は 144KB で上限内です。

## 変更内容

`--patch` を外します。**1 行の変更**です（コメント 5 行を追加）。

```diff
-          gh pr diff "$PR_NUM" --repo "$REPO" --patch > /tmp/oversize-diff.patch
+          gh pr diff "$PR_NUM" --repo "$REPO" > /tmp/oversize-diff.patch
```

webhook がレビューするのは PR の最終差分（サーバー側が PR 番号から取得）なので、`--patch` なしが正しい単位です。GitHub API の `application/vnd.github.v3.diff` と一致することを実測で確認しました。

## 検証

配布前に全 48 リポ分を機械確認しています。

- `gh pr diff` の行に `--patch` が無い（`/tmp/oversize-diff.patch` というファイル名の `.patch` は別）
- **gate step 以外が 1 文字も変わっていない**
- 行数差がコメント 5 行分ちょうど
- 意味検査（6 シナリオ）で verdict が期待どおり投稿される

canonical 側には `--patch` への逆戻りを防ぐ回帰テストを追加しました。
