### PR TITLE
fix(codex-review): file filter に中央配布対象を含める

### DIFF
--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -113,6 +113,9 @@ jobs:
                   specs/*.md|specs/**/*.md) SHOULD_REVIEW=true ;;
                   .github/workflows/*.yml|.github/workflows/*.yaml) SHOULD_REVIEW=true ;;
                   CLAUDE.md) SHOULD_REVIEW=true ;;
+                  scripts/codex-review-json.cjs) SHOULD_REVIEW=true ;;
+                  scripts/ai_review_cost.py) SHOULD_REVIEW=true ;;
+                  scripts/codex-review-json.test.cjs) SHOULD_REVIEW=true ;;
                 esac
               done
               if [ "$SHOULD_REVIEW" = "false" ]; then APPLICABLE=false; REASONS+=("no reviewable files"); fi


### PR DESCRIPTION
中央配布された `scripts/codex-review-json.cjs` などだけを変更する PR が「no reviewable files」で skip され、bot の承認が出ずマージできない問題を解消します。

配布対象パスを file filter の `case` に追加します。既存の per-repo パターンは変更しません。

正本: [estack-inc/easy-flow](https://github.com/estack-inc/easy-flow) `scripts/prep_repo.py` の `ensure_distributed_paths_reviewable`。配布対象は `manifests/profiles/codex-review.yaml` から読みます。